### PR TITLE
fix(milpacs): route errors to NotFound vs Internal

### DIFF
--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -60,9 +60,6 @@ func (ds Mysql) FindProfilesByUsername(username string) ([]*proto.Profile, error
 		First(&profile)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("no profile found for username: %s", username)
-		}
 		return nil, result.Error
 	}
 

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -32,9 +32,6 @@ func (ds Mysql) FindProfilesById(userIds ...uint64) ([]*proto.Profile, error) {
 		First(&profile, userIds[0])
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("no profile found for userid: %d", userIds)
-		}
 		return nil, result.Error
 	}
 

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -73,11 +73,14 @@ func (ds Mysql) FindRosterByType(rosterType proto.RosterType) (*proto.Roster, er
 	var rosterProfiles []milpacs.Profile
 
 	Info.Println("Searching for roster: ", rosterType.String(), "id:", uint(rosterType.Number()))
-	ds.Db.Preload(clause.Associations).
+	result := ds.Db.Preload(clause.Associations).
 		Preload("AwardRecords.Award").
 		Joins(xenforo.ConnectedAccountJoin).
 		Where(map[string]interface{}{"roster_id": uint(rosterType.Number())}).
 		Find(&rosterProfiles)
+	if result.Error != nil {
+		return nil, fmt.Errorf("find roster %s: %w", rosterType, result.Error)
+	}
 
 	profiles, err := ds.processProfiles(rosterProfiles)
 	if err != nil {

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -102,9 +102,6 @@ func (ds Mysql) FindProfileByKeycloakID(keycloakId string) (*proto.Profile, erro
 		First(&profile)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("no profile found for KeycloakID: %s", keycloakId)
-		}
 		return nil, result.Error
 	}
 

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -341,12 +341,15 @@ func (ds Mysql) FindS1UniformsRosterByType(rosterType proto.RosterType) (*proto.
 	var rosterProfiles []milpacs.Profile
 
 	Info.Println("Searching for S1 Uniforms roster: ", rosterType.String(), "id:", uint(rosterType.Number()))
-	ds.Db.Preload(clause.Associations).
+	result := ds.Db.Preload(clause.Associations).
 		Preload("Primary.Group").
 		Preload("AwardRecords.Award").
 		Joins(xenforo.ConnectedAccountJoin).
 		Where(map[string]interface{}{"roster_id": uint(rosterType.Number())}).
 		Find(&rosterProfiles)
+	if result.Error != nil {
+		return nil, fmt.Errorf("find s1 uniforms roster %s: %w", rosterType, result.Error)
+	}
 
 	var profiles = make(map[uint64]*proto.S1UniformsProfile, len(rosterProfiles))
 	for _, profile := range rosterProfiles {

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -126,9 +126,6 @@ func (ds Mysql) FindProfileByDiscordID(discordId string) (*proto.Profile, error)
 		First(&profile)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("no profile found for discordID: %s", discordId)
-		}
 		return nil, result.Error
 	}
 

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -738,9 +738,6 @@ func (ds Mysql) FindProfileByGamertag(gamertag string) (*proto.Profile, error) {
 		First(&profile)
 
 	if result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("no profile found for gamertag: %s", gamertag)
-		}
 		return nil, result.Error
 	}
 

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -257,11 +257,14 @@ func (ds Mysql) FindLiteRosterByType(rosterType proto.RosterType) (*proto.LiteRo
 	var rosterProfiles []milpacs.Profile
 
 	Info.Println("Searching for lite roster: ", rosterType.String(), "id:", uint(rosterType.Number()))
-	ds.Db.Preload(clause.Associations).
+	result := ds.Db.Preload(clause.Associations).
 		Omit("Records", "AwardRecords").
 		Joins(xenforo.ConnectedAccountJoin).
 		Where(map[string]interface{}{"roster_id": uint(rosterType.Number())}).
 		Find(&rosterProfiles)
+	if result.Error != nil {
+		return nil, fmt.Errorf("find lite roster %s: %w", rosterType, result.Error)
+	}
 
 	profiles, err := ds.processLiteProfiles(rosterProfiles)
 	if err != nil {

--- a/servers/grpc/fake_datastore_test.go
+++ b/servers/grpc/fake_datastore_test.go
@@ -1,0 +1,73 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/xenforo"
+)
+
+// fakeDatastore is the shared in-process Datastore stub used by both
+// tickets_test.go and milpacs_test.go. Each handler-under-test gets the
+// matching function field populated; everything else either panics
+// (methods this PR does not exercise) or, for milpacs methods, nil-derefs
+// on call so an accidentally-untouched test fails loudly with a clear
+// stack rather than a silent zero-value response.
+type fakeDatastore struct {
+	// Tickets — configurable function fields used by tickets_test.go.
+	listTickets func(*datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error)
+	getTicket   func(uint32) (*proto.Ticket, error)
+	getByRef    func(string) (*proto.Ticket, error)
+	firstMsgs   func(uint32, int) ([]*proto.Message, uint32, error)
+	listMsgs    func(uint32, string, uint32, bool) ([]*proto.Message, string, bool, error)
+	listCats    func() ([]*proto.Category, error)
+}
+
+func (f *fakeDatastore) ListTickets(_ context.Context, _ datastores.TicketReferenceCache, fi *datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error) {
+	return f.listTickets(fi)
+}
+func (f *fakeDatastore) GetTicket(_ context.Context, _ datastores.TicketReferenceCache, id uint32, _ string) (*proto.Ticket, error) {
+	return f.getTicket(id)
+}
+func (f *fakeDatastore) GetTicketByRef(_ context.Context, _ datastores.TicketReferenceCache, ref string, _ string) (*proto.Ticket, error) {
+	return f.getByRef(ref)
+}
+func (f *fakeDatastore) GetTicketFirstMessages(_ context.Context, id uint32, n int, _ bool) ([]*proto.Message, uint32, error) {
+	return f.firstMsgs(id, n)
+}
+func (f *fakeDatastore) ListTicketMessages(_ context.Context, id uint32, after string, per uint32, hidden bool) ([]*proto.Message, string, bool, error) {
+	return f.listMsgs(id, after, per, hidden)
+}
+func (f *fakeDatastore) ListCategories(_ context.Context, _ datastores.TicketReferenceCache) ([]*proto.Category, error) {
+	return f.listCats()
+}
+
+// Milpacs methods — left panicking in this task; converted to configurable
+// function fields in Task 2.
+func (f *fakeDatastore) FindProfilesById(_ ...uint64) ([]*proto.Profile, error)           { panic("unused") }
+func (f *fakeDatastore) FindProfilesByUsername(string) ([]*proto.Profile, error)          { panic("unused") }
+func (f *fakeDatastore) FindRosterByType(proto.RosterType) (*proto.Roster, error)         { panic("unused") }
+func (f *fakeDatastore) FindLiteRosterByType(proto.RosterType) (*proto.LiteRoster, error) { panic("unused") }
+func (f *fakeDatastore) FindProfileByKeycloakID(string) (*proto.Profile, error)           { panic("unused") }
+func (f *fakeDatastore) FindProfileByDiscordID(string) (*proto.Profile, error)            { panic("unused") }
+func (f *fakeDatastore) FindProfilesByPosition(string) (*proto.LiteRoster, error)         { panic("unused") }
+func (f *fakeDatastore) FindS1UniformsRosterByType(proto.RosterType) (*proto.S1UniformsRoster, error) {
+	panic("unused")
+}
+func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error)            { panic("unused") }
+func (f *fakeDatastore) FindAllPositionGroups() ([]*proto.PositionGroup, error)  { panic("unused") }
+func (f *fakeDatastore) FindAwol() ([]*proto.Awol, error)                        { panic("unused") }
+func (f *fakeDatastore) GetTableUpdates() ([]xenforo.TableInfo, error)           { panic("unused") }
+func (f *fakeDatastore) FindProfileByGamertag(string) (*proto.Profile, error)    { panic("unused") }
+func (f *fakeDatastore) ValidateApiKey(string) (*datastores.ApiKeyResult, error) { panic("unused") }
+
+// withTicketsKey builds a context carrying an ApiKeyResult with the given
+// scope set. Mirrors the auth middleware's behavior in production.
+func withTicketsKey(scopes ...string) context.Context {
+	m := map[string]struct{}{}
+	for _, s := range scopes {
+		m[s] = struct{}{}
+	}
+	return ContextWithKey(context.Background(), &datastores.ApiKeyResult{Scopes: m})
+}

