### PR TITLE
feat(grpc): log per-request [REQ] line for #92 evidence slice

### DIFF
--- a/servers/grpc/auth_test.go
+++ b/servers/grpc/auth_test.go
@@ -1,15 +1,31 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
+	"net"
 	"testing"
 
 	"github.com/7cav/api/datastores"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
+
+// captureInfo redirects the package Info logger to a buffer for the duration
+// of the test and restores it on cleanup.
+func captureInfo(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := Info.Writer()
+	Info.SetOutput(buf)
+	t.Cleanup(func() { Info.SetOutput(prev) })
+	return buf
+}
 
 func TestKeyFromContext_NilWhenAbsent(t *testing.T) {
 	got := KeyFromContext(context.Background())
@@ -55,4 +71,64 @@ func TestRequireScope_RejectsWhenKeyAbsent(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+
+// buildAuthCtx returns an incoming-gRPC context populated with a bearer token
+// and a peer address — the two things the interceptor reads off the wire.
+func buildAuthCtx(token, peerIP string) context.Context {
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Bearer "+token),
+	)
+	return peer.NewContext(ctx, &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP(peerIP), Port: 4242},
+	})
+}
+
+func TestAuthInterceptor_LogsRequestOnSuccess(t *testing.T) {
+	ds := &fakeDatastore{
+		validateApiKey: func(token string) (*datastores.ApiKeyResult, error) {
+			return &datastores.ApiKeyResult{KeyId: 17}, nil
+		},
+	}
+	buf := captureInfo(t)
+	interceptor := NewAuthInterceptor(ds)
+	ctx := buildAuthCtx("cav7_abc", "10.0.0.5")
+	info := &grpc.UnaryServerInfo{FullMethod: "/proto.MilpacService/GetProfile"}
+	resp, err := interceptor(ctx, "req", info, func(ctx context.Context, req any) (any, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "[REQ] transport=grpc")
+	assert.Contains(t, logged, "method=/proto.MilpacService/GetProfile")
+	assert.Contains(t, logged, "peer=10.0.0.5:4242")
+	assert.Contains(t, logged, "key_id=17")
+}
+
+func TestAuthInterceptor_LogsRequestOnAuthFailure(t *testing.T) {
+	ds := &fakeDatastore{
+		validateApiKey: func(token string) (*datastores.ApiKeyResult, error) {
+			return nil, status.Errorf(codes.Unauthenticated, "bad")
+		},
+	}
+	buf := captureInfo(t)
+	interceptor := NewAuthInterceptor(ds)
+	ctx := buildAuthCtx("cav7_bogus", "10.0.0.5")
+	info := &grpc.UnaryServerInfo{FullMethod: "/proto.MilpacService/GetProfile"}
+	handlerCalled := false
+	_, err := interceptor(ctx, "req", info, func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return nil, nil
+	})
+	require.Error(t, err)
+	assert.False(t, handlerCalled, "handler must not run on auth failure")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "[REQ] transport=grpc")
+	assert.Contains(t, logged, "method=/proto.MilpacService/GetProfile")
+	assert.Contains(t, logged, "peer=10.0.0.5:4242")
+	assert.Contains(t, logged, "key_id=none")
 }

--- a/servers/grpc/authentication.go
+++ b/servers/grpc/authentication.go
@@ -20,11 +20,13 @@ package grpc
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/7cav/api/datastores"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -32,6 +34,15 @@ const maxTokenLen = 128
 
 func NewAuthInterceptor(ds datastores.Datastore) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		peerAddr := "unknown"
+		if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+			peerAddr = p.Addr.String()
+		}
+		keyID := "none"
+		defer func() {
+			Info.Printf("[REQ] transport=grpc method=%s peer=%s key_id=%s", info.FullMethod, peerAddr, keyID)
+		}()
+
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			return nil, status.Errorf(codes.Unauthenticated, "missing metadata")
@@ -52,6 +63,7 @@ func NewAuthInterceptor(ds datastores.Datastore) grpc.UnaryServerInterceptor {
 			return nil, status.Errorf(codes.Unauthenticated, "invalid api key")
 		}
 
