### PR TITLE
feat(logging): append parseable duration= to request log lines

### DIFF
--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"compress/gzip"
-	"github.com/7cav/api/cache"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -17,7 +16,16 @@ var (
 	Error = log.New(os.Stdout, "ERROR: ", log.LstdFlags)
 )
 
-func CacheMiddleware(cache *cache.RedisCache, next http.Handler) http.Handler {
+// responseCache is the slice of cache.RedisCache the middleware actually
+// uses. *cache.RedisCache satisfies it implicitly, so callers are unchanged;
+// tests substitute an in-memory fake.
+type responseCache interface {
+	Get(key string) ([]byte, error)
+	Set(key string, response []byte) error
+	GenerateCacheKey(path string) string
+}
+
+func CacheMiddleware(cache responseCache, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/tickets" || strings.HasPrefix(r.URL.Path, "/api/v1/tickets/") {
 			next.ServeHTTP(w, r)
@@ -28,7 +36,12 @@ func CacheMiddleware(cache *cache.RedisCache, next http.Handler) http.Handler {
 		r.Header.Del("Accept-Encoding")
 		endodeGzip := strings.Contains(acceptEncoding, "gzip")
 		defer func() {
-			Info.Printf("[CACHE] Request completed in %v", time.Since(start))
+			// Phase 0 measuring stick (#112/#114): duration= duplicates the
+			// human-readable elapsed value as a parseable field, appended so
+			// existing ad-hoc analytics keep matching the line. Fires on hit
+			// and miss alike. Temporary; retires once Prometheus owns metrics.
+			elapsed := time.Since(start)
+			Info.Printf("[CACHE] Request completed in %v duration=%v", elapsed, elapsed)
 		}()
 
 		if r.Method != http.MethodGet {

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -42,9 +42,10 @@ func CacheMiddleware(cache responseCache, next http.Handler) http.Handler {
 		defer func() {
 			// Phase 0 measuring stick (#112/#114): duration= duplicates the
 			// human-readable elapsed value as a parseable field, appended so
-			// existing ad-hoc analytics keep matching the line. Fires on hit
-			// and miss alike. Temporary; this middleware is deleted at Phase 2
-			// de-cache (#123).
+			// existing ad-hoc analytics keep matching the line. Fires on every
+			// request past the tickets bypass (hit, miss, and non-GET alike).
+			// Temporary; this middleware leaves the chain at Phase 2 de-cache
+			// (#123); deletion follows post-soak (#124).
 			elapsed := time.Since(start)
 			Info.Printf("[CACHE] Request completed in %v duration=%v", elapsed, elapsed)
 		}()

--- a/middleware/cache.go
+++ b/middleware/cache.go
@@ -16,9 +16,13 @@ var (
 	Error = log.New(os.Stdout, "ERROR: ", log.LstdFlags)
 )
 
-// responseCache is the slice of cache.RedisCache the middleware actually
-// uses. *cache.RedisCache satisfies it implicitly, so callers are unchanged;
-// tests substitute an in-memory fake.
+// responseCache is the subset of cache.RedisCache's method set the middleware
+// actually uses. *cache.RedisCache satisfies it implicitly, so callers are
+// unchanged; tests substitute an in-memory fake.
+//
+// Get returns a non-nil error when the key is absent or the cache is
+// unreachable; the middleware treats any error as a miss. A nil error
+// guarantees the returned bytes are a complete cached response.
 type responseCache interface {
 	Get(key string) ([]byte, error)
 	Set(key string, response []byte) error
@@ -39,7 +43,8 @@ func CacheMiddleware(cache responseCache, next http.Handler) http.Handler {
 			// Phase 0 measuring stick (#112/#114): duration= duplicates the
 			// human-readable elapsed value as a parseable field, appended so
 			// existing ad-hoc analytics keep matching the line. Fires on hit
-			// and miss alike. Temporary; retires once Prometheus owns metrics.
+			// and miss alike. Temporary; this middleware is deleted at Phase 2
+			// de-cache (#123).
 			elapsed := time.Since(start)
 			Info.Printf("[CACHE] Request completed in %v duration=%v", elapsed, elapsed)
 		}()

--- a/middleware/cache_test.go
+++ b/middleware/cache_test.go
@@ -1,0 +1,119 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureInfo redirects the package Info logger to a buffer for the duration
+// of the test and restores it on cleanup.
+func captureInfo(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := Info.Writer()
+	Info.SetOutput(buf)
+	t.Cleanup(func() { Info.SetOutput(prev) })
+	return buf
+}
+
+// fakeCache is an in-memory stand-in for cache.RedisCache, mirroring its
+// key scheme. An empty fakeCache misses on every Get.
+type fakeCache struct {
+	data map[string][]byte
+}
+
+func (f *fakeCache) Get(key string) ([]byte, error) {
+	if b, ok := f.data[key]; ok {
+		return b, nil
+	}
+	return nil, errors.New("redis: nil")
+}
+
+func (f *fakeCache) Set(key string, response []byte) error {
+	if f.data == nil {
+		f.data = map[string][]byte{}
+	}
+	f.data[key] = response
+	return nil
+}
+
+func (f *fakeCache) GenerateCacheKey(path string) string {
+	return "api:response:" + path
+}
+
+var cacheDurationPattern = regexp.MustCompile(`duration=(\S+)`)
+
+// extractCacheDuration pulls the duration= value out of the captured log
+// output and parses it as a real time.Duration.
+func extractCacheDuration(t *testing.T, logged string) time.Duration {
+	t.Helper()
+	m := cacheDurationPattern.FindStringSubmatch(logged)
+	require.Len(t, m, 2, "log output must carry a duration= field, got: %q", logged)
+	d, err := time.ParseDuration(m[1])
+	require.NoError(t, err, "duration= value must parse as a Go duration")
+	return d
+}
+
+// Phase 0 measuring stick (#114): a cache-miss request must end with a
+// completion line carrying a parseable duration= covering the handler, while
+// the existing line text stays intact for the ad-hoc analytics.
+func TestCacheMiddleware_MissLogsDuration(t *testing.T) {
+	buf := captureInfo(t)
+	const handlerDelay = 15 * time.Millisecond
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(handlerDelay)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	})
+	h := CacheMiddleware(&fakeCache{}, next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+	assert.Equal(t, `{"ok":true}`, rec.Body.String())
+
+	logged := buf.String()
+	// Existing consumer-visible lines unbroken.
+	assert.Contains(t, logged, "[CACHE] MISS: Cache miss for key: api:response:/api/v1/roster")
+	assert.Regexp(t, `\[CACHE\] Request completed in \S+ duration=\S+`, logged)
+	d := extractCacheDuration(t, logged)
+	assert.GreaterOrEqual(t, d, handlerDelay,
+		"duration must cover the handler on the miss path")
+}
+
+// A cache-hit request never reaches the gRPC [REQ] line, so its duration must
+// come from the [CACHE] completion line — otherwise the Phase 2 de-cache
+// delta is invisible for hits.
+func TestCacheMiddleware_HitLogsDuration(t *testing.T) {
+	buf := captureInfo(t)
+	fc := &fakeCache{data: map[string][]byte{
+		"api:response:/api/v1/roster": []byte(`{"cached":true}`),
+	}}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run on a cache hit")
+	})
+	h := CacheMiddleware(fc, next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "HIT", rec.Header().Get("X-Cache"))
+	assert.Equal(t, `{"cached":true}`, rec.Body.String())
+
+	logged := buf.String()
+	// Existing consumer-visible lines unbroken.
+	assert.Contains(t, logged, "[CACHE] HIT: Found cached response for key: api:response:/api/v1/roster")
+	assert.Regexp(t, `\[CACHE\] Request completed in \S+ duration=\S+`, logged)
+	extractCacheDuration(t, logged)
+}

--- a/middleware/cache_test.go
+++ b/middleware/cache_test.go
@@ -9,12 +9,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/7cav/api/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// Drift guard: *cache.RedisCache must keep satisfying responseCache. The
+// cache import is test-only, so the production package keeps its
+// dependency-edge removal.
+var _ responseCache = (*cache.RedisCache)(nil)
+
 // captureInfo redirects the package Info logger to a buffer for the duration
-// of the test and restores it on cleanup.
+// of the test and restores it on cleanup. Not parallel-safe: swaps a shared
+// package-level logger; do not add t.Parallel() to this package.
 func captureInfo(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	buf := &bytes.Buffer{}
@@ -50,6 +57,21 @@ func (f *fakeCache) GenerateCacheKey(path string) string {
 }
 
 var cacheDurationPattern = regexp.MustCompile(`duration=(\S+)`)
+
+// completionLinePattern captures both renderings of the elapsed value on the
+// completion line: the human-readable "in <v>" and the parseable "duration=<v>".
+var completionLinePattern = regexp.MustCompile(`\[CACHE\] Request completed in (\S+) duration=(\S+)`)
+
+// requireCompletionValuesEqual asserts both renderings are identical, locking
+// the compute-elapsed-once contract: cache.go computes elapsed one time and
+// prints it twice.
+func requireCompletionValuesEqual(t *testing.T, logged string) {
+	t.Helper()
+	m := completionLinePattern.FindStringSubmatch(logged)
+	require.Len(t, m, 3, "log output must carry a completion line with both values, got: %q", logged)
+	assert.Equal(t, m[1], m[2],
+		"human-readable and duration= values must come from a single elapsed computation")
+}
 
 // extractCacheDuration pulls the duration= value out of the captured log
 // output and parses it as a real time.Duration.
@@ -89,6 +111,52 @@ func TestCacheMiddleware_MissLogsDuration(t *testing.T) {
 	d := extractCacheDuration(t, logged)
 	assert.GreaterOrEqual(t, d, handlerDelay,
 		"duration must cover the handler on the miss path")
+	requireCompletionValuesEqual(t, logged)
+}
+
+// Tickets requests bypass the middleware before timing starts, so they emit
+// no [CACHE] completion line — intent, not accident: the gRPC [REQ] line
+// covers those requests downstream.
+func TestCacheMiddleware_TicketsBypassEmitsNoCompletionLine(t *testing.T) {
+	buf := captureInfo(t)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CacheMiddleware(&fakeCache{}, next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/tickets/123", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, buf.String(), "[CACHE] Request completed",
+		"tickets bypass must return before the timing defer is installed")
+}
+
+// Non-GET requests skip the cache but must still get a timed completion line:
+// the timing defer sits above the GET guard in cache.go, and this test makes
+// that placement load-bearing instead of accidental. The skip line itself
+// must stay verbatim for the ad-hoc analytics.
+func TestCacheMiddleware_PostSkipsCacheButLogsDuration(t *testing.T) {
+	buf := captureInfo(t)
+	const handlerDelay = 15 * time.Millisecond
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(handlerDelay)
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CacheMiddleware(&fakeCache{}, next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/roster", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	logged := buf.String()
+	// Existing consumer-visible line unbroken.
+	assert.Contains(t, logged, "[CACHE] Skipping cache for POST request: /api/v1/roster")
+	assert.Regexp(t, `\[CACHE\] Request completed in \S+ duration=\S+`, logged)
+	d := extractCacheDuration(t, logged)
+	assert.GreaterOrEqual(t, d, handlerDelay,
+		"duration must cover the handler on the non-GET bypass path")
 }
 
 // A cache-hit request never reaches the gRPC [REQ] line, so its duration must
@@ -116,4 +184,5 @@ func TestCacheMiddleware_HitLogsDuration(t *testing.T) {
 	assert.Contains(t, logged, "[CACHE] HIT: Found cached response for key: api:response:/api/v1/roster")
 	assert.Regexp(t, `\[CACHE\] Request completed in \S+ duration=\S+`, logged)
 	extractCacheDuration(t, logged)
+	requireCompletionValuesEqual(t, logged)
 }

--- a/servers/grpc/auth_test.go
+++ b/servers/grpc/auth_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 // captureInfo redirects the package Info logger to a buffer for the duration
-// of the test and restores it on cleanup.
+// of the test and restores it on cleanup. Not parallel-safe: swaps a shared
+// package-level logger; do not add t.Parallel() to this package.
 func captureInfo(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	buf := &bytes.Buffer{}

--- a/servers/grpc/authentication.go
+++ b/servers/grpc/authentication.go
@@ -21,6 +21,7 @@ package grpc
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/7cav/api/datastores"
 	"google.golang.org/grpc"
@@ -41,13 +42,19 @@ const errBearerScheme = "Unauthenticated: expected 'Authorization: Bearer <key>'
 
 func NewAuthInterceptor(ds datastores.Datastore) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		// Phase 0 measuring stick (#112/#114): duration= times the whole
+		// request (handler included — the deferred line fires after the
+		// `return handler(...)` value is computed). Temporary field; retires
+		// with this stack once Prometheus owns metrics. Appended after the
+		// existing fields so the ad-hoc log analytics keep parsing.
+		start := time.Now()
 		peerAddr := "unknown"
 		if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
 			peerAddr = p.Addr.String()
 		}
 		keyID := "none"
 		defer func() {
-			Info.Printf("[REQ] transport=grpc method=%s peer=%s key_id=%s", info.FullMethod, peerAddr, keyID)
+			Info.Printf("[REQ] transport=grpc method=%s peer=%s key_id=%s duration=%v", info.FullMethod, peerAddr, keyID, time.Since(start))
 		}()
 
 		md, ok := metadata.FromIncomingContext(ctx)

--- a/servers/grpc/authentication.go
+++ b/servers/grpc/authentication.go
@@ -42,11 +42,12 @@ const errBearerScheme = "Unauthenticated: expected 'Authorization: Bearer <key>'
 
 func NewAuthInterceptor(ds datastores.Datastore) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		// Phase 0 measuring stick (#112/#114): duration= times the whole
-		// request (handler included — the deferred line fires after the
-		// `return handler(...)` value is computed). Temporary field; retires
-		// with this stack once Prometheus owns metrics. Appended after the
-		// existing fields so the ad-hoc log analytics keep parsing.
+		// Phase 0 measuring stick (#112/#114): duration= times auth + handler
+		// (excludes gRPC response marshal/wire write). The handler is included
+		// because the deferred line fires after the `return handler(...)`
+		// value is computed. Temporary field; retires with this stack once
+		// Prometheus owns metrics. Appended after the existing fields so the
+		// ad-hoc log analytics keep parsing.
 		start := time.Now()
 		peerAddr := "unknown"
 		if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {

--- a/servers/grpc/authentication_test.go
+++ b/servers/grpc/authentication_test.go
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (C) 2021 7Cav.us
+ *  This file is part of 7Cav-API <https://github.com/7cav/api>.
+ *
+ *  7Cav-API is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  7Cav-API is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with 7Cav-API. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package grpc
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/7cav/api/datastores"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// reqDurationPattern extracts the duration= field from a [REQ] log line.
+var reqDurationPattern = regexp.MustCompile(`duration=(\S+)`)
+
+// extractReqDuration pulls the duration= value out of the captured log output
+// and parses it, so tests assert on a real time.Duration rather than string
+// shape alone.
+func extractReqDuration(t *testing.T, logged string) time.Duration {
+	t.Helper()
+	m := reqDurationPattern.FindStringSubmatch(logged)
+	require.Len(t, m, 2, "log output must carry a duration= field, got: %q", logged)
+	d, err := time.ParseDuration(m[1])
+	require.NoError(t, err, "duration= value must parse as a Go duration")
+	return d
+}
+
+// Phase 0 measuring stick (#114): the [REQ] line must time the whole request
+// including the handler, appended after the existing fields so the ad-hoc
+// analytics keep parsing transport/method/peer/key_id unchanged.
+func TestAuthInterceptor_ReqLineCarriesHandlerDuration(t *testing.T) {
+	ds := &fakeDatastore{
+		validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
+			return &datastores.ApiKeyResult{KeyId: 17}, nil
+		},
+	}
+	buf := captureInfo(t)
+	interceptor := NewAuthInterceptor(ds)
+	ctx := buildAuthCtx("cav7_abc", "10.0.0.5")
+	info := &grpc.UnaryServerInfo{FullMethod: "/proto.MilpacService/GetProfile"}
+
+	const handlerDelay = 15 * time.Millisecond
+	resp, err := interceptor(ctx, "req", info, func(ctx context.Context, req any) (any, error) {
+		time.Sleep(handlerDelay)
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+
+	logged := buf.String()
+	// Existing fields stay, in order; duration= is appended after key_id.
+	assert.Regexp(t,
+		`\[REQ\] transport=grpc method=/proto\.MilpacService/GetProfile peer=10\.0\.0\.5:4242 key_id=17 duration=\S+`,
+		logged)
+	d := extractReqDuration(t, logged)
+	assert.GreaterOrEqual(t, d, handlerDelay,
+		"duration must cover the handler, not just interceptor overhead")
+}
+
+// Every [REQ] line carries duration= — including requests rejected before the
+// handler runs (auth failures), where key_id stays "none".
+func TestAuthInterceptor_ReqLineCarriesDurationOnAuthFailure(t *testing.T) {
+	ds := &fakeDatastore{
+		validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
+			return nil, nil
+		},
+	}
+	buf := captureInfo(t)
+	interceptor := NewAuthInterceptor(ds)
+	ctx := buildAuthCtx("cav7_badkey", "10.0.0.5")
+	info := &grpc.UnaryServerInfo{FullMethod: "/proto.MilpacService/GetProfile"}
+
+	_, err := interceptor(ctx, "req", info, func(ctx context.Context, req any) (any, error) {
+		t.Fatal("handler must not run on auth failure")
+		return nil, nil
+	})
+	require.Error(t, err)
+
+	logged := buf.String()
+	assert.Regexp(t, `\[REQ\] transport=grpc method=\S+ peer=\S+ key_id=none duration=\S+`, logged)
+	extractReqDuration(t, logged)
+}

--- a/servers/grpc/authentication_test.go
+++ b/servers/grpc/authentication_test.go
@@ -45,9 +45,10 @@ func extractReqDuration(t *testing.T, logged string) time.Duration {
 	return d
 }
 
-// Phase 0 measuring stick (#114): the [REQ] line must time the whole request
-// including the handler, appended after the existing fields so the ad-hoc
-// analytics keep parsing transport/method/peer/key_id unchanged.
+// Phase 0 measuring stick (#114): the [REQ] line must time auth + handler
+// (excludes gRPC response marshal/wire write), appended after the existing
+// fields so the ad-hoc analytics keep parsing transport/method/peer/key_id
+// unchanged.
 func TestAuthInterceptor_ReqLineCarriesHandlerDuration(t *testing.T) {
 	ds := &fakeDatastore{
 		validateApiKey: func(string) (*datastores.ApiKeyResult, error) {


### PR DESCRIPTION
## Summary

Adds a `duration=` field to the existing request log lines — the Phase 0 measuring stick that makes the Phase 1 (index) and Phase 2 (de-cache) latency deltas observable in prod (PRD #112).

- `[REQ]` line (gRPC auth interceptor): times auth + handler via a deferred closure (excludes response marshal/wire write)
- `[CACHE]` completion line: `duration=` appended; fires on every request past the tickets bypass (hit, miss, and non-GET alike)
- Existing line text and field order preserved verbatim — the ad-hoc grep analytics keep matching
- `CacheMiddleware` param narrowed to a consumer-side `responseCache` interface so the HIT path is testable without redis or new deps (production `middleware→cache` import edge removed; gateway caller satisfies it implicitly, untouched)

## Review

3 supervised review rounds (code-reviewer, pr-test-analyzer, comment-analyzer, type-design agents) — all findings closed. Pin tests are mutation-checked: defer placement above the GET guard, tickets-bypass ordering, dual-print equality, and an interface drift guard each fail their target test when broken.

## Test plan

- [x] `go build && go vet && go test ./...` green
- [x] `-race -count=5 -shuffle=on` green on touched packages
- [x] Merged-tree preflight with the #118 branch: build + full suite + race/shuffle green

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)