### PR TITLE
chore: gitignore Claude Code local working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ out/
 api
 
 docker-compose.yaml
+
+# Claude Code local working files
+.claude/
+docs/superpowers/
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Ignore `.claude/`, `docs/superpowers/`, and `CLAUDE.md` so personal filesystem paths and AI-assisted dev working notes don't leak into the repo.

## Test plan
- [x] `.gitignore` patterns added under a clearly-labeled section
- [x] No currently-tracked files match the new patterns (verified with `git ls-files`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)