### PR TITLE
chore(deps): bundle grpc 1.81.1 + build-push-action 7.1.0

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           push: true

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4
-	google.golang.org/grpc v1.81.0
+	google.golang.org/grpc v1.81.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
 	google.golang.org/protobuf v1.36.11
 	gorm.io/driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:Q9HWtNeE7tM9npdIsEvqXj1QJIvVoeAV3rtXtS715Cw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 h1:tEkOQcXgF6dH1G+MVKZrfpYvozGrzb91k6ha7jireSM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
-google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2 h1:rgSNvqscFZ1JgV/4wH5GOsZFSFkR2Eua9As3KIr2LlM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2/go.mod h1:iMEtFwDlAhjDU9L5mY6U1XLwlIId/G3h+QcBHDIvrJ8=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
## Summary
Bundles two clean Dependabot bumps superseding #87 and #88. Originally also carried Dependabot #86 (nginx 1.27-alpine → 1.31-alpine), but the rebase onto develop after #90 merged dropped that commit — the `nginx` service was removed from the compose template in #90, so the bump no longer has a target.

- `google.golang.org/grpc` 1.81.0 → 1.81.1 (patch; supersedes #88)
- `docker/build-push-action` v7 → v7.1.0 (GHA tag pin; supersedes #87)

## Test plan
Local smoke against `xenforo-db:9999` + `dev-redis:6379` with the new grpc lib in-process — all green:

- [x] `go build ./...` + `go vet ./...` clean
- [x] `/milpacs/ranks` → 200, 30 ranks
- [x] `/milpacs/profile/id/1` → 200, real user
- [x] `/roster/1/lite` → 200, 845 profiles
- [x] `/tickets/categories` → 200, 19 categories
- [x] `bearer` lowercase prefix → 200 (PR #51 holds)
- [x] missing / invalid token → 401
- [x] unknown user → 404 (PR #83 error mapping holds)
- [x] Redis cache HIT logged on second request

#86 (nginx bump) will be auto-closed by Dependabot on its next scan since the image is no longer referenced. If it's still hanging around in a day or two, close it manually pointing at #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)