+		keyID = strconv.FormatUint(uint64(key.KeyId), 10)
 		return handler(ContextWithKey(ctx, key), req)
 	}
 }

--- a/servers/grpc/fake_datastore_test.go
+++ b/servers/grpc/fake_datastore_test.go
@@ -33,6 +33,9 @@ type fakeDatastore struct {
 	findRosterByType           func(proto.RosterType) (*proto.Roster, error)
 	findLiteRosterByType       func(proto.RosterType) (*proto.LiteRoster, error)
 	findS1UniformsRosterByType func(proto.RosterType) (*proto.S1UniformsRoster, error)
+
+	// Auth — used by auth_test.go to drive the interceptor end-to-end.
+	validateApiKey func(string) (*datastores.ApiKeyResult, error)
 }
 
 func (f *fakeDatastore) ListTickets(_ context.Context, _ datastores.TicketReferenceCache, fi *datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error) {
@@ -85,7 +88,10 @@ func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error)           
 func (f *fakeDatastore) FindAllPositionGroups() ([]*proto.PositionGroup, error)           { panic("unused") }
 func (f *fakeDatastore) FindAwol() ([]*proto.Awol, error)                                 { panic("unused") }
 func (f *fakeDatastore) GetTableUpdates() ([]xenforo.TableInfo, error)                    { panic("unused") }
-func (f *fakeDatastore) ValidateApiKey(string) (*datastores.ApiKeyResult, error)          { panic("unused") }
+
+func (f *fakeDatastore) ValidateApiKey(token string) (*datastores.ApiKeyResult, error) {
+	return f.validateApiKey(token)
+}
 
 // makeKeyCtx builds a context carrying an ApiKeyResult with the given scope
 // set. The withTicketsKey / withMilpacsKey wrappers stay as named entry


### PR DESCRIPTION
Evidence slice for #92. Adds a defer'd log line to the gRPC `UnaryInterceptor` so every call emits:

```
[REQ] transport=grpc method=<full_method> peer=<addr> key_id=<id|none>
```

## Why this shape

- **Auth-success and auth-failure both log.** Unauthenticated probes (port scanners, broken consumers) still constitute external traffic for the `:10000`-vs-`:11000` question that gates #94/#95.
- **Peer disambiguates gateway from external.** The HTTP gateway's intra-process dial shows `peer=127.0.0.1`; external traffic reaching gRPC via nginx shows the nginx container IP. Filter loopback out of the log to find the external set.
- **`key_id` (not raw token, not user) is the actionable identifier.** Bounded, ACP-managed, lets the operator cross-reference owner.

Scope intentionally narrow — no HTTP gateway counter, no Redis persistence, no stack choice. Probe is throwaway; the long-term analytics surface gets picked when #94/#95 close.

## Test plan
- [x] `go test ./...` — passes; two new tests in `auth_test.go` cover the success and auth-failure log paths.
- [x] `go build -v ./...`
- [x] `make lint`
- [x] `make generate` (no drift)
- [x] `go mod tidy` (no drift)
- [x] **Local-stack smoke** (CLAUDE.md manual review gate, auth touch). Observed on local API + xenforo-db + dev-redis:
  - HTTP gateway hit → `[REQ] transport=grpc method=/proto.MilpacService/GetRoster peer=127.0.0.1:62807 key_id=3`
  - Direct grpcurl with valid bearer → `... peer=127.0.0.1:62870 key_id=3` (distinct port from gateway dial)
  - Direct grpcurl with no bearer → `... peer=127.0.0.1:62873 key_id=none` + `Unauthenticated`
  - Direct grpcurl with bogus bearer → `... peer=127.0.0.1:62874 key_id=none` + `Unauthenticated`

  Local stack has no nginx so all peers are `127.0.0.1`; in prod the gateway dial will be loopback and external traffic will show the nginx container IP — that's the disambiguation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)