### PR TITLE
chore: post-2.2.0 cleanup batch

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -30,7 +30,7 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Launches the api servers",
 	Run: func(cmd *cobra.Command, args []string) {
-		// PORT is the loopback port the HTTP gateway dials to reach the in-process gRPC server.
+		// PORT is the port the HTTP gateway dials to reach the in-process gRPC server.
 		// It is NOT a listen port: both the gRPC server (:10000) and HTTP gateway (:11000) listen
 		// ports are hardcoded in servers/server.go. PORT must match the hardcoded gRPC port (10000)
 		// for the gateway-to-gRPC dial to succeed.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -30,6 +30,10 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Launches the api servers",
 	Run: func(cmd *cobra.Command, args []string) {
+		// PORT is the loopback port the HTTP gateway dials to reach the in-process gRPC server.
+		// It is NOT a listen port: both the gRPC server (:10000) and HTTP gateway (:11000) listen
+		// ports are hardcoded in servers/server.go. PORT must match the hardcoded gRPC port (10000)
+		// for the gateway-to-gRPC dial to succeed.
 		server := servers.New(fmt.Sprintf("0.0.0.0:%s", viper.GetString("port")))
 		server.Start()
 	},

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -19,7 +19,7 @@ var (
 
 func CacheMiddleware(cache *cache.RedisCache, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/v1/tickets") {
+		if r.URL.Path == "/api/v1/tickets" || strings.HasPrefix(r.URL.Path, "/api/v1/tickets/") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/servers/server.go
+++ b/servers/server.go
@@ -52,8 +52,9 @@ type MicroServer struct {
 }
 
 // New initializes a new Backend struct.
-// addr is the gRPC dial target consumed by the HTTP gateway (from $PORT); not a listen address.
-// The gRPC and HTTP listen ports are hardcoded literals in Start().
+// addr is the gRPC dial target consumed by the HTTP gateway (from $PORT).
+// Listen ports for both gRPC (:10000) and HTTP (:11000) are hardcoded in Start();
+// addr must match the gRPC literal for the gateway-to-gRPC dial to succeed.
 func New(addr string) *MicroServer {
 
 	return &MicroServer{

--- a/servers/server.go
+++ b/servers/server.go
@@ -136,7 +136,7 @@ func (server *MicroServer) Start() {
 	httpL, err := net.Listen("tcp", "0.0.0.0:11000")
 
 	if err != nil {
-		Error.Fatalf("Failed to listen on %s: %w", server.addr, err)
+		Error.Fatalf("Failed to listen on %s: %v", server.addr, err)
 	}
 
 	ds := setupDatasource()
@@ -180,7 +180,7 @@ func servGRPC(server *MicroServer, lis net.Listener, grpcOpts []grpc.ServerOptio
 	milpacs.RegisterTicketsServiceServer(server.grpcServer, ticketsService)
 
 	if err := server.grpcServer.Serve(lis); err != nil {
-		Error.Fatalf("unable to start external gRPC servers: ", err)
+		Error.Fatalf("unable to start external gRPC servers: %v", err)
 	}
 }
 
@@ -188,7 +188,7 @@ func servHTTP(server *MicroServer, lis net.Listener, ds datastores.Datastore) {
 	service := httpServices.Service{Address: server.addr, Cache: server.cache, Datastore: ds}
 	server.httpServer = service.Server()
 	if err := server.httpServer.Serve(lis); err != nil {
-		Error.Fatalf("unable to start HTTP servers: ", err)
+		Error.Fatalf("unable to start HTTP servers: %v", err)
 	}
 }
 

--- a/servers/server.go
+++ b/servers/server.go
@@ -52,6 +52,8 @@ type MicroServer struct {
 }
 
 // New initializes a new Backend struct.
+// addr is the gRPC dial target consumed by the HTTP gateway (from $PORT); not a listen address.
+// The gRPC and HTTP listen ports are hardcoded literals in Start().
 func New(addr string) *MicroServer {
 
 	return &MicroServer{

--- a/servers/server.go
+++ b/servers/server.go
@@ -80,8 +80,7 @@ func setupRedis() *cache.RedisCache {
 
 	redisPassword := viper.GetString("REDIS_PASSWORD")
 	if redisPassword == "" {
-		Error.Println("no redis password provided")
-		os.Exit(1)
+		Info.Println("REDIS_PASSWORD empty — connecting without AUTH")
 	}
 
 	return cache.NewRedisCache(redisHost, redisPort, redisPassword)


### PR DESCRIPTION
Post-2.2.0 cleanup batch — four small, independent code edits. No release, no version bump, no consumer-visible behavior change. Ships with the next feature release.

## Changes
- **`servers/server.go`** — `Fatalf` format-string vet fixes (`%w` → `%v` on L139; verb-less `%v` added on L183, L191).
- **`middleware/cache.go`** — tighten tickets cache-bypass from loose `HasPrefix` to exact path OR trailing-slash prefix. Defense-in-depth; no existing route changes behavior.
- **`servers/server.go`** — `setupRedis` no longer exits on empty `REDIS_PASSWORD`; logs an info line and connects without AUTH. Prod is unaffected (password is set in compose env); enables local-dev against a vanilla `redis:7`.
- **`cmd/serve.go`, `servers/server.go`** — document that `PORT` is the gateway-to-grpc dial target, not a listen port. Both listen ports are hardcoded. (`CLAUDE.md` got a matching paragraph update on disk for local-Claude context; that file is `.gitignore`d in this repo so it does not appear in this diff.)

## Commits
Five commits — four tasks plus one fix-up on the PORT doc commit to drop a misleading "loopback" word and rewrite the `New` doc-comment to drop the inaccurate "not a listen address" framing. Squash-merge.

## Verification
- `go vet ./...` is clean (the three pre-existing warnings on `servers/server.go` L139/183/191 are gone).
- `go build ./...` exits 0.
- Local smoke against the `xenforo-db` mirror (v2.2.0 schema present): binary starts with empty `REDIS_PASSWORD` and logs the new `REDIS_PASSWORD empty — connecting without AUTH` info line (Task 3 verified end-to-end); both `:10000` and `:11000` bind; OpenAPI UI returns 200; `/api/v1/milpac/1` and `/api/v1/tickets[/123]` return 401 against the gateway, proving the gateway-to-gRPC dial path works under `PORT=10000` (Task 4 invariant verified).
- Cache-bypass conditional (cache.go change): no raw API token was available locally, so verified by build + vet + code-review (cache middleware sits inside auth; the conditional only fires on authenticated requests).
- No proto changes; no `make generate` needed.
- No new endpoints; no `monitoredTables` change needed.
- No test suite exists in this repo.

Closes #70