### PR TITLE
security: bump opencontainers/selinux to v1.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
-	github.com/opencontainers/selinux v1.12.0 // indirect
+	github.com/opencontainers/selinux v1.13.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
+github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+LGaWfbL84=
+github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=

--- a/proto/milpacs.proto
+++ b/proto/milpacs.proto
@@ -29,7 +29,7 @@ import "google/protobuf/empty.proto";
 // These annotations are used when generating the OpenAPI file.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
-    version: "2.0.0";
+    version: "2.0.2";
   };
   external_docs: {
     url: "https://github.com/7cav/api";

--- a/servers/server.go
+++ b/servers/server.go
@@ -38,7 +38,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const version = "2.0.1"
+const version = "2.0.2"
 
 type MicroServer struct {
 	addr       string


### PR DESCRIPTION
## Summary

- Bumps `github.com/opencontainers/selinux` from v1.12.0 to v1.13.0

## Alert Addressed

| Severity | Package | Before | After | CVE |
|----------|---------|--------|-------|-----|
| 🟠 High | `github.com/opencontainers/selinux` | v1.12.0 | v1.13.0 | CVE-2025-52881 |

**CVE-2025-52881** — runc container escape and denial of service via arbitrary write gadgets and procfs write redirects. An attacker can trick runc into misdirecting writes to `/proc` through racing containers with shared mounts, potentially allowing container escape or host system crash.

## Remaining Open Alerts

- `github.com/docker/docker` HIGH (#37) and MEDIUM (#36) — require v29.3.1 which is not yet published to the Go module proxy. These are purely transitive deps of `bufbuild/buf` (build tooling) and are **not compiled into the production binary** (`go mod why` confirms this).

## Test plan

- [x] `go build ./...` passes clean
- [ ] Verify Dependabot alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)