### PR TITLE
chore: gitignore .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docker-compose.yaml
 .claude/
 docs/superpowers/
 CLAUDE.md
+.playwright-mcp/


### PR DESCRIPTION
## Summary

Playwright MCP drops page-snapshot YAML files into `.playwright-mcp/` at the project root during browser smoke runs (e.g. the OpenAPI Swagger UI verification done for PR #82). These are session-local artifacts with no consumer in the repo, but they keep appearing in `git status` across sessions.

Adding `.playwright-mcp/` to `.gitignore` (in the existing "Claude Code local working files" block) keeps the working tree clean. Mirrors the same pattern already used for `.claude/`, `docs/superpowers/`, and `CLAUDE.md`.

## Test plan

- [x] `git status` clean after deleting the existing stale snapshot
- [x] Future Playwright MCP runs won't surface in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)