--- a/servers/grpc/fake_datastore_test.go
+++ b/servers/grpc/fake_datastore_test.go
@@ -87,9 +87,10 @@ func (f *fakeDatastore) FindAwol() ([]*proto.Awol, error)                       
 func (f *fakeDatastore) GetTableUpdates() ([]xenforo.TableInfo, error)                    { panic("unused") }
 func (f *fakeDatastore) ValidateApiKey(string) (*datastores.ApiKeyResult, error)          { panic("unused") }
 
-// withTicketsKey builds a context carrying an ApiKeyResult with the given
-// scope set. Mirrors the auth middleware's behavior in production.
-func withTicketsKey(scopes ...string) context.Context {
+// makeKeyCtx builds a context carrying an ApiKeyResult with the given scope
+// set. The withTicketsKey / withMilpacsKey wrappers stay as named entry
+// points so a test reader sees which handler family the scope applies to.
+func makeKeyCtx(scopes ...string) context.Context {
 	m := map[string]struct{}{}
 	for _, s := range scopes {
 		m[s] = struct{}{}
@@ -97,13 +98,10 @@ func withTicketsKey(scopes ...string) context.Context {
 	return ContextWithKey(context.Background(), &datastores.ApiKeyResult{Scopes: m})
 }
 
-// withMilpacsKey builds a context carrying an ApiKeyResult with the given
-// scope set, mirroring withTicketsKey but for milpacs-handler tests.
+// withTicketsKey builds a context carrying an ApiKeyResult with the given
+// scope set. Mirrors the auth middleware's behavior in production.
+func withTicketsKey(scopes ...string) context.Context { return makeKeyCtx(scopes...) }
+
+// withMilpacsKey is the milpacs-handler equivalent of withTicketsKey.
 // Pass "read" to satisfy RequireScope; pass nothing for permission-denied paths.
-func withMilpacsKey(scopes ...string) context.Context {
-	m := map[string]struct{}{}
-	for _, s := range scopes {
-		m[s] = struct{}{}
-	}
-	return ContextWithKey(context.Background(), &datastores.ApiKeyResult{Scopes: m})
-}
+func withMilpacsKey(scopes ...string) context.Context { return makeKeyCtx(scopes...) }

--- a/servers/grpc/fake_datastore_test.go
+++ b/servers/grpc/fake_datastore_test.go
@@ -10,8 +10,10 @@ import (
 
 // fakeDatastore is the shared in-process Datastore stub used by both
 // tickets_test.go and milpacs_test.go. Each handler-under-test gets the
-// matching function field populated; milpacs methods panic until Task 2
-// converts them to configurable function fields.
+// matching function field populated; everything else either panics (methods
+// this PR does not exercise) or nil-derefs on call (unset configurable
+// fields) so an accidentally-untouched test fails loudly with a clear stack
+// rather than a silent zero-value response.
 type fakeDatastore struct {
 	// Tickets — configurable function fields used by tickets_test.go.
 	listTickets func(*datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error)
@@ -20,6 +22,17 @@ type fakeDatastore struct {
 	firstMsgs   func(uint32, int) ([]*proto.Message, uint32, error)
 	listMsgs    func(uint32, string, uint32, bool) ([]*proto.Message, string, bool, error)
 	listCats    func() ([]*proto.Category, error)
+
+	// Milpacs — configurable function fields. Unset fields nil-deref on call;
+	// same diagnostic level as tickets fields.
+	findProfilesById           func(...uint64) ([]*proto.Profile, error)
+	findProfilesByUsername     func(string) ([]*proto.Profile, error)
+	findProfileByKeycloakID    func(string) (*proto.Profile, error)
+	findProfileByDiscordID     func(string) (*proto.Profile, error)
+	findProfileByGamertag      func(string) (*proto.Profile, error)
+	findRosterByType           func(proto.RosterType) (*proto.Roster, error)
+	findLiteRosterByType       func(proto.RosterType) (*proto.LiteRoster, error)
+	findS1UniformsRosterByType func(proto.RosterType) (*proto.S1UniformsRoster, error)
 }
 
 func (f *fakeDatastore) ListTickets(_ context.Context, _ datastores.TicketReferenceCache, fi *datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error) {
@@ -41,28 +54,53 @@ func (f *fakeDatastore) ListCategories(_ context.Context, _ datastores.TicketRef
 	return f.listCats()
 }
 
-// Milpacs methods — left panicking in this task; converted to configurable
-// function fields in Task 2.
-func (f *fakeDatastore) FindProfilesById(_ ...uint64) ([]*proto.Profile, error)           { panic("unused") }
-func (f *fakeDatastore) FindProfilesByUsername(string) ([]*proto.Profile, error)          { panic("unused") }
-func (f *fakeDatastore) FindRosterByType(proto.RosterType) (*proto.Roster, error)         { panic("unused") }
-func (f *fakeDatastore) FindLiteRosterByType(proto.RosterType) (*proto.LiteRoster, error) { panic("unused") }
-func (f *fakeDatastore) FindProfileByKeycloakID(string) (*proto.Profile, error)           { panic("unused") }
-func (f *fakeDatastore) FindProfileByDiscordID(string) (*proto.Profile, error)            { panic("unused") }
-func (f *fakeDatastore) FindProfilesByPosition(string) (*proto.LiteRoster, error)         { panic("unused") }
-func (f *fakeDatastore) FindS1UniformsRosterByType(proto.RosterType) (*proto.S1UniformsRoster, error) {
-	panic("unused")
+func (f *fakeDatastore) FindProfilesById(ids ...uint64) ([]*proto.Profile, error) {
+	return f.findProfilesById(ids...)
 }
-func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error)            { panic("unused") }
-func (f *fakeDatastore) FindAllPositionGroups() ([]*proto.PositionGroup, error)  { panic("unused") }
-func (f *fakeDatastore) FindAwol() ([]*proto.Awol, error)                        { panic("unused") }
-func (f *fakeDatastore) GetTableUpdates() ([]xenforo.TableInfo, error)           { panic("unused") }
-func (f *fakeDatastore) FindProfileByGamertag(string) (*proto.Profile, error)    { panic("unused") }
-func (f *fakeDatastore) ValidateApiKey(string) (*datastores.ApiKeyResult, error) { panic("unused") }
+func (f *fakeDatastore) FindProfilesByUsername(u string) ([]*proto.Profile, error) {
+	return f.findProfilesByUsername(u)
+}
+func (f *fakeDatastore) FindRosterByType(t proto.RosterType) (*proto.Roster, error) {
+	return f.findRosterByType(t)
+}
+func (f *fakeDatastore) FindLiteRosterByType(t proto.RosterType) (*proto.LiteRoster, error) {
+	return f.findLiteRosterByType(t)
+}
+func (f *fakeDatastore) FindProfileByKeycloakID(k string) (*proto.Profile, error) {
+	return f.findProfileByKeycloakID(k)
+}
+func (f *fakeDatastore) FindProfileByDiscordID(d string) (*proto.Profile, error) {
+	return f.findProfileByDiscordID(d)
+}
+func (f *fakeDatastore) FindS1UniformsRosterByType(t proto.RosterType) (*proto.S1UniformsRoster, error) {
+	return f.findS1UniformsRosterByType(t)
+}
+func (f *fakeDatastore) FindProfileByGamertag(g string) (*proto.Profile, error) {
+	return f.findProfileByGamertag(g)
+}
+
+// Milpacs methods this PR does not exercise — stay panicking.
+func (f *fakeDatastore) FindProfilesByPosition(string) (*proto.LiteRoster, error)         { panic("unused") }
+func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error)                     { panic("unused") }
+func (f *fakeDatastore) FindAllPositionGroups() ([]*proto.PositionGroup, error)           { panic("unused") }
+func (f *fakeDatastore) FindAwol() ([]*proto.Awol, error)                                 { panic("unused") }
+func (f *fakeDatastore) GetTableUpdates() ([]xenforo.TableInfo, error)                    { panic("unused") }
+func (f *fakeDatastore) ValidateApiKey(string) (*datastores.ApiKeyResult, error)          { panic("unused") }
 
 // withTicketsKey builds a context carrying an ApiKeyResult with the given
 // scope set. Mirrors the auth middleware's behavior in production.
 func withTicketsKey(scopes ...string) context.Context {
+	m := map[string]struct{}{}
+	for _, s := range scopes {
+		m[s] = struct{}{}
+	}
+	return ContextWithKey(context.Background(), &datastores.ApiKeyResult{Scopes: m})
+}
+
+// withMilpacsKey builds a context carrying an ApiKeyResult with the given
+// scope set, mirroring withTicketsKey but for milpacs-handler tests.
+// Pass "read" to satisfy RequireScope; pass nothing for permission-denied paths.
+func withMilpacsKey(scopes ...string) context.Context {
 	m := map[string]struct{}{}
 	for _, s := range scopes {
 		m[s] = struct{}{}

--- a/servers/grpc/fake_datastore_test.go
+++ b/servers/grpc/fake_datastore_test.go
@@ -10,10 +10,8 @@ import (
 
 // fakeDatastore is the shared in-process Datastore stub used by both
 // tickets_test.go and milpacs_test.go. Each handler-under-test gets the
-// matching function field populated; everything else either panics
-// (methods this PR does not exercise) or, for milpacs methods, nil-derefs
-// on call so an accidentally-untouched test fails loudly with a clear
-// stack rather than a silent zero-value response.
+// matching function field populated; milpacs methods panic until Task 2
+// converts them to configurable function fields.
 type fakeDatastore struct {
 	// Tickets — configurable function fields used by tickets_test.go.
 	listTickets func(*datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error)

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -86,7 +86,7 @@ func (server *MilpacsService) GetRoster(ctx context.Context, request *proto.Rost
 	roster, err := server.Datastore.FindRosterByType(request.Roster)
 
 	if err != nil {
-		return &proto.Roster{}, status.Errorf(codes.NotFound, "no roster found for %s", request.Roster)
+		return nil, status.Errorf(codes.Internal, "fetch roster %s: %v", request.Roster, err)
 	}
 
 	return roster, nil

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -63,10 +63,13 @@ func (server *MilpacsService) GetProfile(ctx context.Context, request *proto.Pro
 		Info.Println("GetProfile, requested via userid")
 		profiles, err = server.Datastore.FindProfilesById(request.UserId)
 		if err != nil {
-			return &proto.Profile{}, status.Errorf(codes.NotFound, "no profile found for user ID: %d", request.UserId)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, status.Errorf(codes.NotFound, "no profile found for user ID: %d", request.UserId)
+			}
+			return nil, status.Errorf(codes.Internal, "fetch profile by user id: %v", err)
 		}
 	} else {
-		return &proto.Profile{}, status.Errorf(codes.InvalidArgument, "no username or user ID provided")
+		return nil, status.Errorf(codes.InvalidArgument, "no username or user ID provided")
 	}
 
 	return profiles[0], nil

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -229,13 +229,16 @@ func (server *MilpacsService) GetGamertagProfile(ctx context.Context, request *p
 	}
 	if request.GetGamertag() == "" {
 		Warn.Println("Empty Gamertag provided, cannot return profile")
-		return &proto.Profile{}, status.Errorf(codes.InvalidArgument, "gamertag cannot be empty")
+		return nil, status.Errorf(codes.InvalidArgument, "gamertag cannot be empty")
 	}
 
 	profile, err := server.Datastore.FindProfileByGamertag(request.GetGamertag())
 
 	if err != nil {
-		return &proto.Profile{}, status.Errorf(codes.NotFound, "no user found for gamertag: %v", request.GetGamertag())
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Errorf(codes.NotFound, "no user found for gamertag: %v", request.GetGamertag())
+		}
+		return nil, status.Errorf(codes.Internal, "fetch profile by gamertag: %v", err)
 	}
 	return profile, nil
 }

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -21,14 +21,15 @@ package grpc
 import (
 	"context"
 	"errors"
+	"log"
+	"os"
+
 	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gorm.io/gorm"
-	"log"
-	"os"
 )
 
 type MilpacsService struct {

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"gorm.io/gorm"
 	"log"
 	"os"
 )
@@ -52,7 +53,10 @@ func (server *MilpacsService) GetProfile(ctx context.Context, request *proto.Pro
 		Info.Println("GetProfile, Requested via username")
 		profiles, err = server.Datastore.FindProfilesByUsername(request.Username)
 		if err != nil {
-			return &proto.Profile{}, status.Errorf(codes.NotFound, "no profile found for username: %s", request.Username)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, status.Errorf(codes.NotFound, "no profile found for username: %s", request.Username)
+			}
+			return nil, status.Errorf(codes.Internal, "fetch profile by username: %v", err)
 		}
 	} else if request.UserId != 0 {
 		Info.Println("GetProfile, requested via userid")

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -176,7 +176,7 @@ func (server *MilpacsService) GetS1UniformsRoster(ctx context.Context, request *
 	roster, err := server.Datastore.FindS1UniformsRosterByType(request.Roster)
 
 	if err != nil {
-		return &proto.S1UniformsRoster{}, status.Errorf(codes.NotFound, "no roster found for %s", request.Roster)
+		return nil, status.Errorf(codes.Internal, "fetch s1 uniforms roster %s: %v", request.Roster, err)
 	}
 	return roster, nil
 }

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -104,7 +104,10 @@ func (server *MilpacsService) GetUserViaKeycloakId(ctx context.Context, request 
 	profile, err := server.Datastore.FindProfileByKeycloakID(request.GetKeycloakId())
 
 	if err != nil {
-		return &proto.Profile{}, status.Errorf(codes.NotFound, "no user found for keycloakid: %s", request.GetKeycloakId())
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Errorf(codes.NotFound, "no user found for keycloakid: %s", request.GetKeycloakId())
+		}
+		return nil, status.Errorf(codes.Internal, "fetch profile by keycloak id: %v", err)
 	}
 
 	return profile, nil

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -125,7 +125,10 @@ func (server *MilpacsService) GetUserViaDiscordId(ctx context.Context, request *
 	profile, err := server.Datastore.FindProfileByDiscordID(request.GetDiscordId())
 
 	if err != nil {
-		return &proto.Profile{}, status.Errorf(codes.NotFound, "no user found for discordid: %s", request.GetDiscordId())
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Errorf(codes.NotFound, "no user found for discordid: %s", request.GetDiscordId())
+		}
+		return nil, status.Errorf(codes.Internal, "fetch profile by discord id: %v", err)
 	}
 
 	return profile, nil

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -144,7 +144,7 @@ func (server *MilpacsService) GetLiteRoster(ctx context.Context, request *proto.
 	roster, err := server.Datastore.FindLiteRosterByType(request.Roster)
 
 	if err != nil {
-		return &proto.LiteRoster{}, status.Errorf(codes.NotFound, "no roster found for %s", request.Roster)
+		return nil, status.Errorf(codes.Internal, "fetch lite roster %s: %v", request.Roster, err)
 	}
 
 	return roster, nil

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -115,3 +115,29 @@ func TestGetUserViaDiscordId_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetGamertagProfile_NotFound(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfileByGamertag: func(string) (*proto.Profile, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}}
+	_, err := svc.GetGamertagProfile(withMilpacsKey("read"), &proto.GamertagRequest{Gamertag: "Nobody#0001"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetGamertagProfile_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfileByGamertag: func(string) (*proto.Profile, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetGamertagProfile(withMilpacsKey("read"), &proto.GamertagRequest{Gamertag: "any"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -141,3 +141,16 @@ func TestGetGamertagProfile_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetRoster_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findRosterByType: func(proto.RosterType) (*proto.Roster, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetRoster(withMilpacsKey("read"), &proto.RosterRequest{Roster: proto.RosterType_ROSTER_TYPE_COMBAT})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -1,0 +1,39 @@
+package grpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/7cav/api/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+func TestGetProfile_ByUsername_NotFound(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfilesByUsername: func(string) ([]*proto.Profile, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}}
+	_, err := svc.GetProfile(withMilpacsKey("read"), &proto.ProfileRequest{Username: "ghost"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetProfile_ByUsername_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfilesByUsername: func(string) ([]*proto.Profile, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetProfile(withMilpacsKey("read"), &proto.ProfileRequest{Username: "anyone"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -37,3 +37,29 @@ func TestGetProfile_ByUsername_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetProfile_ByUserID_NotFound(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfilesById: func(...uint64) ([]*proto.Profile, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}}
+	_, err := svc.GetProfile(withMilpacsKey("read"), &proto.ProfileRequest{UserId: 99999})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetProfile_ByUserID_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfilesById: func(...uint64) ([]*proto.Profile, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetProfile(withMilpacsKey("read"), &proto.ProfileRequest{UserId: 42})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -154,3 +154,16 @@ func TestGetRoster_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetLiteRoster_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findLiteRosterByType: func(proto.RosterType) (*proto.LiteRoster, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetLiteRoster(withMilpacsKey("read"), &proto.RosterRequest{Roster: proto.RosterType_ROSTER_TYPE_COMBAT})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -63,3 +63,29 @@ func TestGetProfile_ByUserID_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetUserViaKeycloakId_NotFound(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfileByKeycloakID: func(string) (*proto.Profile, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}}
+	_, err := svc.GetUserViaKeycloakId(withMilpacsKey("read"), &proto.KeycloakIdRequest{KeycloakId: "ghost-uuid"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetUserViaKeycloakId_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfileByKeycloakID: func(string) (*proto.Profile, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetUserViaKeycloakId(withMilpacsKey("read"), &proto.KeycloakIdRequest{KeycloakId: "any"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -167,3 +167,16 @@ func TestGetLiteRoster_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetS1UniformsRoster_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetS1UniformsRoster(withMilpacsKey("read"), &proto.RosterRequest{Roster: proto.RosterType_ROSTER_TYPE_COMBAT})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/milpacs_test.go
+++ b/servers/grpc/milpacs_test.go
@@ -89,3 +89,29 @@ func TestGetUserViaKeycloakId_DatastoreError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestGetUserViaDiscordId_NotFound(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfileByDiscordID: func(string) (*proto.Profile, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}}
+	_, err := svc.GetUserViaDiscordId(withMilpacsKey("read"), &proto.DiscordIdRequest{DiscordId: "404"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetUserViaDiscordId_DatastoreError(t *testing.T) {
+	svc := &MilpacsService{Datastore: &fakeDatastore{
+		findProfileByDiscordID: func(string) (*proto.Profile, error) {
+			return nil, errors.New("boom")
+		},
+	}}
+	_, err := svc.GetUserViaDiscordId(withMilpacsKey("read"), &proto.DiscordIdRequest{DiscordId: "any"})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/servers/grpc/tickets_test.go
+++ b/servers/grpc/tickets_test.go
@@ -1,7 +1,6 @@
 package grpc
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -9,7 +8,6 @@ import (
 	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/proto"
 	"github.com/7cav/api/referencecache"
-	"github.com/7cav/api/xenforo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -17,63 +15,6 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gorm.io/gorm"
 )
-
-// fakeDatastore implements datastores.Datastore with just the methods we need
-// for tickets-handler tests stubbed. Other methods panic so the test surface
-// stays explicit.
-type fakeDatastore struct {
-	listTickets func(*datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error)
-	getTicket   func(uint32) (*proto.Ticket, error)
-	getByRef    func(string) (*proto.Ticket, error)
-	firstMsgs   func(uint32, int) ([]*proto.Message, uint32, error)
-	listMsgs    func(uint32, string, uint32, bool) ([]*proto.Message, string, bool, error)
-	listCats    func() ([]*proto.Category, error)
-}
-
-func (f *fakeDatastore) ListTickets(_ context.Context, _ datastores.TicketReferenceCache, fi *datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error) {
-	return f.listTickets(fi)
-}
-func (f *fakeDatastore) GetTicket(_ context.Context, _ datastores.TicketReferenceCache, id uint32, _ string) (*proto.Ticket, error) {
-	return f.getTicket(id)
-}
-func (f *fakeDatastore) GetTicketByRef(_ context.Context, _ datastores.TicketReferenceCache, ref string, _ string) (*proto.Ticket, error) {
-	return f.getByRef(ref)
-}
-func (f *fakeDatastore) GetTicketFirstMessages(_ context.Context, id uint32, n int, _ bool) ([]*proto.Message, uint32, error) {
-	return f.firstMsgs(id, n)
-}
-func (f *fakeDatastore) ListTicketMessages(_ context.Context, id uint32, after string, per uint32, hidden bool) ([]*proto.Message, string, bool, error) {
-	return f.listMsgs(id, after, per, hidden)
-}
-func (f *fakeDatastore) ListCategories(_ context.Context, _ datastores.TicketReferenceCache) ([]*proto.Category, error) {
-	return f.listCats()
-}
-
-// Milpacs methods omitted; tickets tests don't use them.
-func (f *fakeDatastore) FindProfilesById(_ ...uint64) ([]*proto.Profile, error)           { panic("unused") }
-func (f *fakeDatastore) FindProfilesByUsername(string) ([]*proto.Profile, error)          { panic("unused") }
-func (f *fakeDatastore) FindRosterByType(proto.RosterType) (*proto.Roster, error)         { panic("unused") }
-func (f *fakeDatastore) FindLiteRosterByType(proto.RosterType) (*proto.LiteRoster, error) { panic("unused") }
-func (f *fakeDatastore) FindProfileByKeycloakID(string) (*proto.Profile, error)           { panic("unused") }
-func (f *fakeDatastore) FindProfileByDiscordID(string) (*proto.Profile, error)            { panic("unused") }
-func (f *fakeDatastore) FindProfilesByPosition(string) (*proto.LiteRoster, error)         { panic("unused") }
-func (f *fakeDatastore) FindS1UniformsRosterByType(proto.RosterType) (*proto.S1UniformsRoster, error) {
-	panic("unused")
-}
-func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error)             { panic("unused") }
-func (f *fakeDatastore) FindAllPositionGroups() ([]*proto.PositionGroup, error)   { panic("unused") }
-func (f *fakeDatastore) FindAwol() ([]*proto.Awol, error)                         { panic("unused") }
-func (f *fakeDatastore) GetTableUpdates() ([]xenforo.TableInfo, error)            { panic("unused") }
-func (f *fakeDatastore) FindProfileByGamertag(string) (*proto.Profile, error)     { panic("unused") }
-func (f *fakeDatastore) ValidateApiKey(string) (*datastores.ApiKeyResult, error)  { panic("unused") }
-
-func withTicketsKey(scopes ...string) context.Context {
-	m := map[string]struct{}{}
-	for _, s := range scopes {
-		m[s] = struct{}{}
-	}
-	return ContextWithKey(context.Background(), &datastores.ApiKeyResult{Scopes: m})
-}
 
 func TestListTickets_RequiresScope(t *testing.T) {
 	svc := &TicketsService{Datastore: &fakeDatastore{}, ReferenceCache: &referencecache.Cache{}}


### PR DESCRIPTION
## Summary

Fixes [the long-standing `MilpacsService` error-routing bug](https://github.com/7Cav/api/blob/develop/CLAUDE.md): every datastore error mapped to `codes.NotFound` (HTTP 404). DB outages, query timeouts, and genuine missing-record lookups were indistinguishable to consumers.

Two distinct bug shapes get fixed in one bundled PR:

- **Pattern A — single-row finders** (5 datastore funcs, 4 RPCs, 5 call sites). Datastore caught `gorm.ErrRecordNotFound` and wrapped with `fmt.Errorf` without `%w`, destroying the sentinel. Now the datastore returns `result.Error` directly; handler adds `errors.Is(err, gorm.ErrRecordNotFound)` → `codes.NotFound`, everything else → `codes.Internal`. Mirrors `TicketsService`.
- **Pattern B — roster finders** (3 datastore funcs, 3 RPCs). Datastore used `Find()` without capturing `result.Error`, so DB outages produced empty slices with no error — handlers returned `HTTP 200 {Profiles: {}}`. Handler's `if err != nil → 404` branch was dead code. Now the datastore captures `result.Error` and wraps with `%w`; handler maps any error to `codes.Internal`.

All `&proto.X{}` error returns flipped to `nil` (gRPC ignores the message on error; matches the tickets convention).

13 new unit tests via a shared `fakeDatastore` lifted out of `tickets_test.go` into `fake_datastore_test.go`.

No proto / OpenAPI / interface changes. No release cut.

## Files

- `datastores/mysql.go` — Pattern A unwrap on 5 single-row finders; Pattern B `result.Error` capture on 3 roster finders
- `servers/grpc/grpc.go` — handler updates on 7 RPCs (`GetProfile` username + user_id, `GetUserViaKeycloakId`, `GetUserViaDiscordId`, `GetGamertagProfile`, `GetRoster`, `GetLiteRoster`, `GetS1UniformsRoster`)
- `servers/grpc/fake_datastore_test.go` — new shared test stub
- `servers/grpc/milpacs_test.go` — new, 13 unit tests
- `servers/grpc/tickets_test.go` — `fakeDatastore` block removed (moved to the new shared file)

## Already-correct RPCs untouched

`SearchByPosition`, `GetAllRanks`, `GetPositionGroups`, `GetAwol` — all four already route errors correctly via the `Internal` pattern. Listed for reviewer context, no code change.

## Out of scope (tracked as followup chore in the vault, blocked by this PR)

- `errors.New("cannot request null roster type")` on 3 roster handlers (should be `codes.InvalidArgument`).
- Empty Keycloak/Discord ID `Warn.Println(...)` warn-but-continue (should early-return `InvalidArgument`).
- Three `fmt.Errorf("error generating profile")` outliers without `%w` (`FindProfileByKeycloakID`, `FindProfileByDiscordID`, S1-uniforms inline loop).

## Test plan

- [x] `go test ./...` — 13 new milpacs tests + existing suite green
- [x] `go vet ./... && go build ./...` — clean
- [x] Local-stack smoke: known user `Jarvis.A` → 200, bogus user → 404, combat roster → 200, post-`docker stop`/`docker start` cycle recovery → 200
- [x] **Insomnia 61/61** — verified manually
- [ ] Reviewer to confirm

### Coverage gap acknowledged

The Pattern-B unit tests stub the datastore method and verify the *handler's* mapping; they do not directly verify the datastore-side `result.Error` capture. The planned end-to-end `docker stop xenforo-db → expect 500` smoke can't isolate that path because the auth middleware (`ValidateApiKey`) also queries xenforo-db, so requests 401 before reaching the milpacs handlers. The datastore-side capture is verified by code inspection only. Reviewing the diff is the path of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)