### PR TITLE
chore(milpacs): deprecate GetUserViaKeycloakId rpc + keycloak_id fields (#97)

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -11,3 +11,4 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-openapiv2
     out: openapi/assets
+    opt: enable_field_deprecation=true

--- a/openapi/assets/milpacs.swagger.json
+++ b/openapi/assets/milpacs.swagger.json
@@ -107,12 +107,14 @@
             "name": "keycloakId",
             "in": "path",
             "required": true,
+            "deprecated": true,
             "type": "string"
           }
         ],
         "tags": [
           "Roster, Milpacs, Keycloak"
-        ]
+        ],
+        "deprecated": true
       }
     },
     "/api/v1/milpacs/awol": {

--- a/openapi/openapi_test.go
+++ b/openapi/openapi_test.go
@@ -1,0 +1,39 @@
+package openapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Phase 1 deprecation surface for GetUserViaKeycloakId (issue #97).
+// OpenAPI 2.0 supports `deprecated` on operations and parameters but NOT on
+// schema properties (added in OpenAPI 3.0). This test pins what the
+// swagger.json — i.e. the API doc surface — actually advertises to consumers.
+// Schema-property deprecation for Profile.keycloak_id / LiteProfile.keycloak_id
+// is asserted via the proto descriptor in proto_deprecation_test.go.
+func TestMilpacsSwagger_DeprecatesKeycloakIdSurface(t *testing.T) {
+	raw, err := Files.ReadFile("assets/milpacs.swagger.json")
+	require.NoError(t, err)
+
+	var spec struct {
+		Paths map[string]map[string]struct {
+			Deprecated bool `json:"deprecated"`
+			Parameters []struct {
+				Name       string `json:"name"`
+				Deprecated bool   `json:"deprecated"`
+			} `json:"parameters"`
+		} `json:"paths"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &spec))
+
+	op, ok := spec.Paths["/api/v1/milpac/keycloak/{keycloakId}"]["get"]
+	require.True(t, ok, "GET /api/v1/milpac/keycloak/{keycloakId} missing from spec")
+	assert.True(t, op.Deprecated, "GetUserViaKeycloakId op must be deprecated")
+
+	require.Len(t, op.Parameters, 1)
+	assert.Equal(t, "keycloakId", op.Parameters[0].Name)
+	assert.True(t, op.Parameters[0].Deprecated, "keycloakId path parameter must be deprecated")
+}

--- a/proto/deprecation_test.go
+++ b/proto/deprecation_test.go
@@ -1,0 +1,47 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Phase 1 deprecation contract for GetUserViaKeycloakId (issue #97).
+// Asserts the proto-level deprecation flags that downstream consumers
+// (generated code, descriptors, linters) actually observe. The OpenAPI
+// surface is asserted in openapi/openapi_test.go.
+func TestKeycloakIdDeprecationContract(t *testing.T) {
+	svc := File_milpacs_proto.Services().ByName("MilpacService")
+	require.NotNil(t, svc, "MilpacService missing from descriptor")
+
+	rpc := svc.Methods().ByName("GetUserViaKeycloakId")
+	require.NotNil(t, rpc, "GetUserViaKeycloakId rpc missing")
+	assert.True(t, methodDeprecated(rpc), "GetUserViaKeycloakId must be deprecated")
+
+	for _, c := range []struct {
+		msg, field string
+	}{
+		{"KeycloakIdRequest", "keycloak_id"},
+		{"Profile", "keycloak_id"},
+		{"LiteProfile", "keycloak_id"},
+	} {
+		msg := File_milpacs_proto.Messages().ByName(protoreflect.Name(c.msg))
+		require.NotNil(t, msg, "%s missing from descriptor", c.msg)
+		f := msg.Fields().ByName(protoreflect.Name(c.field))
+		require.NotNil(t, f, "%s.%s missing from descriptor", c.msg, c.field)
+		assert.True(t, fieldDeprecated(f), "%s.%s must be deprecated", c.msg, c.field)
+	}
+}
+
+func methodDeprecated(m protoreflect.MethodDescriptor) bool {
+	opts, ok := m.Options().(*descriptorpb.MethodOptions)
+	return ok && opts.GetDeprecated()
+}
+
+func fieldDeprecated(f protoreflect.FieldDescriptor) bool {
+	opts, ok := f.Options().(*descriptorpb.FieldOptions)
+	return ok && opts.GetDeprecated()
+}

--- a/proto/milpacs.pb.go
+++ b/proto/milpacs.pb.go
@@ -355,8 +355,9 @@ func (x *ProfileRequest) GetUsername() string {
 }
 
 type KeycloakIdRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	KeycloakId    string                 `protobuf:"bytes,1,opt,name=keycloak_id,json=keycloakId,proto3" json:"keycloak_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Deprecated: Marked as deprecated in milpacs.proto.
+	KeycloakId    string `protobuf:"bytes,1,opt,name=keycloak_id,json=keycloakId,proto3" json:"keycloak_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -391,6 +392,7 @@ func (*KeycloakIdRequest) Descriptor() ([]byte, []int) {
 	return file_milpacs_proto_rawDescGZIP(), []int{1}
 }
 
+// Deprecated: Marked as deprecated in milpacs.proto.
 func (x *KeycloakIdRequest) GetKeycloakId() string {
 	if x != nil {
 		return x.KeycloakId
@@ -555,23 +557,24 @@ func (x *Thingy) GetAck() string {
 }
 
 type Profile struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	User              *User                  `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
-	Rank              *Rank                  `protobuf:"bytes,2,opt,name=rank,proto3" json:"rank,omitempty"`
-	RealName          string                 `protobuf:"bytes,3,opt,name=real_name,json=realName,proto3" json:"real_name,omitempty"`
-	UniformUrl        string                 `protobuf:"bytes,4,opt,name=uniform_url,json=uniformUrl,proto3" json:"uniform_url,omitempty"`
-	Roster            RosterType             `protobuf:"varint,5,opt,name=roster,proto3,enum=proto.RosterType" json:"roster,omitempty"`
-	Primary           *Position              `protobuf:"bytes,6,opt,name=primary,proto3" json:"primary,omitempty"`
-	Secondaries       []*Position            `protobuf:"bytes,7,rep,name=secondaries,proto3" json:"secondaries,omitempty"`
-	Records           []*Record              `protobuf:"bytes,8,rep,name=records,proto3" json:"records,omitempty"`
-	Awards            []*Award               `protobuf:"bytes,9,rep,name=awards,proto3" json:"awards,omitempty"`
-	JoinDate          string                 `protobuf:"bytes,10,opt,name=join_date,json=joinDate,proto3" json:"join_date,omitempty"`
-	PromotionDate     string                 `protobuf:"bytes,11,opt,name=promotion_date,json=promotionDate,proto3" json:"promotion_date,omitempty"`
-	KeycloakId        string                 `protobuf:"bytes,12,opt,name=keycloak_id,json=keycloakId,proto3" json:"keycloak_id,omitempty"`
-	DiscordId         string                 `protobuf:"bytes,13,opt,name=discord_id,json=discordId,proto3" json:"discord_id,omitempty"`
-	LastForumPostDate string                 `protobuf:"bytes,14,opt,name=last_forum_post_date,json=lastForumPostDate,proto3" json:"last_forum_post_date,omitempty"`
-	Mos               string                 `protobuf:"bytes,15,opt,name=mos,proto3" json:"mos,omitempty"`
-	ConsoleGamertag   string                 `protobuf:"bytes,16,opt,name=console_gamertag,json=consoleGamertag,proto3" json:"console_gamertag,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	User          *User                  `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
+	Rank          *Rank                  `protobuf:"bytes,2,opt,name=rank,proto3" json:"rank,omitempty"`
+	RealName      string                 `protobuf:"bytes,3,opt,name=real_name,json=realName,proto3" json:"real_name,omitempty"`
+	UniformUrl    string                 `protobuf:"bytes,4,opt,name=uniform_url,json=uniformUrl,proto3" json:"uniform_url,omitempty"`
+	Roster        RosterType             `protobuf:"varint,5,opt,name=roster,proto3,enum=proto.RosterType" json:"roster,omitempty"`
+	Primary       *Position              `protobuf:"bytes,6,opt,name=primary,proto3" json:"primary,omitempty"`
+	Secondaries   []*Position            `protobuf:"bytes,7,rep,name=secondaries,proto3" json:"secondaries,omitempty"`
+	Records       []*Record              `protobuf:"bytes,8,rep,name=records,proto3" json:"records,omitempty"`
+	Awards        []*Award               `protobuf:"bytes,9,rep,name=awards,proto3" json:"awards,omitempty"`
+	JoinDate      string                 `protobuf:"bytes,10,opt,name=join_date,json=joinDate,proto3" json:"join_date,omitempty"`
+	PromotionDate string                 `protobuf:"bytes,11,opt,name=promotion_date,json=promotionDate,proto3" json:"promotion_date,omitempty"`
+	// Deprecated: Marked as deprecated in milpacs.proto.
+	KeycloakId        string `protobuf:"bytes,12,opt,name=keycloak_id,json=keycloakId,proto3" json:"keycloak_id,omitempty"`
+	DiscordId         string `protobuf:"bytes,13,opt,name=discord_id,json=discordId,proto3" json:"discord_id,omitempty"`
+	LastForumPostDate string `protobuf:"bytes,14,opt,name=last_forum_post_date,json=lastForumPostDate,proto3" json:"last_forum_post_date,omitempty"`
+	Mos               string `protobuf:"bytes,15,opt,name=mos,proto3" json:"mos,omitempty"`
+	ConsoleGamertag   string `protobuf:"bytes,16,opt,name=console_gamertag,json=consoleGamertag,proto3" json:"console_gamertag,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -683,6 +686,7 @@ func (x *Profile) GetPromotionDate() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in milpacs.proto.
 func (x *Profile) GetKeycloakId() string {
 	if x != nil {
 		return x.KeycloakId
@@ -1055,23 +1059,24 @@ func (x *Position) GetPositionId() uint64 {
 }
 
 type LiteProfile struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	User              *User                  `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
-	Rank              *Rank                  `protobuf:"bytes,2,opt,name=rank,proto3" json:"rank,omitempty"`
-	RealName          string                 `protobuf:"bytes,3,opt,name=real_name,json=realName,proto3" json:"real_name,omitempty"`
-	UniformUrl        string                 `protobuf:"bytes,4,opt,name=uniform_url,json=uniformUrl,proto3" json:"uniform_url,omitempty"`
-	Roster            RosterType             `protobuf:"varint,5,opt,name=roster,proto3,enum=proto.RosterType" json:"roster,omitempty"`
-	Primary           *Position              `protobuf:"bytes,6,opt,name=primary,proto3" json:"primary,omitempty"`
-	Secondaries       []*Position            `protobuf:"bytes,7,rep,name=secondaries,proto3" json:"secondaries,omitempty"`
-	JoinDate          string                 `protobuf:"bytes,8,opt,name=join_date,json=joinDate,proto3" json:"join_date,omitempty"`
-	PromotionDate     string                 `protobuf:"bytes,9,opt,name=promotion_date,json=promotionDate,proto3" json:"promotion_date,omitempty"`
-	KeycloakId        string                 `protobuf:"bytes,10,opt,name=keycloak_id,json=keycloakId,proto3" json:"keycloak_id,omitempty"`
-	DiscordId         string                 `protobuf:"bytes,11,opt,name=discord_id,json=discordId,proto3" json:"discord_id,omitempty"`
-	AwardDate         string                 `protobuf:"bytes,12,opt,name=award_date,json=awardDate,proto3" json:"award_date,omitempty"`
-	RecordDate        string                 `protobuf:"bytes,13,opt,name=record_date,json=recordDate,proto3" json:"record_date,omitempty"`
-	LastForumPostDate string                 `protobuf:"bytes,14,opt,name=last_forum_post_date,json=lastForumPostDate,proto3" json:"last_forum_post_date,omitempty"`
-	Mos               string                 `protobuf:"bytes,15,opt,name=mos,proto3" json:"mos,omitempty"`
-	ConsoleGamertag   string                 `protobuf:"bytes,16,opt,name=console_gamertag,json=consoleGamertag,proto3" json:"console_gamertag,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	User          *User                  `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
+	Rank          *Rank                  `protobuf:"bytes,2,opt,name=rank,proto3" json:"rank,omitempty"`
+	RealName      string                 `protobuf:"bytes,3,opt,name=real_name,json=realName,proto3" json:"real_name,omitempty"`
+	UniformUrl    string                 `protobuf:"bytes,4,opt,name=uniform_url,json=uniformUrl,proto3" json:"uniform_url,omitempty"`
+	Roster        RosterType             `protobuf:"varint,5,opt,name=roster,proto3,enum=proto.RosterType" json:"roster,omitempty"`
+	Primary       *Position              `protobuf:"bytes,6,opt,name=primary,proto3" json:"primary,omitempty"`
+	Secondaries   []*Position            `protobuf:"bytes,7,rep,name=secondaries,proto3" json:"secondaries,omitempty"`
+	JoinDate      string                 `protobuf:"bytes,8,opt,name=join_date,json=joinDate,proto3" json:"join_date,omitempty"`
+	PromotionDate string                 `protobuf:"bytes,9,opt,name=promotion_date,json=promotionDate,proto3" json:"promotion_date,omitempty"`
+	// Deprecated: Marked as deprecated in milpacs.proto.
+	KeycloakId        string `protobuf:"bytes,10,opt,name=keycloak_id,json=keycloakId,proto3" json:"keycloak_id,omitempty"`
+	DiscordId         string `protobuf:"bytes,11,opt,name=discord_id,json=discordId,proto3" json:"discord_id,omitempty"`
+	AwardDate         string `protobuf:"bytes,12,opt,name=award_date,json=awardDate,proto3" json:"award_date,omitempty"`
+	RecordDate        string `protobuf:"bytes,13,opt,name=record_date,json=recordDate,proto3" json:"record_date,omitempty"`
+	LastForumPostDate string `protobuf:"bytes,14,opt,name=last_forum_post_date,json=lastForumPostDate,proto3" json:"last_forum_post_date,omitempty"`
+	Mos               string `protobuf:"bytes,15,opt,name=mos,proto3" json:"mos,omitempty"`
+	ConsoleGamertag   string `protobuf:"bytes,16,opt,name=console_gamertag,json=consoleGamertag,proto3" json:"console_gamertag,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1169,6 +1174,7 @@ func (x *LiteProfile) GetPromotionDate() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in milpacs.proto.
 func (x *LiteProfile) GetKeycloakId() string {
 	if x != nil {
 		return x.KeycloakId
@@ -2081,9 +2087,9 @@ const file_milpacs_proto_rawDesc = "" +
 	"\rmilpacs.proto\x12\x05proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\x1a\x1bgoogle/protobuf/empty.proto\"E\n" +
 	"\x0eProfileRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\x04R\x06userId\x12\x1a\n" +
-	"\busername\x18\x02 \x01(\tR\busername\"4\n" +
-	"\x11KeycloakIdRequest\x12\x1f\n" +
-	"\vkeycloak_id\x18\x01 \x01(\tR\n" +
+	"\busername\x18\x02 \x01(\tR\busername\"8\n" +
+	"\x11KeycloakIdRequest\x12#\n" +
+	"\vkeycloak_id\x18\x01 \x01(\tB\x02\x18\x01R\n" +
 	"keycloakId\"1\n" +
 	"\x10DiscordIdRequest\x12\x1d\n" +
 	"\n" +
@@ -2095,7 +2101,7 @@ const file_milpacs_proto_rawDesc = "" +
 	"\x0erank_image_url\x18\x03 \x01(\tR\frankImageUrl\x12\x17\n" +
 	"\arank_id\x18\x04 \x01(\x04R\x06rankId\"\x1a\n" +
 	"\x06Thingy\x12\x10\n" +
-	"\x03ack\x18\x01 \x01(\tR\x03ack\"\xd3\x04\n" +
+	"\x03ack\x18\x01 \x01(\tR\x03ack\"\xd7\x04\n" +
 	"\aProfile\x12\x1f\n" +
 	"\x04user\x18\x01 \x01(\v2\v.proto.UserR\x04user\x12\x1f\n" +
 	"\x04rank\x18\x02 \x01(\v2\v.proto.RankR\x04rank\x12\x1b\n" +
@@ -2109,8 +2115,8 @@ const file_milpacs_proto_rawDesc = "" +
 	"\x06awards\x18\t \x03(\v2\f.proto.AwardR\x06awards\x12\x1b\n" +
 	"\tjoin_date\x18\n" +
 	" \x01(\tR\bjoinDate\x12%\n" +
-	"\x0epromotion_date\x18\v \x01(\tR\rpromotionDate\x12\x1f\n" +
-	"\vkeycloak_id\x18\f \x01(\tR\n" +
+	"\x0epromotion_date\x18\v \x01(\tR\rpromotionDate\x12#\n" +
+	"\vkeycloak_id\x18\f \x01(\tB\x02\x18\x01R\n" +
 	"keycloakId\x12\x1d\n" +
 	"\n" +
 	"discord_id\x18\r \x01(\tR\tdiscordId\x12/\n" +
@@ -2146,7 +2152,7 @@ const file_milpacs_proto_rawDesc = "" +
 	"\bPosition\x12%\n" +
 	"\x0eposition_title\x18\x01 \x01(\tR\rpositionTitle\x12\x1f\n" +
 	"\vposition_id\x18\x02 \x01(\x04R\n" +
-	"positionId\"\xc8\x04\n" +
+	"positionId\"\xcc\x04\n" +
 	"\vLiteProfile\x12\x1f\n" +
 	"\x04user\x18\x01 \x01(\v2\v.proto.UserR\x04user\x12\x1f\n" +
 	"\x04rank\x18\x02 \x01(\v2\v.proto.RankR\x04rank\x12\x1b\n" +
@@ -2157,9 +2163,9 @@ const file_milpacs_proto_rawDesc = "" +
 	"\aprimary\x18\x06 \x01(\v2\x0f.proto.PositionR\aprimary\x121\n" +
 	"\vsecondaries\x18\a \x03(\v2\x0f.proto.PositionR\vsecondaries\x12\x1b\n" +
 	"\tjoin_date\x18\b \x01(\tR\bjoinDate\x12%\n" +
-	"\x0epromotion_date\x18\t \x01(\tR\rpromotionDate\x12\x1f\n" +
+	"\x0epromotion_date\x18\t \x01(\tR\rpromotionDate\x12#\n" +
 	"\vkeycloak_id\x18\n" +
-	" \x01(\tR\n" +
+	" \x01(\tB\x02\x18\x01R\n" +
 	"keycloakId\x12\x1d\n" +
 	"\n" +
 	"discord_id\x18\v \x01(\tR\tdiscordId\x12\x1d\n" +
@@ -2295,15 +2301,15 @@ const file_milpacs_proto_rawDesc = "" +
 	"\rRANK_TYPE_CW3\x10\x1c\x12\x11\n" +
 	"\rRANK_TYPE_CW2\x10\x1d\x12\x11\n" +
 	"\rRANK_TYPE_WO1\x10\x1e\x12\x10\n" +
-	"\fRANK_TYPE_AR\x10\x1f2\xb3\x14\n" +
+	"\fRANK_TYPE_AR\x10\x1f2\xb8\x14\n" +
 	"\rMilpacService\x12\xf9\x01\n" +
 	"\n" +
 	"GetProfile\x12\x15.proto.ProfileRequest\x1a\x0e.proto.Profile\"\xc3\x01\x92Ae\n" +
 	"\x17Users, Milpacs, Profile\x12\x1dGet given user milpac Profile\x1a+Get milpac Profile data for a specific user\x82\xd3\xe4\x93\x02UZ-\x12+/api/v1/milpacs/profile/username/{username}\x12$/api/v1/milpacs/profile/id/{user_id}\x12\xa9\x01\n" +
 	"\tGetRoster\x12\x14.proto.RosterRequest\x1a\r.proto.Roster\"w\x92AU\n" +
-	"\x0fRoster, Milpacs\x12\x12Get a given roster\x1a.Get all milpac Profile data for a given roster\x82\xd3\xe4\x93\x02\x19\x12\x17/api/v1/roster/{roster}\x12\xf9\x01\n" +
-	"\x14GetUserViaKeycloakId\x12\x18.proto.KeycloakIdRequest\x1a\x0e.proto.Profile\"\xb6\x01\x92A\x85\x01\n" +
-	"\x19Roster, Milpacs, Keycloak\x12$Get a Milpac profile via keycloak ID\x1aBGet all milpac Profile data for a given user via their Keycloak ID\x82\xd3\xe4\x93\x02'\x12%/api/v1/milpac/keycloak/{keycloak_id}\x12\xf2\x01\n" +
+	"\x0fRoster, Milpacs\x12\x12Get a given roster\x1a.Get all milpac Profile data for a given roster\x82\xd3\xe4\x93\x02\x19\x12\x17/api/v1/roster/{roster}\x12\xfe\x01\n" +
+	"\x14GetUserViaKeycloakId\x12\x18.proto.KeycloakIdRequest\x1a\x0e.proto.Profile\"\xbb\x01\x92A\x87\x01\n" +
+	"\x19Roster, Milpacs, Keycloak\x12$Get a Milpac profile via keycloak ID\x1aBGet all milpac Profile data for a given user via their Keycloak IDX\x01\x82\xd3\xe4\x93\x02'\x12%/api/v1/milpac/keycloak/{keycloak_id}\x88\x02\x01\x12\xf2\x01\n" +
 	"\x13GetUserViaDiscordId\x12\x17.proto.DiscordIdRequest\x1a\x0e.proto.Profile\"\xb1\x01\x92A\x82\x01\n" +
 	"\x18Roster, Milpacs, Discord\x12#Get a Milpac profile via Discord ID\x1aAGet all milpac Profile data for a given user via their Discord ID\x82\xd3\xe4\x93\x02%\x12#/api/v1/milpac/discord/{discord_id}\x12\xf2\x01\n" +
 	"\rGetLiteRoster\x12\x14.proto.RosterRequest\x1a\x11.proto.LiteRoster\"\xb7\x01\x92A\x8f\x01\n" +

--- a/proto/milpacs.proto
+++ b/proto/milpacs.proto
@@ -81,6 +81,7 @@ service MilpacService {
     };
   };
   rpc GetUserViaKeycloakId(KeycloakIdRequest) returns (Profile){
+    option deprecated = true;
     option(google.api.http) = {
       get: "/api/v1/milpac/keycloak/{keycloak_id}"
     };
@@ -88,6 +89,7 @@ service MilpacService {
       summary: "Get a Milpac profile via keycloak ID"
       description: "Get all milpac Profile data for a given user via their Keycloak ID"
       tags: "Roster, Milpacs, Keycloak"
+      deprecated: true
     };
   };
   rpc GetUserViaDiscordId(DiscordIdRequest) returns (Profile){
@@ -239,7 +241,7 @@ message ProfileRequest {
 }
 
 message KeycloakIdRequest {
-  string keycloak_id = 1;
+  string keycloak_id = 1 [deprecated = true];
 }
 
 message DiscordIdRequest {
@@ -269,7 +271,7 @@ message Profile {
   repeated Award awards = 9;
   string join_date = 10;
   string promotion_date = 11;
-  string keycloak_id = 12;
+  string keycloak_id = 12 [deprecated = true];
   string discord_id = 13;
   string last_forum_post_date = 14;
   string mos = 15;
@@ -319,7 +321,7 @@ message LiteProfile {
   repeated Position secondaries = 7;
   string join_date = 8;
   string promotion_date = 9;
-  string keycloak_id = 10;
+  string keycloak_id = 10 [deprecated = true];
   string discord_id = 11;
   string award_date = 12;
   string record_date = 13;

--- a/proto/milpacs_grpc.pb.go
+++ b/proto/milpacs_grpc.pb.go
@@ -56,6 +56,7 @@ const (
 type MilpacServiceClient interface {
 	GetProfile(ctx context.Context, in *ProfileRequest, opts ...grpc.CallOption) (*Profile, error)
 	GetRoster(ctx context.Context, in *RosterRequest, opts ...grpc.CallOption) (*Roster, error)
+	// Deprecated: Do not use.
 	GetUserViaKeycloakId(ctx context.Context, in *KeycloakIdRequest, opts ...grpc.CallOption) (*Profile, error)
 	GetUserViaDiscordId(ctx context.Context, in *DiscordIdRequest, opts ...grpc.CallOption) (*Profile, error)
 	GetLiteRoster(ctx context.Context, in *RosterRequest, opts ...grpc.CallOption) (*LiteRoster, error)
@@ -95,6 +96,7 @@ func (c *milpacServiceClient) GetRoster(ctx context.Context, in *RosterRequest, 
 	return out, nil
 }
 
+// Deprecated: Do not use.
 func (c *milpacServiceClient) GetUserViaKeycloakId(ctx context.Context, in *KeycloakIdRequest, opts ...grpc.CallOption) (*Profile, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(Profile)
@@ -191,6 +193,7 @@ func (c *milpacServiceClient) GetGamertagProfile(ctx context.Context, in *Gamert
 type MilpacServiceServer interface {
 	GetProfile(context.Context, *ProfileRequest) (*Profile, error)
 	GetRoster(context.Context, *RosterRequest) (*Roster, error)
+	// Deprecated: Do not use.
 	GetUserViaKeycloakId(context.Context, *KeycloakIdRequest) (*Profile, error)
 	GetUserViaDiscordId(context.Context, *DiscordIdRequest) (*Profile, error)
 	GetLiteRoster(context.Context, *RosterRequest) (*LiteRoster, error)


### PR DESCRIPTION
Closes #97. Phase 1/2. Deprecation only. No behavior change. Removal = #100.

## Diff
- `option deprecated = true;` on `GetUserViaKeycloakId` rpc + `deprecated: true` in openapiv2_operation -> swagger UI struck-through.
- `[deprecated = true]` on `keycloak_id` in `KeycloakIdRequest`, `Profile`, `LiteProfile` -> propagates to `.pb.go` getters as `// Deprecated:` comments. Go consumers get IDE/lint warnings.
- `enable_field_deprecation=true` in `buf.gen.yaml` -> `keycloakId` path param renders `deprecated: true` in swagger.
- Regenerated artifacts committed (pb.go, grpc.pb.go, swagger.json).

## Tests added
- `proto/deprecation_test.go` — descriptor contract via protoreflect. Pins rpc + 3 field deprecation flags. Survives codegen churn.
- `openapi/openapi_test.go` — pins swagger op + path-param deprecated markers.
- Existing `TestGetUserViaKeycloakId_*` unchanged + still pass.

## AC deviation
- AC wanted `"deprecated": true` on `Profile.keycloak_id` / `LiteProfile.keycloak_id` schema props in swagger.json. **Not possible** under Swagger 2.0 — `deprecated` on schema props is OpenAPI 3.0 only. `protoc-gen-openapiv2`'s `openapiSchemaObject` Go type has no field for it.
- Field deprecation still visible to:
  - Go consumers (cavbot2 et al) via `// Deprecated:` getter comments.
  - Other-language gRPC clients via descriptor flag.
- Gap = REST-only consumer reading `keycloakId` from `GetProfile` response. Narrow given cavbot2 cutover (#83) already done + #92 traffic-gating before Phase 2.

## CI gate local
- `make generate` deterministic (re-run = no diff)
- `go mod tidy` clean
- `go build ./...` clean
- `make lint` (buf lint + buf breaking vs develop) clean
- `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)