### PR TITLE
feat(sentry): env-gated errors-only capture wrapping the current stack

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,10 @@ services:
       # Optional — enables errors-only Sentry capture (#118). The DSN lives only
       # in the prod host's compose config (#113); unset anywhere else = no-op.
       # SENTRY_DSN:
+      # Optional — verbose Sentry SDK diagnostics (one log line per event sent;
+      # send failures/drops/rate limits become visible). For debugging delivery
+      # problems without a rebuild; leave unset normally.
+      # SENTRY_DEBUG: "true"
     depends_on:
       - redis
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,9 @@ services:
       # FORUM_BASE_URL: https://7cav.us
       # Optional — refresh interval for the in-memory ticket reference cache; defaults to 15m.
       # REFERENCE_CACHE_REFRESH_INTERVAL: 15m
+      # Optional — enables errors-only Sentry capture (#118). The DSN lives only
+      # in the prod host's compose config (#113); unset anywhere else = no-op.
+      # SENTRY_DSN:
     depends_on:
       - redis
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.10
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/bufbuild/buf v1.70.0
+	github.com/getsentry/sentry-go v0.46.2
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/redis/go-redis/v9 v9.20.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,10 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK6ojns=
+github.com/getsentry/sentry-go v0.46.2/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -150,6 +154,10 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 h1:WDsQxOJDy0N1VRAjXLpi8sCEZRSGarLWQevDxpTBRrM=
 github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9 h1:arwj11zP0yJIxIRiDn22E0H8PxfF7TsTrc2wIPFIsf4=

--- a/servers/gateway/gateway.go
+++ b/servers/gateway/gateway.go
@@ -126,6 +126,24 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	return w.Writer.Write(b)
 }
 
+// buildAPIHandler assembles the /api middleware chain:
+// auth(sentry(cache(compression(inner)))). Sentry sits inside auth so it only
+// sees authenticated requests, with the API key already on ctx for key-id
+// tagging, and outside the cache and compression layers so it observes the
+// final response status. No SENTRY_DSN → it is a pass-through.
+//
+// Sentry-inside-auth also means auth-layer infrastructure failures (e.g. a
+// datastore outage producing mass 401s) generate no Sentry events by design —
+// accepted for Phase 0, revisit in the Phase 3 first-class wiring (#130–#132).
+//
+// Package-level (not inlined in Server) so the chain order is a tested
+// contract — see the buildAPIHandler tests — rather than an untestable
+// expression inside a dialing function.
+func buildAPIHandler(ds datastores.Datastore, c *cache.RedisCache, inner http.Handler) http.Handler {
+	return authMiddleware(ds,
+		sentryMiddleware(middleware.CacheMiddleware(c, compressionMiddleware(inner))))
+}
+
 func (service *Service) Server() *http.Server {
 	// relevant Grpc _dialing_ options
 	// note: commenting out the TransportCredentials option, because internally (nginx <-> golang) traffic is not encrypted.
@@ -163,12 +181,7 @@ func (service *Service) Server() *http.Server {
 
 	openApi := getOpenAPIHandler()
 
-	// Sentry sits inside auth so it only sees authenticated requests, with
-	// the API key already on ctx for key-id tagging, and outside the cache
-	// and compression layers so it observes the final response status. No
-	// SENTRY_DSN → it is a pass-through.
-	handler := authMiddleware(service.Datastore,
-		sentryMiddleware(middleware.CacheMiddleware(service.Cache, compressionMiddleware(gwMux))))
+	handler := buildAPIHandler(service.Datastore, service.Cache, gwMux)
 
 	// if requests start with /api then forward it on to the grpc-gateway client
 	// otherwise, just serve it as norma (basically the OpenAPI)

--- a/servers/gateway/gateway.go
+++ b/servers/gateway/gateway.go
@@ -134,7 +134,8 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 //
 // Sentry-inside-auth also means auth-layer infrastructure failures (e.g. a
 // datastore outage producing mass 401s) generate no Sentry events by design —
-// accepted for Phase 0, revisit in the Phase 3 first-class wiring (#130–#132).
+// accepted for Phase 0, revisit in the Phase 3 observability slices
+// (#130–#132).
 //
 // Package-level (not inlined in Server) so the chain order is a tested
 // contract — see the buildAPIHandler tests — rather than an untestable

--- a/servers/gateway/gateway.go
+++ b/servers/gateway/gateway.go
@@ -34,6 +34,7 @@ import (
 	"github.com/7cav/api/middleware"
 	"github.com/7cav/api/openapi"
 	"github.com/7cav/api/proto"
+	grpcServices "github.com/7cav/api/servers/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 )
@@ -90,7 +91,10 @@ func authMiddleware(ds datastores.Datastore, next http.Handler) http.Handler {
 			return
 		}
 
-		next.ServeHTTP(w, r)
+		// Attach the validated key to the request ctx (mirrors the gRPC auth
+		// interceptor) so downstream consumers — e.g. Sentry key-id tagging —
+		// can identify the caller without ever seeing the bearer token.
+		next.ServeHTTP(w, r.WithContext(grpcServices.ContextWithKey(r.Context(), key)))
 	})
 }
 
@@ -159,8 +163,12 @@ func (service *Service) Server() *http.Server {
 
 	openApi := getOpenAPIHandler()
 
+	// Sentry sits inside auth so it only sees authenticated requests, with
+	// the API key already on ctx for key-id tagging, and outside the cache
+	// and compression layers so it observes the final response status. No
+	// SENTRY_DSN → it is a pass-through.
 	handler := authMiddleware(service.Datastore,
-		middleware.CacheMiddleware(service.Cache, compressionMiddleware(gwMux)))
+		sentryMiddleware(middleware.CacheMiddleware(service.Cache, compressionMiddleware(gwMux))))
 
 	// if requests start with /api then forward it on to the grpc-gateway client
 	// otherwise, just serve it as norma (basically the OpenAPI)

--- a/servers/gateway/sentry.go
+++ b/servers/gateway/sentry.go
@@ -63,7 +63,11 @@ func sentryMiddleware(next http.Handler) http.Handler {
 			if sw.status >= http.StatusInternalServerError {
 				scope.SetTag("http_status", strconv.Itoa(sw.status))
 				scope.SetLevel(sentry.LevelError)
-				hub.CaptureMessage(fmt.Sprintf("HTTP %d %s %s", sw.status, r.Method, r.URL.Path))
+				// Group by method+status, not URL: parameterized paths
+				// (/profile/{id}) must not fan one failure into N Sentry
+				// issues. The raw path stays available on the route tag.
+				scope.SetFingerprint([]string{"http-5xx", r.Method, strconv.Itoa(sw.status)})
+				hub.CaptureMessage(fmt.Sprintf("HTTP %d %s %s", sw.status, r.Method, r.URL.Path)) // event queued; ID unused — async transport
 			}
 		}()
 
@@ -71,9 +75,10 @@ func sentryMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// statusRecorder remembers the first status code written so the deferred
-// 5xx check can see what the handler chain produced. Mirrors the embedding
-// style of the package's other ResponseWriter wrappers.
+// statusRecorder captures the status the client actually saw for the
+// deferred 5xx check: the first explicit WriteHeader wins, and a body Write
+// without one latches the implicit 200 — mirroring net/http, where any later
+// WriteHeader is a superfluous no-op.
 type statusRecorder struct {
 	http.ResponseWriter
 	status      int
@@ -86,4 +91,12 @@ func (sr *statusRecorder) WriteHeader(code int) {
 		sr.wroteHeader = true
 	}
 	sr.ResponseWriter.WriteHeader(code)
+}
+
+// Write latches the implicit 200 (status already defaults to it) so a buggy
+// Write-then-WriteHeader(500) handler cannot record a status the client
+// never received.
+func (sr *statusRecorder) Write(b []byte) (int, error) {
+	sr.wroteHeader = true
+	return sr.ResponseWriter.Write(b)
 }

--- a/servers/gateway/sentry.go
+++ b/servers/gateway/sentry.go
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (C) 2021 7Cav.us
+ *  This file is part of 7Cav-API <https://github.com/7cav/api>.
+ *
+ *  7Cav-API is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  7Cav-API is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with 7Cav-API. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	grpcServices "github.com/7cav/api/servers/grpc"
+	"github.com/getsentry/sentry-go"
+)
+
+// sentryMiddleware reports handler panics and 5xx responses to Sentry, tagged
+// with the route and the calling API key id (never the bearer token). Wired
+// inside authMiddleware so the validated key is already on the request ctx.
+//
+// Without an initialised Sentry client (no SENTRY_DSN) it is a pass-through:
+// responses flow unchanged and panics propagate exactly as they do today
+// (net/http recovers them per-connection). Panics are re-raised after capture
+// either way — Phase 0 observes, it does not change crash semantics (PRD #112).
+func sentryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if sentry.CurrentHub().Client() == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		hub := sentry.CurrentHub().Clone()
+		scope := hub.Scope()
+		scope.SetTag("transport", "http")
+		scope.SetTag("route", r.URL.Path)
+		if key := grpcServices.KeyFromContext(r.Context()); key != nil {
+			scope.SetTag("key_id", strconv.FormatUint(uint64(key.KeyId), 10))
+		}
+
+		sw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				hub.RecoverWithContext(r.Context(), rec)
+				// Re-raise: net/http's per-connection recovery handles it
+				// exactly as it does today. The process survives, so the
+				// async transport delivers the event — no flush needed.
+				panic(rec)
+			}
+			if sw.status >= http.StatusInternalServerError {
+				scope.SetTag("http_status", strconv.Itoa(sw.status))
+				scope.SetLevel(sentry.LevelError)
+				hub.CaptureMessage(fmt.Sprintf("HTTP %d %s %s", sw.status, r.Method, r.URL.Path))
+			}
+		}()
+
+		next.ServeHTTP(sw, r)
+	})
+}
+
+// statusRecorder remembers the first status code written so the deferred
+// 5xx check can see what the handler chain produced. Mirrors the embedding
+// style of the package's other ResponseWriter wrappers.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (sr *statusRecorder) WriteHeader(code int) {
+	if !sr.wroteHeader {
+		sr.status = code
+		sr.wroteHeader = true
+	}
+	sr.ResponseWriter.WriteHeader(code)
+}

--- a/servers/gateway/sentry.go
+++ b/servers/gateway/sentry.go
@@ -28,8 +28,14 @@ import (
 )
 
 // sentryMiddleware reports handler panics and 5xx responses to Sentry, tagged
-// with the route and the calling API key id (never the bearer token). Wired
-// inside authMiddleware so the validated key is already on the request ctx.
+// with the route and the calling API key id (never the bearer token). Expects
+// to run inside auth so the validated key is already on the request ctx; if
+// it is absent, the event simply omits the key_id tag.
+//
+// An Internal-class error on an HTTP-originated request produces two events —
+// the gRPC interceptor's exception plus this HTTP message, sharing the key_id
+// but with distinct transport tags. Deliberate Phase 0 wrap-both-ends
+// behavior.
 //
 // Without an initialised Sentry client (no SENTRY_DSN) it is a pass-through:
 // responses flow unchanged and panics propagate exactly as they do today
@@ -54,7 +60,7 @@ func sentryMiddleware(next http.Handler) http.Handler {
 
 		defer func() {
 			if rec := recover(); rec != nil {
-				hub.RecoverWithContext(r.Context(), rec)
+				hub.RecoverWithContext(r.Context(), rec) // event queued; ID unused — async transport
 				// Re-raise: net/http's per-connection recovery handles it
 				// exactly as it does today. The process survives, so the
 				// async transport delivers the event — no flush needed.

--- a/servers/gateway/sentry_test.go
+++ b/servers/gateway/sentry_test.go
@@ -17,9 +17,11 @@ import (
 
 // captureTransport is an in-memory sentry.Transport recording every event the
 // client would have sent over the wire — the observable seam for these tests.
-// flushed records whether anything ever flushed synchronously, pinning the
-// HTTP side of the deliberate sync/async flush asymmetry (gRPC panics flush,
-// HTTP panics must not — the process survives and the async transport sends).
+// Flush here always drains (per the SDK contract Flush reports queue drain,
+// not delivery); flushed records whether anything ever flushed synchronously,
+// pinning the HTTP side of the deliberate sync/async flush asymmetry (gRPC
+// panics flush, HTTP panics must not — the process survives and the async
+// transport sends).
 type captureTransport struct {
 	mu      sync.Mutex
 	events  []*sentry.Event
@@ -198,7 +200,10 @@ func TestSentryMiddleware_BearerTokenNeverInPayload(t *testing.T) {
 	const secret = "cav7_topsecrettokenvalue"
 
 	makeReq := func() *http.Request {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil)
+		// Secret in BOTH vectors — header and query string — so the
+		// whole-payload sweep below also pins the query-borne path
+		// (?api_key=...), not just the Authorization header.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/roster?api_key="+secret, nil)
 		req.Header.Set("Authorization", "Bearer "+secret)
 		return req
 	}

--- a/servers/gateway/sentry_test.go
+++ b/servers/gateway/sentry_test.go
@@ -39,12 +39,16 @@ func (t *captureTransport) Events() []*sentry.Event {
 	return append([]*sentry.Event(nil), t.events...)
 }
 
+// testRelease stands in for the build-time version injection so tests can
+// prove events carry the release tag.
+const testRelease = "test-release-1.2.3"
+
 // bindCaptureClient binds a capture-only Sentry client to the global hub for
 // the duration of the test, restoring the unbound (disabled) state afterwards.
 func bindCaptureClient(t *testing.T) *captureTransport {
 	t.Helper()
 	transport := &captureTransport{}
-	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport, Release: testRelease})
 	require.NoError(t, err)
 	sentry.CurrentHub().BindClient(client)
 	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
@@ -119,6 +123,7 @@ func TestSentryMiddleware_HandlerPanic_CapturedThenRepanics(t *testing.T) {
 	assert.Equal(t, "/api/v1/tickets", event.Tags["route"])
 	assert.Equal(t, "http", event.Tags["transport"])
 	assert.Equal(t, sentry.LevelFatal, event.Level)
+	assert.Equal(t, testRelease, event.Release, "panic events must carry the release")
 }
 
 func TestSentryMiddleware_NoClient_PassThrough(t *testing.T) {

--- a/servers/gateway/sentry_test.go
+++ b/servers/gateway/sentry_test.go
@@ -221,6 +221,56 @@ func TestSentryMiddleware_BearerTokenNeverInPayload(t *testing.T) {
 	}
 }
 
+// TestBuildAPIHandler_500BehindValidAuth_OneEventWithKeyID drives the actual
+// production chain constructor — auth(sentry(cache(compression))) — end to
+// end: a 500 from the inner handler behind valid auth must produce exactly
+// one event carrying the key_id auth attached. The /api/v1/tickets path is
+// deliberate: CacheMiddleware passes tickets straight through, so the nil
+// RedisCache is never touched.
+func TestBuildAPIHandler_500BehindValidAuth_OneEventWithKeyID(t *testing.T) {
+	transport := bindCaptureClient(t)
+	ds := &fakeAuthDatastore{validateApiKey: func(token string) (*datastores.ApiKeyResult, error) {
+		assert.Equal(t, "cav7_goodkey", token)
+		return &datastores.ApiKeyResult{KeyId: 42}, nil
+	}}
+	h := buildAPIHandler(ds, nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", nil)
+	req.Header.Set("Authorization", "Bearer cav7_goodkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	events := transport.Events()
+	require.Len(t, events, 1, "one 500 through the full chain must mean exactly one event")
+	assert.Equal(t, "42", events[0].Tags["key_id"], "the chain order is the contract: auth must run before sentry")
+	assert.Equal(t, "500", events[0].Tags["http_status"])
+}
+
+// TestBuildAPIHandler_BadAuth_401NoEvents pins the other side of the chain
+// order: rejected requests never reach Sentry (or the inner handler).
+func TestBuildAPIHandler_BadAuth_401NoEvents(t *testing.T) {
+	transport := bindCaptureClient(t)
+	ds := &fakeAuthDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
+		return nil, nil // zero rows — invalid key
+	}}
+	innerCalled := false
+	h := buildAPIHandler(ds, nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tickets", nil)
+	req.Header.Set("Authorization", "Bearer cav7_badkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, innerCalled, "auth must reject before anything inner runs")
+	assert.Empty(t, transport.Events(), "auth rejections are expected behavior, not Sentry events")
+}
+
 // TestSentryMiddleware_BehindAuth_EventCarriesKeyID exercises the real chain
 // shape — authMiddleware outside, sentryMiddleware inside — and proves the
 // validated API key id reaches the event while the raw key never does.

--- a/servers/gateway/sentry_test.go
+++ b/servers/gateway/sentry_test.go
@@ -1,0 +1,198 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/7cav/api/datastores"
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureTransport is an in-memory sentry.Transport recording every event the
+// client would have sent over the wire — the observable seam for these tests.
+type captureTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *captureTransport) Configure(sentry.ClientOptions)        {}
+func (t *captureTransport) Flush(time.Duration) bool              { return true }
+func (t *captureTransport) FlushWithContext(context.Context) bool { return true }
+func (t *captureTransport) Close()                                {}
+
+func (t *captureTransport) SendEvent(event *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+
+func (t *captureTransport) Events() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]*sentry.Event(nil), t.events...)
+}
+
+// bindCaptureClient binds a capture-only Sentry client to the global hub for
+// the duration of the test, restoring the unbound (disabled) state afterwards.
+func bindCaptureClient(t *testing.T) *captureTransport {
+	t.Helper()
+	transport := &captureTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+	sentry.CurrentHub().BindClient(client)
+	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
+	return transport
+}
+
+func TestSentryMiddleware_500Response_CapturedWithRouteAndStatus(t *testing.T) {
+	transport := bindCaptureClient(t)
+	h := sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusInternalServerError)
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code, "response must pass through untouched")
+
+	events := transport.Events()
+	require.Len(t, events, 1, "a 5xx response must produce exactly one event")
+	event := events[0]
+	assert.Equal(t, "/api/v1/roster", event.Tags["route"])
+	assert.Equal(t, "500", event.Tags["http_status"])
+	assert.Equal(t, "http", event.Tags["transport"])
+	assert.Equal(t, sentry.LevelError, event.Level)
+}
+
+func TestSentryMiddleware_NonServerErrorResponses_NoEvents(t *testing.T) {
+	transport := bindCaptureClient(t)
+
+	cases := []struct {
+		name   string
+		handle http.HandlerFunc
+		want   int
+	}{
+		{"implicit 200", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{}`)) // no explicit WriteHeader
+		}, http.StatusOK},
+		{"explicit 200", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}, http.StatusOK},
+		{"404", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "no such profile", http.StatusNotFound)
+		}, http.StatusNotFound},
+		{"401", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		}, http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			sentryMiddleware(tc.handle).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+			assert.Equal(t, tc.want, rr.Code)
+		})
+	}
+
+	assert.Empty(t, transport.Events(), "non-5xx responses must not generate Sentry noise")
+}
+
+func TestSentryMiddleware_HandlerPanic_CapturedThenRepanics(t *testing.T) {
+	transport := bindCaptureClient(t)
+	h := sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("kaboom")
+	}))
+
+	assert.PanicsWithValue(t, "kaboom", func() {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/tickets", nil))
+	}, "panic must propagate so net/http's per-connection recovery behaves as today")
+
+	events := transport.Events()
+	require.Len(t, events, 1, "a handler panic must produce exactly one event")
+	event := events[0]
+	assert.Equal(t, "/api/v1/tickets", event.Tags["route"])
+	assert.Equal(t, "http", event.Tags["transport"])
+	assert.Equal(t, sentry.LevelFatal, event.Level)
+}
+
+func TestSentryMiddleware_NoClient_PassThrough(t *testing.T) {
+	// No client bound — the no-DSN state. Responses and panics must behave
+	// exactly as they do today.
+	require.Nil(t, sentry.CurrentHub().Client(), "test requires the disabled state")
+
+	rr := httptest.NewRecorder()
+	sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusInternalServerError)
+	})).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	assert.PanicsWithValue(t, "kaboom", func() {
+		sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("kaboom")
+		})).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+	}, "panics must still propagate when Sentry is disabled")
+}
+
+func TestSentryMiddleware_BearerTokenNeverInPayload(t *testing.T) {
+	transport := bindCaptureClient(t)
+	const secret = "cav7_topsecrettokenvalue"
+
+	makeReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil)
+		req.Header.Set("Authorization", "Bearer "+secret)
+		return req
+	}
+
+	sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusInternalServerError)
+	})).ServeHTTP(httptest.NewRecorder(), makeReq())
+	assert.PanicsWithValue(t, "kaboom", func() {
+		sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("kaboom")
+		})).ServeHTTP(httptest.NewRecorder(), makeReq())
+	})
+
+	events := transport.Events()
+	require.Len(t, events, 2)
+	for _, event := range events {
+		payload, err := json.Marshal(event)
+		require.NoError(t, err)
+		assert.NotContains(t, string(payload), secret, "bearer material must never appear in any event payload")
+	}
+}
+
+// TestSentryMiddleware_BehindAuth_EventCarriesKeyID exercises the real chain
+// shape — authMiddleware outside, sentryMiddleware inside — and proves the
+// validated API key id reaches the event while the raw key never does.
+func TestSentryMiddleware_BehindAuth_EventCarriesKeyID(t *testing.T) {
+	transport := bindCaptureClient(t)
+	const secret = "cav7_topsecrettokenvalue"
+
+	ds := &fakeAuthDatastore{validateApiKey: func(token string) (*datastores.ApiKeyResult, error) {
+		assert.Equal(t, secret, token)
+		return &datastores.ApiKeyResult{KeyId: 42, UserId: 7}, nil
+	}}
+	h := authMiddleware(ds, sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusInternalServerError)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil)
+	req.Header.Set("Authorization", "Bearer "+secret)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	events := transport.Events()
+	require.Len(t, events, 1)
+	event := events[0]
+	assert.Equal(t, "42", event.Tags["key_id"], "events carry the key id, not the key")
+	payload, err := json.Marshal(event)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), secret, "bearer material must never appear in any event payload")
+}

--- a/servers/gateway/sentry_test.go
+++ b/servers/gateway/sentry_test.go
@@ -17,15 +17,38 @@ import (
 
 // captureTransport is an in-memory sentry.Transport recording every event the
 // client would have sent over the wire — the observable seam for these tests.
+// flushed records whether anything ever flushed synchronously, pinning the
+// HTTP side of the deliberate sync/async flush asymmetry (gRPC panics flush,
+// HTTP panics must not — the process survives and the async transport sends).
 type captureTransport struct {
-	mu     sync.Mutex
-	events []*sentry.Event
+	mu      sync.Mutex
+	events  []*sentry.Event
+	flushed bool
 }
 
-func (t *captureTransport) Configure(sentry.ClientOptions)        {}
-func (t *captureTransport) Flush(time.Duration) bool              { return true }
-func (t *captureTransport) FlushWithContext(context.Context) bool { return true }
-func (t *captureTransport) Close()                                {}
+func (t *captureTransport) Configure(sentry.ClientOptions) {}
+
+func (t *captureTransport) Flush(time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.flushed = true
+	return true
+}
+
+func (t *captureTransport) FlushWithContext(context.Context) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.flushed = true
+	return true
+}
+
+func (t *captureTransport) Close() {}
+
+func (t *captureTransport) Flushed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.flushed
+}
 
 func (t *captureTransport) SendEvent(event *sentry.Event) {
 	t.mu.Lock()
@@ -45,10 +68,12 @@ const testRelease = "test-release-1.2.3"
 
 // bindCaptureClient binds a capture-only Sentry client to the global hub for
 // the duration of the test, restoring the unbound (disabled) state afterwards.
+// AttachStacktrace mirrors production (setupSentry) so string-panic events
+// carry frames here exactly as they do live.
 func bindCaptureClient(t *testing.T) *captureTransport {
 	t.Helper()
 	transport := &captureTransport{}
-	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport, Release: testRelease})
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport, Release: testRelease, AttachStacktrace: true})
 	require.NoError(t, err)
 	sentry.CurrentHub().BindClient(client)
 	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
@@ -73,6 +98,25 @@ func TestSentryMiddleware_500Response_CapturedWithRouteAndStatus(t *testing.T) {
 	assert.Equal(t, "500", event.Tags["http_status"])
 	assert.Equal(t, "http", event.Tags["transport"])
 	assert.Equal(t, sentry.LevelError, event.Level)
+	assert.Equal(t, []string{"http-5xx", "GET", "500"}, event.Fingerprint,
+		"grouping must be method+status, not URL — parameterized paths must not fan one failure into N issues")
+}
+
+// TestSentryMiddleware_WriteThenWriteHeader_Records200 pins the implicit-200
+// latch: once a handler writes the body, net/http has committed status 200,
+// and a buggy late WriteHeader(500) must not record a false 500.
+func TestSentryMiddleware_WriteThenWriteHeader_Records200(t *testing.T) {
+	transport := bindCaptureClient(t)
+	h := sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`)) // commits the implicit 200
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/roster", nil))
+
+	assert.Equal(t, http.StatusOK, rr.Code, "the committed implicit 200 is what the client saw")
+	assert.Empty(t, transport.Events(), "a status the client never received must not produce an event")
 }
 
 func TestSentryMiddleware_NonServerErrorResponses_NoEvents(t *testing.T) {
@@ -124,6 +168,11 @@ func TestSentryMiddleware_HandlerPanic_CapturedThenRepanics(t *testing.T) {
 	assert.Equal(t, "http", event.Tags["transport"])
 	assert.Equal(t, sentry.LevelFatal, event.Level)
 	assert.Equal(t, testRelease, event.Release, "panic events must carry the release")
+	assert.False(t, transport.Flushed(),
+		"HTTP panics must NOT flush synchronously — the process survives and the async transport delivers")
+	require.NotEmpty(t, event.Threads, "a string panic must carry a stack (AttachStacktrace shapes it as a thread)")
+	require.NotNil(t, event.Threads[0].Stacktrace)
+	assert.NotEmpty(t, event.Threads[0].Stacktrace.Frames, "a string panic without frames is undebuggable")
 }
 
 func TestSentryMiddleware_NoClient_PassThrough(t *testing.T) {

--- a/servers/grpc/sentry.go
+++ b/servers/grpc/sentry.go
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2021 7Cav.us
+ *  This file is part of 7Cav-API <https://github.com/7cav/api>.
+ *
+ *  7Cav-API is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  7Cav-API is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with 7Cav-API. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package grpc
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// sentryFlushTimeout bounds how long a panicking request waits for its event
+// to reach Sentry before the panic resumes (and, for gRPC, the process dies).
+const sentryFlushTimeout = 2 * time.Second
+
+// NewSentryInterceptor reports handler panics and Internal-class errors to
+// Sentry, tagged with the route and the calling API key id (never the bearer
+// token). Chained inside the auth interceptor so the key is already on ctx.
+//
+// Without an initialised Sentry client (no SENTRY_DSN) it is a pass-through:
+// errors flow unchanged and panics propagate exactly as they do today.
+// Panics are re-raised after capture either way — Phase 0 observes, it does
+// not change crash semantics (PRD #112).
+func NewSentryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		if sentry.CurrentHub().Client() == nil {
+			return handler(ctx, req)
+		}
+
+		hub := sentry.CurrentHub().Clone()
+		scope := hub.Scope()
+		scope.SetTag("transport", "grpc")
+		scope.SetTag("route", info.FullMethod)
+		if key := KeyFromContext(ctx); key != nil {
+			scope.SetTag("key_id", strconv.FormatUint(uint64(key.KeyId), 10))
+		}
+
+		defer func() {
+			if r := recover(); r != nil {
+				hub.RecoverWithContext(ctx, r)
+				// The panic will take the process down (grpc-go has no
+				// recovery layer) — flush synchronously so the event
+				// survives the crash.
+				hub.Flush(sentryFlushTimeout)
+				panic(r)
+			}
+		}()
+
+		resp, err = handler(ctx, req)
+		if err != nil {
+			if code := status.Code(err); isServerErrorCode(code) {
+				scope.SetTag("grpc_code", code.String())
+				hub.CaptureException(err)
+			}
+		}
+		return resp, err
+	}
+}
+
+// isServerErrorCode reports whether a gRPC status code is Internal-class —
+// i.e. it maps to an HTTP 5xx under the grpc-gateway translation. Client-side
+// codes (NotFound, Unauthenticated, InvalidArgument, ...) are expected
+// behavior, not errors worth a Sentry event.
+func isServerErrorCode(code codes.Code) bool {
+	switch code {
+	case codes.Unknown, codes.DeadlineExceeded, codes.Unimplemented,
+		codes.Internal, codes.Unavailable, codes.DataLoss:
+		return true
+	default:
+		return false
+	}
+}

--- a/servers/grpc/sentry.go
+++ b/servers/grpc/sentry.go
@@ -35,7 +35,12 @@ const sentryFlushTimeout = 2 * time.Second
 
 // NewSentryInterceptor reports handler panics and Internal-class errors to
 // Sentry, tagged with the route and the calling API key id (never the bearer
-// token). Chained inside the auth interceptor so the key is already on ctx.
+// token). Expects to run inside auth so the key is already on ctx; if it is
+// absent, the event simply omits the key_id tag.
+//
+// An Internal-class error on an HTTP-originated request produces two events —
+// this gRPC exception plus the gateway's HTTP message, sharing the key_id but
+// with distinct transport tags. Deliberate Phase 0 wrap-both-ends behavior.
 //
 // Without an initialised Sentry client (no SENTRY_DSN) it is a pass-through:
 // errors flow unchanged and panics propagate exactly as they do today.
@@ -72,7 +77,7 @@ func NewSentryInterceptor() grpc.UnaryServerInterceptor {
 		if err != nil {
 			if code := status.Code(err); isServerErrorCode(code) {
 				scope.SetTag("grpc_code", code.String())
-				hub.CaptureException(err)
+				hub.CaptureException(err) // event queued; ID unused — async transport
 			}
 		}
 		return resp, err
@@ -82,7 +87,8 @@ func NewSentryInterceptor() grpc.UnaryServerInterceptor {
 // isServerErrorCode reports whether a gRPC status code is Internal-class —
 // i.e. it maps to an HTTP 5xx under the grpc-gateway translation. Client-side
 // codes (NotFound, Unauthenticated, InvalidArgument, ...) are expected
-// behavior, not errors worth a Sentry event.
+// behavior, not errors worth a Sentry event. (Unrecognized custom codes,
+// which the gateway also maps to 500, are deliberately ignored here.)
 func isServerErrorCode(code codes.Code) bool {
 	switch code {
 	case codes.Unknown, codes.DeadlineExceeded, codes.Unimplemented,

--- a/servers/grpc/sentry.go
+++ b/servers/grpc/sentry.go
@@ -77,6 +77,14 @@ func NewSentryInterceptor() grpc.UnaryServerInterceptor {
 		if err != nil {
 			if code := status.Code(err); isServerErrorCode(code) {
 				scope.SetTag("grpc_code", code.String())
+				// status.Error values carry no stack, so the SDK stamps every
+				// capture here with the identical interceptor-frame stack —
+				// default grouping would fold all Internal-class errors across
+				// all methods into ONE Sentry issue. Group by code+method
+				// instead (mirrors the HTTP middleware's method+status
+				// fingerprint). Panic events are untouched: they carry real
+				// stacks and group fine on default rules.
+				scope.SetFingerprint([]string{"grpc-error", code.String(), info.FullMethod})
 				hub.CaptureException(err) // event queued; ID unused — async transport
 			}
 		}

--- a/servers/grpc/sentry.go
+++ b/servers/grpc/sentry.go
@@ -57,11 +57,13 @@ func NewSentryInterceptor() grpc.UnaryServerInterceptor {
 
 		defer func() {
 			if r := recover(); r != nil {
-				hub.RecoverWithContext(ctx, r)
+				hub.RecoverWithContext(ctx, r) // event queued; ID unused — async transport
 				// The panic will take the process down (grpc-go has no
 				// recovery layer) — flush synchronously so the event
 				// survives the crash.
-				hub.Flush(sentryFlushTimeout)
+				if !hub.Flush(sentryFlushTimeout) {
+					Warn.Printf("sentry flush timed out — panic event for %s was likely dropped", info.FullMethod)
+				}
 				panic(r)
 			}
 		}()

--- a/servers/grpc/sentry_test.go
+++ b/servers/grpc/sentry_test.go
@@ -41,12 +41,16 @@ func (t *captureTransport) Events() []*sentry.Event {
 	return append([]*sentry.Event(nil), t.events...)
 }
 
+// testRelease stands in for the build-time version injection so tests can
+// prove events carry the release tag.
+const testRelease = "test-release-1.2.3"
+
 // bindCaptureClient binds a capture-only Sentry client to the global hub for
 // the duration of the test, restoring the unbound (disabled) state afterwards.
 func bindCaptureClient(t *testing.T) *captureTransport {
 	t.Helper()
 	transport := &captureTransport{}
-	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport, Release: testRelease})
 	require.NoError(t, err)
 	sentry.CurrentHub().BindClient(client)
 	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
@@ -134,6 +138,7 @@ func TestSentryInterceptor_HandlerPanic_CapturedThenRepanics(t *testing.T) {
 	assert.Equal(t, "7", event.Tags["key_id"])
 	assert.Equal(t, "grpc", event.Tags["transport"])
 	assert.Equal(t, sentry.LevelFatal, event.Level)
+	assert.Equal(t, testRelease, event.Release, "panic events must carry the release")
 }
 
 func TestSentryInterceptor_NoClient_PassThrough(t *testing.T) {

--- a/servers/grpc/sentry_test.go
+++ b/servers/grpc/sentry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"sync"
 	"testing"
@@ -144,6 +145,78 @@ func TestSentryInterceptor_ClientClassOutcomes_NoEvents(t *testing.T) {
 	}
 
 	assert.Empty(t, transport.Events(), "expected outcomes must not generate Sentry noise")
+}
+
+// TestSentryInterceptor_CapturedErrorClass pins exactly which gRPC outcomes
+// are Internal-class (captured) versus expected behavior (silent). A plain
+// non-status error surfaces as codes.Unknown — the most common real-world
+// server bug shape — and must be captured.
+func TestSentryInterceptor_CapturedErrorClass(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		captured bool
+		wantCode string
+	}{
+		{"plain error becomes Unknown — captured", errors.New("kapow"), true, "Unknown"},
+		{"unavailable — captured", status.Error(codes.Unavailable, "downstream gone"), true, "Unavailable"},
+		{"deadline exceeded — captured", status.Error(codes.DeadlineExceeded, "too slow"), true, "DeadlineExceeded"},
+		{"aborted — silent", status.Error(codes.Aborted, "tx conflict"), false, ""},
+		{"resource exhausted — silent", status.Error(codes.ResourceExhausted, "rate limited"), false, ""},
+		{"not found — silent", status.Error(codes.NotFound, "no such row"), false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := bindCaptureClient(t)
+			interceptor := NewSentryInterceptor()
+
+			_, err := interceptor(context.Background(), nil, unaryInfo("/proto.MilpacService/GetProfile"),
+				func(ctx context.Context, req any) (any, error) {
+					return nil, tc.err
+				})
+
+			assert.Equal(t, tc.err, err, "the handler error must pass through unchanged")
+			events := transport.Events()
+			if !tc.captured {
+				assert.Empty(t, events, "expected outcomes must not generate Sentry noise")
+				return
+			}
+			require.Len(t, events, 1, "an Internal-class outcome must produce exactly one event")
+			assert.Equal(t, tc.wantCode, events[0].Tags["grpc_code"])
+		})
+	}
+}
+
+// TestSentryInterceptor_BehindAuthInterceptor_EventCarriesKeyID composes the
+// real auth interceptor around the real Sentry interceptor — mirroring the
+// grpc.ChainUnaryInterceptor order in server.go — and proves the key auth
+// attaches to ctx is what feeds the key_id tag. No test-injected key.
+func TestSentryInterceptor_BehindAuthInterceptor_EventCarriesKeyID(t *testing.T) {
+	transport := bindCaptureClient(t)
+	ds := &fakeDatastore{validateApiKey: func(token string) (*datastores.ApiKeyResult, error) {
+		assert.Equal(t, "cav7_goodkey", token)
+		return &datastores.ApiKeyResult{KeyId: 42}, nil
+	}}
+	authInterceptor := NewAuthInterceptor(ds)
+	sentryInterceptor := NewSentryInterceptor()
+	info := unaryInfo("/proto.MilpacService/GetProfile")
+
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs("authorization", "Bearer cav7_goodkey"))
+	handlerErr := status.Error(codes.Internal, "boom")
+	resp, err := authInterceptor(ctx, nil, info, func(ctx context.Context, req any) (any, error) {
+		return sentryInterceptor(ctx, req, info, func(ctx context.Context, req any) (any, error) {
+			return nil, handlerErr
+		})
+	})
+
+	assert.Nil(t, resp)
+	assert.Equal(t, handlerErr, err)
+	events := transport.Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, "42", events[0].Tags["key_id"],
+		"the key_id must come from auth's ctx attachment, proving the chain wiring end-to-end")
+	assert.Equal(t, "grpc", events[0].Tags["transport"])
 }
 
 func TestSentryInterceptor_HandlerPanic_CapturedThenRepanics(t *testing.T) {

--- a/servers/grpc/sentry_test.go
+++ b/servers/grpc/sentry_test.go
@@ -22,13 +22,16 @@ import (
 
 // captureTransport is an in-memory sentry.Transport recording every event the
 // client would have sent over the wire — the observable seam for these tests.
-// flushFails makes Flush report timeout; flushed records that a synchronous
-// flush happened at all (pinning the sync-flush-on-panic contract).
+// drainTimesOut makes Flush report a drain timeout (queue still busy when the
+// window closes), NOT a delivery failure — per the SDK's Flush contract, fast
+// send failures dequeue and "flush" successfully. flushed records that a
+// synchronous flush happened at all (pinning the sync-flush-on-panic
+// contract).
 type captureTransport struct {
-	mu         sync.Mutex
-	events     []*sentry.Event
-	flushed    bool
-	flushFails bool
+	mu            sync.Mutex
+	events        []*sentry.Event
+	flushed       bool
+	drainTimesOut bool
 }
 
 func (t *captureTransport) Configure(sentry.ClientOptions) {}
@@ -37,14 +40,14 @@ func (t *captureTransport) Flush(time.Duration) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.flushed = true
-	return !t.flushFails
+	return !t.drainTimesOut
 }
 
 func (t *captureTransport) FlushWithContext(context.Context) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.flushed = true
-	return !t.flushFails
+	return !t.drainTimesOut
 }
 
 func (t *captureTransport) Close() {}
@@ -183,6 +186,8 @@ func TestSentryInterceptor_CapturedErrorClass(t *testing.T) {
 			}
 			require.Len(t, events, 1, "an Internal-class outcome must produce exactly one event")
 			assert.Equal(t, tc.wantCode, events[0].Tags["grpc_code"])
+			assert.Equal(t, []string{"grpc-error", tc.wantCode, "/proto.MilpacService/GetProfile"}, events[0].Fingerprint,
+				"status errors carry no stack — without an explicit code+method fingerprint the SDK stamps every capture with the same interceptor frames and folds all Internal-class errors into one issue")
 		})
 	}
 }
@@ -248,7 +253,7 @@ func TestSentryInterceptor_HandlerPanic_CapturedThenRepanics(t *testing.T) {
 
 func TestSentryInterceptor_PanicFlushTimeout_Warns(t *testing.T) {
 	transport := bindCaptureClient(t)
-	transport.flushFails = true
+	transport.drainTimesOut = true
 
 	var warnBuf bytes.Buffer
 	Warn.SetOutput(&warnBuf)
@@ -294,10 +299,13 @@ func TestSentryInterceptor_BearerTokenNeverInPayload(t *testing.T) {
 	interceptor := NewSentryInterceptor()
 
 	// Simulate the real request shape: the bearer token sits in the incoming
-	// gRPC metadata on ctx, exactly where the auth interceptor read it.
+	// gRPC metadata on ctx, exactly where the auth interceptor read it. The
+	// query-shaped gateway URI pair extends the whole-payload sweep to the
+	// query-borne vector (?api_key=...) arriving through forwarded metadata.
 	const secret = "cav7_topsecrettokenvalue"
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		"authorization", "Bearer "+secret,
+		"grpcgateway-uri", "/api/v1/roster?api_key="+secret,
 	))
 	ctx = ContextWithKey(ctx, &datastores.ApiKeyResult{KeyId: 42})
 

--- a/servers/grpc/sentry_test.go
+++ b/servers/grpc/sentry_test.go
@@ -1,0 +1,193 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/7cav/api/datastores"
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// captureTransport is an in-memory sentry.Transport recording every event the
+// client would have sent over the wire — the observable seam for these tests.
+type captureTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *captureTransport) Configure(sentry.ClientOptions)        {}
+func (t *captureTransport) Flush(time.Duration) bool              { return true }
+func (t *captureTransport) FlushWithContext(context.Context) bool { return true }
+func (t *captureTransport) Close()                                {}
+
+func (t *captureTransport) SendEvent(event *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+
+func (t *captureTransport) Events() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]*sentry.Event(nil), t.events...)
+}
+
+// bindCaptureClient binds a capture-only Sentry client to the global hub for
+// the duration of the test, restoring the unbound (disabled) state afterwards.
+func bindCaptureClient(t *testing.T) *captureTransport {
+	t.Helper()
+	transport := &captureTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+	sentry.CurrentHub().BindClient(client)
+	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
+	return transport
+}
+
+func unaryInfo(method string) *grpc.UnaryServerInfo {
+	return &grpc.UnaryServerInfo{FullMethod: method}
+}
+
+func TestSentryInterceptor_InternalError_CapturedWithRouteAndKeyID(t *testing.T) {
+	transport := bindCaptureClient(t)
+	interceptor := NewSentryInterceptor()
+
+	ctx := ContextWithKey(context.Background(), &datastores.ApiKeyResult{KeyId: 42})
+	handlerErr := status.Error(codes.Internal, "boom")
+	resp, err := interceptor(ctx, nil, unaryInfo("/proto.MilpacService/GetProfile"),
+		func(ctx context.Context, req any) (any, error) {
+			return nil, handlerErr
+		})
+
+	assert.Nil(t, resp)
+	assert.Equal(t, handlerErr, err, "interceptor must pass the handler error through unchanged")
+
+	events := transport.Events()
+	require.Len(t, events, 1, "an Internal-class error must produce exactly one event")
+	event := events[0]
+	assert.Equal(t, "/proto.MilpacService/GetProfile", event.Tags["route"])
+	assert.Equal(t, "42", event.Tags["key_id"])
+	assert.Equal(t, "grpc", event.Tags["transport"])
+	assert.Equal(t, "Internal", event.Tags["grpc_code"])
+}
+
+func TestSentryInterceptor_ClientClassOutcomes_NoEvents(t *testing.T) {
+	transport := bindCaptureClient(t)
+	interceptor := NewSentryInterceptor()
+	ctx := context.Background()
+	info := unaryInfo("/proto.MilpacService/GetProfile")
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"success", nil},
+		{"not found", status.Error(codes.NotFound, "no such profile")},
+		{"unauthenticated", status.Error(codes.Unauthenticated, "invalid api key")},
+		{"invalid argument", status.Error(codes.InvalidArgument, "bad cursor")},
+		{"permission denied", status.Error(codes.PermissionDenied, "scope required")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := interceptor(ctx, nil, info,
+				func(ctx context.Context, req any) (any, error) {
+					if tc.err != nil {
+						return nil, tc.err
+					}
+					return "ok", nil
+				})
+			assert.Equal(t, tc.err, err)
+			if tc.err == nil {
+				assert.Equal(t, "ok", resp)
+			}
+		})
+	}
+
+	assert.Empty(t, transport.Events(), "expected outcomes must not generate Sentry noise")
+}
+
+func TestSentryInterceptor_HandlerPanic_CapturedThenRepanics(t *testing.T) {
+	transport := bindCaptureClient(t)
+	interceptor := NewSentryInterceptor()
+	ctx := ContextWithKey(context.Background(), &datastores.ApiKeyResult{KeyId: 7})
+
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_, _ = interceptor(ctx, nil, unaryInfo("/proto.TicketsService/ListTickets"),
+			func(ctx context.Context, req any) (any, error) {
+				panic("kaboom")
+			})
+	}, "panic must propagate after capture — Phase 0 observes, it does not change crash semantics")
+
+	events := transport.Events()
+	require.Len(t, events, 1, "a handler panic must produce exactly one event")
+	event := events[0]
+	assert.Equal(t, "/proto.TicketsService/ListTickets", event.Tags["route"])
+	assert.Equal(t, "7", event.Tags["key_id"])
+	assert.Equal(t, "grpc", event.Tags["transport"])
+	assert.Equal(t, sentry.LevelFatal, event.Level)
+}
+
+func TestSentryInterceptor_NoClient_PassThrough(t *testing.T) {
+	// No client bound — the no-DSN state. Errors and panics must behave
+	// exactly as they do today.
+	require.Nil(t, sentry.CurrentHub().Client(), "test requires the disabled state")
+	interceptor := NewSentryInterceptor()
+	info := unaryInfo("/proto.MilpacService/GetProfile")
+
+	handlerErr := status.Error(codes.Internal, "boom")
+	resp, err := interceptor(context.Background(), nil, info,
+		func(ctx context.Context, req any) (any, error) {
+			return nil, handlerErr
+		})
+	assert.Nil(t, resp)
+	assert.Equal(t, handlerErr, err)
+
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_, _ = interceptor(context.Background(), nil, info,
+			func(ctx context.Context, req any) (any, error) {
+				panic("kaboom")
+			})
+	}, "panics must still propagate when Sentry is disabled")
+}
+
+func TestSentryInterceptor_BearerTokenNeverInPayload(t *testing.T) {
+	transport := bindCaptureClient(t)
+	interceptor := NewSentryInterceptor()
+
+	// Simulate the real request shape: the bearer token sits in the incoming
+	// gRPC metadata on ctx, exactly where the auth interceptor read it.
+	const secret = "cav7_topsecrettokenvalue"
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"authorization", "Bearer "+secret,
+	))
+	ctx = ContextWithKey(ctx, &datastores.ApiKeyResult{KeyId: 42})
+
+	_, _ = interceptor(ctx, nil, unaryInfo("/proto.MilpacService/GetProfile"),
+		func(ctx context.Context, req any) (any, error) {
+			return nil, status.Error(codes.Internal, "boom")
+		})
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_, _ = interceptor(ctx, nil, unaryInfo("/proto.MilpacService/GetProfile"),
+			func(ctx context.Context, req any) (any, error) {
+				panic("kaboom")
+			})
+	})
+
+	events := transport.Events()
+	require.Len(t, events, 2)
+	for _, event := range events {
+		payload, err := json.Marshal(event)
+		require.NoError(t, err)
+		assert.NotContains(t, string(payload), secret, "bearer material must never appear in any event payload")
+		assert.Equal(t, "42", event.Tags["key_id"], "events carry the key id, not the key")
+	}
+}

--- a/servers/grpc/sentry_test.go
+++ b/servers/grpc/sentry_test.go
@@ -1,8 +1,10 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -19,15 +21,38 @@ import (
 
 // captureTransport is an in-memory sentry.Transport recording every event the
 // client would have sent over the wire — the observable seam for these tests.
+// flushFails makes Flush report timeout; flushed records that a synchronous
+// flush happened at all (pinning the sync-flush-on-panic contract).
 type captureTransport struct {
-	mu     sync.Mutex
-	events []*sentry.Event
+	mu         sync.Mutex
+	events     []*sentry.Event
+	flushed    bool
+	flushFails bool
 }
 
-func (t *captureTransport) Configure(sentry.ClientOptions)        {}
-func (t *captureTransport) Flush(time.Duration) bool              { return true }
-func (t *captureTransport) FlushWithContext(context.Context) bool { return true }
-func (t *captureTransport) Close()                                {}
+func (t *captureTransport) Configure(sentry.ClientOptions) {}
+
+func (t *captureTransport) Flush(time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.flushed = true
+	return !t.flushFails
+}
+
+func (t *captureTransport) FlushWithContext(context.Context) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.flushed = true
+	return !t.flushFails
+}
+
+func (t *captureTransport) Close() {}
+
+func (t *captureTransport) Flushed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.flushed
+}
 
 func (t *captureTransport) SendEvent(event *sentry.Event) {
 	t.mu.Lock()
@@ -47,10 +72,12 @@ const testRelease = "test-release-1.2.3"
 
 // bindCaptureClient binds a capture-only Sentry client to the global hub for
 // the duration of the test, restoring the unbound (disabled) state afterwards.
+// AttachStacktrace mirrors production (setupSentry) so string-panic events
+// carry frames here exactly as they do live.
 func bindCaptureClient(t *testing.T) *captureTransport {
 	t.Helper()
 	transport := &captureTransport{}
-	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport, Release: testRelease})
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport, Release: testRelease, AttachStacktrace: true})
 	require.NoError(t, err)
 	sentry.CurrentHub().BindClient(client)
 	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
@@ -139,6 +166,31 @@ func TestSentryInterceptor_HandlerPanic_CapturedThenRepanics(t *testing.T) {
 	assert.Equal(t, "grpc", event.Tags["transport"])
 	assert.Equal(t, sentry.LevelFatal, event.Level)
 	assert.Equal(t, testRelease, event.Release, "panic events must carry the release")
+	assert.True(t, transport.Flushed(),
+		"panic events must be flushed synchronously — the process is about to die and the async transport with it")
+	require.NotEmpty(t, event.Threads, "a string panic must carry a stack (AttachStacktrace shapes it as a thread)")
+	require.NotNil(t, event.Threads[0].Stacktrace)
+	assert.NotEmpty(t, event.Threads[0].Stacktrace.Frames, "a string panic without frames is undebuggable")
+}
+
+func TestSentryInterceptor_PanicFlushTimeout_Warns(t *testing.T) {
+	transport := bindCaptureClient(t)
+	transport.flushFails = true
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	interceptor := NewSentryInterceptor()
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_, _ = interceptor(context.Background(), nil, unaryInfo("/proto.TicketsService/ListTickets"),
+			func(ctx context.Context, req any) (any, error) {
+				panic("kaboom")
+			})
+	}, "a failed flush must not block the re-panic")
+
+	assert.Contains(t, warnBuf.String(), "panic event for /proto.TicketsService/ListTickets was likely dropped",
+		"a dropped crash event must at least leave a trace in the process logs")
 }
 
 func TestSentryInterceptor_NoClient_PassThrough(t *testing.T) {

--- a/servers/sentry.go
+++ b/servers/sentry.go
@@ -19,8 +19,10 @@
 package servers
 
 import (
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -33,14 +35,23 @@ import (
 // events to reach Sentry before the process exits.
 const sentryShutdownFlushTimeout = 2 * time.Second
 
-// sentryStartupProbeTimeout bounds the boot-time delivery check. A var, not a
+// sentryStartupProbeTimeout bounds the boot-time drain check. A var, not a
 // const, only so tests can shrink the window; production never mutates it.
 var sentryStartupProbeTimeout = 5 * time.Second
 
+// sentryDialCheckTimeout bounds the boot-time TCP reachability pre-check of
+// the DSN ingest host — generous enough for a cold DNS resolve plus a
+// cross-region handshake, small enough to keep the worst-case boot delay
+// acceptable (it stacks with the probe window before any listener opens). A
+// var, not a const, only so tests can shrink the window; production never
+// mutates it.
+var sentryDialCheckTimeout = 3 * time.Second
+
 // setupSentry initialises Sentry error capture (errors only, no tracing) when
-// SENTRY_DSN is present in the environment. Without a DSN it is a complete
-// no-op: no init, no capture, local/dev unaffected. Returns whether capture
-// was enabled.
+// SENTRY_DSN is present in the environment. Without a DSN nothing is
+// initialised — no client, no capture, local/dev unaffected; the only side
+// effect is one Info line making the disabled state visible at boot. Returns
+// whether capture was enabled.
 //
 // Temporary Phase 0 scaffolding (PRD #112): the rewritten stack gets its own
 // first-class wiring in Phase 3.
@@ -62,13 +73,18 @@ func setupSentry() bool {
 		// every error event is sent (confirmed convention in #113).
 		SampleRate: 0,
 		// String panics (panic("msg")) become message events; without this
-		// they would arrive with no stack trace at all.
+		// they would arrive with no stack trace at all. Side effect: HTTP 5xx
+		// CaptureMessage events also gain a (middleware-frame) Threads stack —
+		// grouping is unaffected because they set an explicit fingerprint.
 		AttachStacktrace: true,
 		// Env-gated SDK diagnostics: send failures, drops and rate limits
 		// otherwise go to a debug logger defaulting to io.Discard. One log
 		// line per event when on — too chatty for always-on, but lets ops
 		// diagnose delivery without a rebuild.
-		Debug:       viper.GetBool("SENTRY_DEBUG"),
+		Debug: sentryDebugEnabled(),
+		// SDK debug lines land on the Warn logger's underlying writer with
+		// the SDK's own "[Sentry] " prefix — NOT the app's "WARNING: "
+		// prefix. Log scrapers keyed on our prefixes will not match them.
 		DebugWriter: Warn.Writer(),
 		// Belt-and-braces scrubbing at the choke point — see scrubEvent for
 		// the exact (request-material-only) scope of the guarantee.
@@ -80,21 +96,96 @@ func setupSentry() bool {
 		return false
 	}
 
+	// Warn-only reachability pre-check: catches the misconfig class the probe
+	// below structurally cannot (fast send failures drain the queue and so
+	// still "flush"). Never changes the enabled/degraded semantics.
+	sentryDialCheck(dsn)
+
+	// Probe failure still returns true — enabled-degraded, not disabled: a
+	// slow-network false positive must not turn off capture. Do NOT refactor
+	// this into `return sentryStartupProbe()`.
 	if sentryStartupProbe() {
-		Info.Println("Sentry error capture enabled (errors only), release:", version)
+		Info.Println("Sentry error capture enabled (errors only), release:", version,
+			"— startup probe flushed (queue drained; delivery not verified — set SENTRY_DEBUG=true to confirm)")
 	}
 	return true
 }
 
+// sentryDebugEnabled reads SENTRY_DEBUG strictly. viper.GetBool silently maps
+// unparseable values ("yes", "on", typos) to false — a mid-incident operator
+// trap: debug looks enabled but nothing logs. Unset stays silently off; a set
+// but unparseable value warns and is treated as off.
+func sentryDebugEnabled() bool {
+	raw := viper.GetString("SENTRY_DEBUG")
+	if raw == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		Warn.Printf("SENTRY_DEBUG=%q is not a boolean (use \"true\" or \"false\") — treating as off", raw)
+		return false
+	}
+	return enabled
+}
+
+// sentryDialCheck is a boot-time, warn-only TCP reachability check of the DSN
+// ingest host. It exists because the startup probe cannot see fast send
+// failures — DNS errors and refused connections drain the transport queue in
+// milliseconds, so the probe's flush still reports success (see
+// sentryStartupProbe). A failed dial here names the unreachable host while
+// the probe would stay silent. Warn-only by design: the network may heal, and
+// a boot-time blip must not disable capture.
+func sentryDialCheck(rawDSN string) {
+	dsn, err := sentry.NewDsn(rawDSN)
+	if err != nil {
+		// Unreachable in practice — sentry.Init already parsed this DSN.
+		return
+	}
+	addr := net.JoinHostPort(dsn.GetHost(), strconv.Itoa(dsn.GetPort()))
+	conn, err := net.DialTimeout("tcp", addr, sentryDialCheckTimeout)
+	if err != nil {
+		Warn.Printf("sentry DSN host %s is unreachable (%v) — error events will not be delivered; set SENTRY_DEBUG=true for per-event transport diagnostics", addr, err)
+		return
+	}
+	_ = conn.Close()
+}
+
 // sentryStartupProbe pushes one canary event through the real transport and
-// flushes. sentry.Init does no network I/O, and the SDK reports delivery
-// failures (bad DSN host, blocked egress, rate limits) only to its internal
-// debug logger — without this probe a broken pipeline looks exactly like a
-// healthy one. Returns whether the flush confirmed the handoff.
+// flushes. sentry.Init does no network I/O, so without this the pipeline is
+// first exercised by the first real error.
+//
+// What a true return PROVES — per the SDK's documented Flush contract (queue
+// drained, NOT delivered): the transport finished its send attempts within
+// the window. That catches hang-class failures (blackholed egress, connects
+// slower than the window) and guarantees one event exercised the full
+// pipeline so SENTRY_DEBUG has something to report. What it does NOT prove:
+// delivery. The transport worker dequeues on ANY send outcome, so DNS
+// failures, refused connections, Sentry-side rejections (bad DSN key → 4xx)
+// and rate-limit drops all complete in milliseconds, drain the queue, and
+// "flush" successfully — those classes are visible only with
+// SENTRY_DEBUG=true (and partially via sentryDialCheck).
 func sentryStartupProbe() bool {
-	sentry.CaptureMessage("sentry startup probe")
-	if !sentry.Flush(sentryStartupProbeTimeout) {
-		Warn.Println("sentry enabled but startup probe did not flush — events may not be reaching Sentry (check DSN/egress)")
+	// Event hygiene: a fixed fingerprint + info level fold every container
+	// restart into one low-severity Sentry issue instead of resolve→reopen
+	// churn; the probe tag makes canaries filterable. Cloned hub so none of
+	// this leaks into the global scope.
+	var id *sentry.EventID
+	hub := sentry.CurrentHub().Clone()
+	hub.WithScope(func(scope *sentry.Scope) {
+		scope.SetFingerprint([]string{"sentry-startup-probe"})
+		scope.SetTag("probe", "true")
+		scope.SetLevel(sentry.LevelInfo)
+		id = hub.CaptureMessage("sentry startup probe")
+	})
+	if id == nil {
+		// Nil event ID = the client dropped the event before the transport
+		// saw it (e.g. a BeforeSend veto) — nothing queued, so a "successful"
+		// flush below would be vacuous.
+		Warn.Println("sentry startup probe was dropped client-side — no canary reached the transport (check BeforeSend/sampling)")
+		return false
+	}
+	if !hub.Flush(sentryStartupProbeTimeout) {
+		Warn.Println("sentry enabled but startup probe did not flush — transport still busy after the window; events may not be reaching Sentry (check DSN/egress, or set SENTRY_DEBUG=true)")
 		return false
 	}
 	return true
@@ -110,6 +201,9 @@ func sentryStartupProbe() bool {
 // process's signal semantics for nothing.
 func flushSentryOnShutdown() {
 	if sentry.CurrentHub().Client() == nil {
+		// Only reachable on programmer error — the call site gates on
+		// setupSentry(). Loud so misuse never silently skips the handler.
+		Warn.Println("flushSentryOnShutdown called without an initialised sentry client — shutdown flush handler not installed")
 		return
 	}
 	signals := make(chan os.Signal, 1)
@@ -129,7 +223,9 @@ func watchShutdown(signals <-chan os.Signal, flush func() bool, exit func(code i
 	sig := <-signals
 	Info.Printf("received %v — flushing sentry before exit", sig)
 	if !flush() {
-		Warn.Println("sentry flush timed out at shutdown — buffered events were dropped")
+		// "Remaining", not "all": events sent before the window closed made
+		// it out — only what was still buffered is gone.
+		Warn.Println("sentry shutdown flush window expired — remaining buffered events lost")
 	}
 	exit(0)
 }

--- a/servers/sentry.go
+++ b/servers/sentry.go
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2021 7Cav.us
+ *  This file is part of 7Cav-API <https://github.com/7cav/api>.
+ *
+ *  7Cav-API is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  7Cav-API is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with 7Cav-API. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package servers
+
+import (
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/spf13/viper"
+)
+
+// setupSentry initialises Sentry error capture (errors only, no tracing) when
+// SENTRY_DSN is present in the environment. Without a DSN it is a complete
+// no-op: no init, no capture, local/dev unaffected. Returns whether capture
+// was enabled.
+//
+// Temporary Phase 0 scaffolding (PRD #112): the rewritten stack gets its own
+// first-class wiring in Phase 3.
+func setupSentry() bool {
+	dsn := viper.GetString("SENTRY_DSN")
+	if dsn == "" {
+		return false
+	}
+
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn: dsn,
+		// Release reuses the build-time version injection
+		// (-X github.com/7cav/api/servers.version=<tag>).
+		Release: version,
+		// Errors only — no tracing (PRD #112 Phase 0).
+		EnableTracing: false,
+		// SampleRate left at zero so the SDK applies its default of 1.0
+		// (every error event is sent — confirmed convention in #113).
+		// Belt-and-braces: our interceptor/middleware never attach bearer
+		// material, but scrub at the choke point so nothing future-added
+		// can leak it either.
+		BeforeSend: scrubEvent,
+	})
+	if err != nil {
+		// Telemetry must never take the API down: log and run without it.
+		Warn.Printf("sentry init failed — continuing without error capture: %v", err)
+		return false
+	}
+
+	Info.Println("Sentry error capture enabled (errors only), release:", version)
+	return true
+}
+
+// scrubEvent is the BeforeSend hook: it strips credential-bearing request
+// material (Authorization headers, cookies) from every outgoing event so a
+// bearer token can never appear in a Sentry payload.
+func scrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+	if event.Request == nil {
+		return event
+	}
+	event.Request.Cookies = ""
+	for name := range event.Request.Headers {
+		switch strings.ToLower(name) {
+		case "authorization", "cookie", "proxy-authorization":
+			delete(event.Request.Headers, name)
+		}
+	}
+	return event
+}

--- a/servers/sentry.go
+++ b/servers/sentry.go
@@ -19,11 +19,19 @@
 package servers
 
 import (
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/viper"
 )
+
+// sentryShutdownFlushTimeout bounds how long shutdown waits for buffered
+// events to reach Sentry before the process exits.
+const sentryShutdownFlushTimeout = 2 * time.Second
 
 // setupSentry initialises Sentry error capture (errors only, no tracing) when
 // SENTRY_DSN is present in the environment. Without a DSN it is a complete
@@ -60,6 +68,30 @@ func setupSentry() bool {
 
 	Info.Println("Sentry error capture enabled (errors only), release:", version)
 	return true
+}
+
+// flushSentryOnShutdown installs a signal handler that flushes buffered
+// Sentry events before the process exits. The current stack has no graceful
+// shutdown path (Start blocks on Serve and the process dies by signal); this
+// is the minimal hook so error events from the final moments are not lost.
+// Only installed when Sentry is enabled, so the no-DSN path keeps today's
+// default signal behavior exactly.
+func flushSentryOnShutdown() {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	go watchShutdown(signals,
+		func() { sentry.Flush(sentryShutdownFlushTimeout) },
+		os.Exit,
+	)
+}
+
+// watchShutdown waits for a shutdown signal, flushes, then exits 0. Split
+// from flushSentryOnShutdown so the flush-before-exit ordering is testable.
+func watchShutdown(signals <-chan os.Signal, flush func(), exit func(code int)) {
+	sig := <-signals
+	Info.Printf("received %v — flushing sentry before exit", sig)
+	flush()
+	exit(0)
 }
 
 // scrubEvent is the BeforeSend hook: it strips credential-bearing request

--- a/servers/sentry.go
+++ b/servers/sentry.go
@@ -33,6 +33,10 @@ import (
 // events to reach Sentry before the process exits.
 const sentryShutdownFlushTimeout = 2 * time.Second
 
+// sentryStartupProbeTimeout bounds the boot-time delivery check. A var, not a
+// const, only so tests can shrink the window; production never mutates it.
+var sentryStartupProbeTimeout = 5 * time.Second
+
 // setupSentry initialises Sentry error capture (errors only, no tracing) when
 // SENTRY_DSN is present in the environment. Without a DSN it is a complete
 // no-op: no init, no capture, local/dev unaffected. Returns whether capture
@@ -43,6 +47,7 @@ const sentryShutdownFlushTimeout = 2 * time.Second
 func setupSentry() bool {
 	dsn := viper.GetString("SENTRY_DSN")
 	if dsn == "" {
+		Info.Println("Sentry disabled — SENTRY_DSN not set")
 		return false
 	}
 
@@ -53,11 +58,20 @@ func setupSentry() bool {
 		Release: version,
 		// Errors only — no tracing (PRD #112 Phase 0).
 		EnableTracing: false,
-		// SampleRate left at zero so the SDK applies its default of 1.0
-		// (every error event is sent — confirmed convention in #113).
-		// Belt-and-braces: our interceptor/middleware never attach bearer
-		// material, but scrub at the choke point so nothing future-added
-		// can leak it either.
+		// Explicit zero: the SDK normalises 0 to its default of 1.0, so
+		// every error event is sent (confirmed convention in #113).
+		SampleRate: 0,
+		// String panics (panic("msg")) become message events; without this
+		// they would arrive with no stack trace at all.
+		AttachStacktrace: true,
+		// Env-gated SDK diagnostics: send failures, drops and rate limits
+		// otherwise go to a debug logger defaulting to io.Discard. One log
+		// line per event when on — too chatty for always-on, but lets ops
+		// diagnose delivery without a rebuild.
+		Debug:       viper.GetBool("SENTRY_DEBUG"),
+		DebugWriter: Warn.Writer(),
+		// Belt-and-braces scrubbing at the choke point — see scrubEvent for
+		// the exact (request-material-only) scope of the guarantee.
 		BeforeSend: scrubEvent,
 	})
 	if err != nil {
@@ -66,7 +80,23 @@ func setupSentry() bool {
 		return false
 	}
 
-	Info.Println("Sentry error capture enabled (errors only), release:", version)
+	if sentryStartupProbe() {
+		Info.Println("Sentry error capture enabled (errors only), release:", version)
+	}
+	return true
+}
+
+// sentryStartupProbe pushes one canary event through the real transport and
+// flushes. sentry.Init does no network I/O, and the SDK reports delivery
+// failures (bad DSN host, blocked egress, rate limits) only to its internal
+// debug logger — without this probe a broken pipeline looks exactly like a
+// healthy one. Returns whether the flush confirmed the handoff.
+func sentryStartupProbe() bool {
+	sentry.CaptureMessage("sentry startup probe")
+	if !sentry.Flush(sentryStartupProbeTimeout) {
+		Warn.Println("sentry enabled but startup probe did not flush — events may not be reaching Sentry (check DSN/egress)")
+		return false
+	}
 	return true
 }
 
@@ -75,33 +105,48 @@ func setupSentry() bool {
 // shutdown path (Start blocks on Serve and the process dies by signal); this
 // is the minimal hook so error events from the final moments are not lost.
 // Only installed when Sentry is enabled, so the no-DSN path keeps today's
-// default signal behavior exactly.
+// default signal behavior exactly — guarded here as well as at the call site,
+// because installing the handler without a client would silently rewrite the
+// process's signal semantics for nothing.
 func flushSentryOnShutdown() {
+	if sentry.CurrentHub().Client() == nil {
+		return
+	}
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	go watchShutdown(signals,
-		func() { sentry.Flush(sentryShutdownFlushTimeout) },
+		func() bool { return sentry.Flush(sentryShutdownFlushTimeout) },
 		os.Exit,
 	)
 }
 
 // watchShutdown waits for a shutdown signal, flushes, then exits 0. Split
 // from flushSentryOnShutdown so the flush-before-exit ordering is testable.
-func watchShutdown(signals <-chan os.Signal, flush func(), exit func(code int)) {
+// Note on os.Exit: deferred functions do not run, and a second signal
+// arriving during the flush window is absorbed by the still-installed
+// handler — the process is already on its way down.
+func watchShutdown(signals <-chan os.Signal, flush func() bool, exit func(code int)) {
 	sig := <-signals
 	Info.Printf("received %v — flushing sentry before exit", sig)
-	flush()
+	if !flush() {
+		Warn.Println("sentry flush timed out at shutdown — buffered events were dropped")
+	}
 	exit(0)
 }
 
-// scrubEvent is the BeforeSend hook: it strips credential-bearing request
-// material (Authorization headers, cookies) from every outgoing event so a
-// bearer token can never appear in a Sentry payload.
+// scrubEvent is the BeforeSend hook closing the request-material vector: it
+// strips authorization / proxy-authorization / cookie headers
+// (case-insensitive), the cookie jar, and the raw query string from every
+// outgoing error event. It does NOT scan exception text, breadcrumbs or
+// extras — never put key material in error strings. If tracing is ever
+// enabled, transactions bypass BeforeSend and need an equivalent
+// BeforeSendTransaction hook.
 func scrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 	if event.Request == nil {
 		return event
 	}
 	event.Request.Cookies = ""
+	event.Request.QueryString = ""
 	for name := range event.Request.Headers {
 		switch strings.ToLower(name) {
 		case "authorization", "cookie", "proxy-authorization":

--- a/servers/sentry_test.go
+++ b/servers/sentry_test.go
@@ -4,29 +4,41 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/7cav/api/datastores"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // stubTransport is an in-memory sentry.Transport with a controllable Flush
-// outcome — the seam for probing the delivery-failure warning paths.
+// outcome. flushDrains=false simulates a drain timeout (queue still busy when
+// the window closes — the hang-class failure mode), NOT a delivery failure:
+// per the SDK's Flush contract, fast send failures dequeue and "flush"
+// successfully.
 type stubTransport struct {
-	mu      sync.Mutex
-	events  []*sentry.Event
-	flushOK bool
+	mu          sync.Mutex
+	events      []*sentry.Event
+	flushDrains bool
 }
 
 func (t *stubTransport) Configure(sentry.ClientOptions)        {}
-func (t *stubTransport) Flush(time.Duration) bool              { return t.flushOK }
-func (t *stubTransport) FlushWithContext(context.Context) bool { return t.flushOK }
+func (t *stubTransport) Flush(time.Duration) bool              { return t.flushDrains }
+func (t *stubTransport) FlushWithContext(context.Context) bool { return t.flushDrains }
 func (t *stubTransport) Close()                                {}
 
 func (t *stubTransport) SendEvent(event *sentry.Event) {
@@ -43,9 +55,9 @@ func (t *stubTransport) Events() []*sentry.Event {
 
 // bindStubClient binds a stub-transport Sentry client to the global hub for
 // the duration of the test, restoring the unbound (disabled) state afterwards.
-func bindStubClient(t *testing.T, flushOK bool) *stubTransport {
+func bindStubClient(t *testing.T, flushDrains bool) *stubTransport {
 	t.Helper()
-	transport := &stubTransport{flushOK: flushOK}
+	transport := &stubTransport{flushDrains: flushDrains}
 	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
 	require.NoError(t, err)
 	sentry.CurrentHub().BindClient(client)
@@ -73,10 +85,16 @@ func TestSetupSentry_MalformedDSN_DisabledWithoutPanic(t *testing.T) {
 	viper.Set("SENTRY_DSN", "not-a-dsn")
 	defer viper.Set("SENTRY_DSN", "")
 
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
 	enabled := setupSentry()
 
 	assert.False(t, enabled, "a malformed DSN must disable capture, never take the API down")
 	assert.Nil(t, sentry.CurrentHub().Client(), "no client may be bound after a failed init")
+	assert.Contains(t, warnBuf.String(), "sentry init failed — continuing without error capture",
+		"a config so broken it disables capture must say so in the logs, not just return false")
 }
 
 func TestSetupSentry_WithDSN_InitialisesErrorsOnlyClientWithRelease(t *testing.T) {
@@ -88,11 +106,14 @@ func TestSetupSentry_WithDSN_InitialisesErrorsOnlyClientWithRelease(t *testing.T
 		sentry.CurrentHub().BindClient(nil)
 	}()
 
-	// Shrink the startup-probe flush window: the example DSN is not routable,
-	// so the probe's real-transport flush must not stall the suite for 5s.
-	restore := sentryStartupProbeTimeout
+	// Shrink the startup-probe flush and dial-check windows: the example DSN
+	// is not routable, so neither boot check may stall the suite for seconds.
+	restoreProbe := sentryStartupProbeTimeout
 	sentryStartupProbeTimeout = 50 * time.Millisecond
-	defer func() { sentryStartupProbeTimeout = restore }()
+	defer func() { sentryStartupProbeTimeout = restoreProbe }()
+	restoreDial := sentryDialCheckTimeout
+	sentryDialCheckTimeout = 50 * time.Millisecond
+	defer func() { sentryDialCheckTimeout = restoreDial }()
 
 	enabled := setupSentry()
 
@@ -106,10 +127,31 @@ func TestSetupSentry_WithDSN_InitialisesErrorsOnlyClientWithRelease(t *testing.T
 	assert.True(t, opts.AttachStacktrace, "string panics must carry stack traces")
 	assert.True(t, opts.Debug, "SENTRY_DEBUG=true must enable SDK diagnostics without a rebuild")
 	assert.NotNil(t, opts.DebugWriter, "SDK diagnostics must land in our logs, not the default stderr")
-	assert.NotNil(t, opts.BeforeSend, "scrubber must be wired so bearer material can never leave the process")
+
+	// Don't trust NotNil — drive the WIRED hook with credential-bearing
+	// request material and prove it scrubs. Any function would satisfy
+	// NotNil; only the real scrubber survives this.
+	require.NotNil(t, opts.BeforeSend, "scrubber must be wired so bearer material can never leave the process")
+	fixture := sentry.NewEvent()
+	fixture.Request = &sentry.Request{
+		Headers: map[string]string{
+			"Authorization": "Bearer cav7_wiredsecret",
+			"Cookie":        "session=wired123",
+		},
+		Cookies:     "session=wired123",
+		QueryString: "api_key=cav7_wiredsecret",
+	}
+	scrubbed := opts.BeforeSend(fixture, nil)
+	require.NotNil(t, scrubbed, "the wired hook must sanitise, never drop, the event")
+	payload, err := json.Marshal(scrubbed)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "cav7_wiredsecret",
+		"the wired hook must strip bearer material from headers and query strings")
+	assert.NotContains(t, string(payload), "session=wired123",
+		"the wired hook must strip cookie material from headers and the cookie jar")
 }
 
-func TestSentryStartupProbe_FlushTimeout_WarnsLoudly(t *testing.T) {
+func TestSentryStartupProbe_DrainTimeout_WarnsLoudly(t *testing.T) {
 	bindStubClient(t, false)
 
 	var warnBuf bytes.Buffer
@@ -120,10 +162,10 @@ func TestSentryStartupProbe_FlushTimeout_WarnsLoudly(t *testing.T) {
 
 	assert.False(t, ok)
 	assert.Contains(t, warnBuf.String(), "startup probe did not flush",
-		"a swallowed delivery failure is the exact silence this canary exists to break")
+		"a hang-class transport stall is the one failure mode the drain probe can see — it must be loud")
 }
 
-func TestSentryStartupProbe_Delivered_NoWarning(t *testing.T) {
+func TestSentryStartupProbe_FlushDrains_NoWarning(t *testing.T) {
 	transport := bindStubClient(t, true)
 
 	var warnBuf bytes.Buffer
@@ -133,10 +175,202 @@ func TestSentryStartupProbe_Delivered_NoWarning(t *testing.T) {
 	ok := sentryStartupProbe()
 
 	assert.True(t, ok)
-	assert.Empty(t, warnBuf.String(), "a healthy probe must not warn")
+	assert.Empty(t, warnBuf.String(), "a drained probe must not warn")
 	events := transport.Events()
 	require.Len(t, events, 1, "the probe must push exactly one canary event through the transport")
-	assert.Equal(t, "sentry startup probe", events[0].Message)
+	event := events[0]
+	assert.Equal(t, "sentry startup probe", event.Message)
+	assert.Equal(t, []string{"sentry-startup-probe"}, event.Fingerprint,
+		"a fixed fingerprint folds every container restart into one Sentry issue — no resolve→reopen churn")
+	assert.Equal(t, "true", event.Tags["probe"], "probe events must be filterable")
+	assert.Equal(t, sentry.LevelInfo, event.Level, "the canary is informational, never an alertable error")
+}
+
+func TestSentryStartupProbe_ClientSideDrop_WarnsAndFails(t *testing.T) {
+	// A BeforeSend veto makes CaptureMessage return a nil event ID — the
+	// client dropped the canary before the transport ever saw it, so there is
+	// nothing to drain and the flush alone would report a false success.
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Transport:  &stubTransport{flushDrains: true},
+		BeforeSend: func(*sentry.Event, *sentry.EventHint) *sentry.Event { return nil },
+	})
+	require.NoError(t, err)
+	sentry.CurrentHub().BindClient(client)
+	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	ok := sentryStartupProbe()
+
+	assert.False(t, ok, "a client-side drop means no canary exercised the pipeline — probe failed")
+	assert.Contains(t, warnBuf.String(), "dropped client-side",
+		"a canary that never reached the transport must be visible, not a silent flush success")
+}
+
+// TestSetupSentry_ProbeStall_WarnsAndWithholdsEnabledLine pins that
+// setupSentry actually INVOKES the startup probe: the DSN points at a local
+// server that holds the canary's HTTP request past the shrunk probe window,
+// so the real transport cannot drain. Deleting the sentryStartupProbe() call
+// from setupSentry turns both assertions red (no warning, and the enabled
+// line prints). No real network involved.
+func TestSetupSentry_ProbeStall_WarnsAndWithholdsEnabledLine(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hold the connection past the probe window
+	}))
+	defer srv.Close()
+	defer close(release) // LIFO: unblock the handler before Close waits on it
+
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	viper.Set("SENTRY_DSN", "http://public@"+srvURL.Host+"/1")
+	defer func() {
+		viper.Set("SENTRY_DSN", "")
+		sentry.CurrentHub().BindClient(nil)
+	}()
+
+	restore := sentryStartupProbeTimeout
+	sentryStartupProbeTimeout = 100 * time.Millisecond
+	defer func() { sentryStartupProbeTimeout = restore }()
+
+	var warnBuf, infoBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+	Info.SetOutput(&infoBuf)
+	defer Info.SetOutput(os.Stdout)
+
+	enabled := setupSentry()
+
+	assert.True(t, enabled, "a stalled probe means degraded, never disabled — capture stays on")
+	assert.Contains(t, warnBuf.String(), "startup probe did not flush",
+		"a transport that cannot drain within the window must be loud at boot")
+	assert.NotContains(t, infoBuf.String(), "Sentry error capture enabled",
+		"the success line must be withheld when the probe could not drain")
+}
+
+// TestSentryDebugEnabled_StrictParse pins the operator-trap fix: viper's
+// GetBool silently maps "yes"/"on"/typos to false, which mid-incident reads
+// as "debug on but nothing logged". Unparseable values must warn.
+func TestSentryDebugEnabled_StrictParse(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		want     bool
+		wantWarn bool
+	}{
+		{"unset — silently off", "", false, false},
+		{"true", "true", true, false},
+		{"1", "1", true, false},
+		{"TRUE", "TRUE", true, false},
+		{"false", "false", false, false},
+		{"yes — operator trap, warn", "yes", false, true},
+		{"on — operator trap, warn", "on", false, true},
+		{"typo — warn", "ture", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Set("SENTRY_DEBUG", tc.raw)
+			defer viper.Set("SENTRY_DEBUG", "")
+
+			var warnBuf bytes.Buffer
+			Warn.SetOutput(&warnBuf)
+			defer Warn.SetOutput(os.Stdout)
+
+			assert.Equal(t, tc.want, sentryDebugEnabled())
+			if tc.wantWarn {
+				assert.Contains(t, warnBuf.String(), "SENTRY_DEBUG",
+					"an unparseable value must be called out by name, not silently treated as off")
+				assert.Contains(t, warnBuf.String(), tc.raw, "the warning must echo the rejected value")
+			} else {
+				assert.Empty(t, warnBuf.String(), "parseable or unset values must not warn")
+			}
+		})
+	}
+}
+
+func TestSentryDialCheck_UnreachableHost_WarnsWithHost(t *testing.T) {
+	// 127.0.0.1:1 refuses instantly — the deterministic stand-in for the
+	// wrong-DSN-host misconfig class the startup probe cannot see (fast send
+	// failures still drain the queue). Shrink the dial window anyway so a
+	// pathological environment cannot stall the suite.
+	restore := sentryDialCheckTimeout
+	sentryDialCheckTimeout = 500 * time.Millisecond
+	defer func() { sentryDialCheckTimeout = restore }()
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	sentryDialCheck("https://public@127.0.0.1:1/1")
+
+	assert.Contains(t, warnBuf.String(), "127.0.0.1:1",
+		"the warning must name the unreachable host so the misconfig is actionable")
+	assert.Contains(t, warnBuf.String(), "SENTRY_DEBUG",
+		"the warning must point at the diagnostic that shows per-event send failures")
+}
+
+func TestSentryDialCheck_ReachableHost_Silent(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = lis.Close() }()
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	sentryDialCheck("https://public@" + lis.Addr().String() + "/1")
+
+	assert.Empty(t, warnBuf.String(), "a reachable ingest host must not warn")
+}
+
+// chainFakeDatastore embeds the Datastore interface so it satisfies the type
+// while implementing only ValidateApiKey — the single method the auth
+// interceptor touches.
+type chainFakeDatastore struct {
+	datastores.Datastore
+	validateApiKey func(string) (*datastores.ApiKeyResult, error)
+}
+
+func (f *chainFakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
+	return f.validateApiKey(rawKey)
+}
+
+// TestAPIUnaryInterceptors_AuthOuterSentryInner_KeyIDReachesEvent pins the
+// gRPC interceptor chain ORDER as a tested contract — the mirror of the
+// buildAPIHandler tests on the HTTP side. Auth must run outermost (attaching
+// the validated key to ctx) and sentry inner (reading it for the key_id tag);
+// flipping the pair loses the tag.
+func TestAPIUnaryInterceptors_AuthOuterSentryInner_KeyIDReachesEvent(t *testing.T) {
+	transport := bindStubClient(t, true)
+	ds := &chainFakeDatastore{validateApiKey: func(token string) (*datastores.ApiKeyResult, error) {
+		assert.Equal(t, "cav7_goodkey", token)
+		return &datastores.ApiKeyResult{KeyId: 42}, nil
+	}}
+
+	interceptors := apiUnaryInterceptors(ds)
+	require.Len(t, interceptors, 2, "the chain is exactly auth + sentry")
+	info := &grpc.UnaryServerInfo{FullMethod: "/proto.MilpacService/GetProfile"}
+	// Mimic grpc.ChainUnaryInterceptor semantics: index 0 is outermost.
+	chained := func(ctx context.Context, req any, handler grpc.UnaryHandler) (any, error) {
+		return interceptors[0](ctx, req, info, func(ctx context.Context, req any) (any, error) {
+			return interceptors[1](ctx, req, info, handler)
+		})
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs("authorization", "Bearer cav7_goodkey"))
+	handlerErr := status.Error(codes.Internal, "boom")
+	_, err := chained(ctx, nil, func(ctx context.Context, req any) (any, error) {
+		return nil, handlerErr
+	})
+
+	assert.Equal(t, handlerErr, err, "the handler error must pass through the whole chain unchanged")
+	events := transport.Events()
+	require.Len(t, events, 1, "one Internal error through the chain must mean exactly one event")
+	assert.Equal(t, "42", events[0].Tags["key_id"],
+		"auth must run outermost and attach the key before sentry reads it — an order flip silently loses key_id")
 }
 
 func TestScrubEvent_StripsBearerAndCookieMaterial(t *testing.T) {
@@ -172,6 +406,23 @@ func TestScrubEvent_NoRequest_PassesThrough(t *testing.T) {
 
 	require.NotNil(t, scrubbed)
 	assert.Equal(t, "plain event", scrubbed.Message)
+}
+
+// TestFlushSentryOnShutdown_NoClient_WarnsAndSkips pins the guard's
+// visibility: it only fires on programmer error (the call site must gate on
+// setupSentry()), and silent misuse would mean shutdown flushes everyone
+// assumes exist were never installed.
+func TestFlushSentryOnShutdown_NoClient_WarnsAndSkips(t *testing.T) {
+	require.Nil(t, sentry.CurrentHub().Client(), "test requires the disabled state")
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	flushSentryOnShutdown()
+
+	assert.Contains(t, warnBuf.String(), "without an initialised sentry client",
+		"misuse must be visible in logs, not a silent no-op")
 }
 
 func TestWatchShutdown_FlushesBeforeExit(t *testing.T) {
@@ -213,10 +464,10 @@ func TestWatchShutdown_FlushesBeforeExit(t *testing.T) {
 			}
 			assert.Equal(t, []string{"flush", "exit"}, order, "buffered events must be flushed before the process exits")
 			if tc.wantWarn {
-				assert.Contains(t, warnBuf.String(), "sentry flush timed out at shutdown",
+				assert.Contains(t, warnBuf.String(), "shutdown flush window expired — remaining buffered events lost",
 					"silently dropped events at shutdown must leave a trace in the logs")
 			} else {
-				assert.NotContains(t, warnBuf.String(), "flush timed out", "a clean flush must not warn")
+				assert.NotContains(t, warnBuf.String(), "flush window expired", "a clean flush must not warn")
 			}
 		})
 	}

--- a/servers/sentry_test.go
+++ b/servers/sentry_test.go
@@ -2,7 +2,10 @@ package servers
 
 import (
 	"encoding/json"
+	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/viper"
@@ -68,4 +71,27 @@ func TestScrubEvent_NoRequest_PassesThrough(t *testing.T) {
 
 	require.NotNil(t, scrubbed)
 	assert.Equal(t, "plain event", scrubbed.Message)
+}
+
+func TestWatchShutdown_FlushesBeforeExit(t *testing.T) {
+	signals := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	var order []string
+
+	go watchShutdown(signals,
+		func() { order = append(order, "flush") },
+		func(code int) {
+			assert.Equal(t, 0, code, "graceful shutdown must exit 0")
+			order = append(order, "exit")
+			close(done)
+		})
+
+	signals <- syscall.SIGTERM
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchShutdown never exited after the signal")
+	}
+	assert.Equal(t, []string{"flush", "exit"}, order, "buffered events must be flushed before the process exits")
 }

--- a/servers/sentry_test.go
+++ b/servers/sentry_test.go
@@ -1,8 +1,11 @@
 package servers
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"os"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -13,31 +16,127 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stubTransport is an in-memory sentry.Transport with a controllable Flush
+// outcome — the seam for probing the delivery-failure warning paths.
+type stubTransport struct {
+	mu      sync.Mutex
+	events  []*sentry.Event
+	flushOK bool
+}
+
+func (t *stubTransport) Configure(sentry.ClientOptions)        {}
+func (t *stubTransport) Flush(time.Duration) bool              { return t.flushOK }
+func (t *stubTransport) FlushWithContext(context.Context) bool { return t.flushOK }
+func (t *stubTransport) Close()                                {}
+
+func (t *stubTransport) SendEvent(event *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+
+func (t *stubTransport) Events() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]*sentry.Event(nil), t.events...)
+}
+
+// bindStubClient binds a stub-transport Sentry client to the global hub for
+// the duration of the test, restoring the unbound (disabled) state afterwards.
+func bindStubClient(t *testing.T, flushOK bool) *stubTransport {
+	t.Helper()
+	transport := &stubTransport{flushOK: flushOK}
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: transport})
+	require.NoError(t, err)
+	sentry.CurrentHub().BindClient(client)
+	t.Cleanup(func() { sentry.CurrentHub().BindClient(nil) })
+	return transport
+}
+
 func TestSetupSentry_NoDSN_Disabled(t *testing.T) {
 	viper.Set("SENTRY_DSN", "")
 	defer viper.Set("SENTRY_DSN", "")
+
+	var infoBuf bytes.Buffer
+	Info.SetOutput(&infoBuf)
+	defer Info.SetOutput(os.Stdout)
 
 	enabled := setupSentry()
 
 	assert.False(t, enabled, "setupSentry must be a no-op when SENTRY_DSN is unset")
 	assert.Nil(t, sentry.CurrentHub().Client(), "no client may be bound without a DSN")
+	assert.Contains(t, infoBuf.String(), "Sentry disabled — SENTRY_DSN not set",
+		"the disabled state must be visible at boot, not silent")
+}
+
+func TestSetupSentry_MalformedDSN_DisabledWithoutPanic(t *testing.T) {
+	viper.Set("SENTRY_DSN", "not-a-dsn")
+	defer viper.Set("SENTRY_DSN", "")
+
+	enabled := setupSentry()
+
+	assert.False(t, enabled, "a malformed DSN must disable capture, never take the API down")
+	assert.Nil(t, sentry.CurrentHub().Client(), "no client may be bound after a failed init")
 }
 
 func TestSetupSentry_WithDSN_InitialisesErrorsOnlyClientWithRelease(t *testing.T) {
 	viper.Set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1")
+	viper.Set("SENTRY_DEBUG", true)
 	defer func() {
 		viper.Set("SENTRY_DSN", "")
+		viper.Set("SENTRY_DEBUG", false)
 		sentry.CurrentHub().BindClient(nil)
 	}()
+
+	// Shrink the startup-probe flush window: the example DSN is not routable,
+	// so the probe's real-transport flush must not stall the suite for 5s.
+	restore := sentryStartupProbeTimeout
+	sentryStartupProbeTimeout = 50 * time.Millisecond
+	defer func() { sentryStartupProbeTimeout = restore }()
 
 	enabled := setupSentry()
 
 	assert.True(t, enabled)
 	client := sentry.CurrentHub().Client()
 	require.NotNil(t, client, "a client must be bound when SENTRY_DSN is set")
-	assert.Equal(t, version, client.Options().Release, "release must reuse the build-time version injection")
-	assert.False(t, client.Options().EnableTracing, "errors only — no tracing")
-	assert.NotNil(t, client.Options().BeforeSend, "scrubber must be wired so bearer material can never leave the process")
+	opts := client.Options()
+	assert.Equal(t, version, opts.Release, "release must reuse the build-time version injection")
+	assert.False(t, opts.EnableTracing, "errors only — no tracing")
+	assert.Equal(t, 1.0, opts.SampleRate, "explicit zero must normalise to the SDK default of 1.0 — every error event is sent")
+	assert.True(t, opts.AttachStacktrace, "string panics must carry stack traces")
+	assert.True(t, opts.Debug, "SENTRY_DEBUG=true must enable SDK diagnostics without a rebuild")
+	assert.NotNil(t, opts.DebugWriter, "SDK diagnostics must land in our logs, not the default stderr")
+	assert.NotNil(t, opts.BeforeSend, "scrubber must be wired so bearer material can never leave the process")
+}
+
+func TestSentryStartupProbe_FlushTimeout_WarnsLoudly(t *testing.T) {
+	bindStubClient(t, false)
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	ok := sentryStartupProbe()
+
+	assert.False(t, ok)
+	assert.Contains(t, warnBuf.String(), "startup probe did not flush",
+		"a swallowed delivery failure is the exact silence this canary exists to break")
+}
+
+func TestSentryStartupProbe_Delivered_NoWarning(t *testing.T) {
+	transport := bindStubClient(t, true)
+
+	var warnBuf bytes.Buffer
+	Warn.SetOutput(&warnBuf)
+	defer Warn.SetOutput(os.Stdout)
+
+	ok := sentryStartupProbe()
+
+	assert.True(t, ok)
+	assert.Empty(t, warnBuf.String(), "a healthy probe must not warn")
+	events := transport.Events()
+	require.Len(t, events, 1, "the probe must push exactly one canary event through the transport")
+	assert.Equal(t, "sentry startup probe", events[0].Message)
 }
 
 func TestScrubEvent_StripsBearerAndCookieMaterial(t *testing.T) {
@@ -50,12 +149,14 @@ func TestScrubEvent_StripsBearerAndCookieMaterial(t *testing.T) {
 			"cookie":        "session=abc123",
 			"User-Agent":    "test-agent",
 		},
-		Cookies: "session=abc123",
+		Cookies:     "session=abc123",
+		QueryString: "api_key=cav7_supersecrettoken&page=2",
 	}
 
 	scrubbed := scrubEvent(event, nil)
 
 	require.NotNil(t, scrubbed, "scrubbing must sanitise, never drop, the event")
+	assert.Empty(t, scrubbed.Request.QueryString, "query strings can carry credentials — cleared wholesale")
 	payload, err := json.Marshal(scrubbed)
 	require.NoError(t, err)
 	assert.NotContains(t, string(payload), "cav7_supersecrettoken", "bearer material must never appear in any event payload")
@@ -74,24 +175,49 @@ func TestScrubEvent_NoRequest_PassesThrough(t *testing.T) {
 }
 
 func TestWatchShutdown_FlushesBeforeExit(t *testing.T) {
-	signals := make(chan os.Signal, 1)
-	done := make(chan struct{})
-	var order []string
-
-	go watchShutdown(signals,
-		func() { order = append(order, "flush") },
-		func(code int) {
-			assert.Equal(t, 0, code, "graceful shutdown must exit 0")
-			order = append(order, "exit")
-			close(done)
-		})
-
-	signals <- syscall.SIGTERM
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("watchShutdown never exited after the signal")
+	cases := []struct {
+		name     string
+		flushOK  bool
+		wantWarn bool
+	}{
+		{"flush succeeds — silent", true, false},
+		{"flush times out — dropped events are visible", false, true},
 	}
-	assert.Equal(t, []string{"flush", "exit"}, order, "buffered events must be flushed before the process exits")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var warnBuf bytes.Buffer
+			Warn.SetOutput(&warnBuf)
+			defer Warn.SetOutput(os.Stdout)
+
+			signals := make(chan os.Signal, 1)
+			done := make(chan struct{})
+			var order []string
+
+			go watchShutdown(signals,
+				func() bool {
+					order = append(order, "flush")
+					return tc.flushOK
+				},
+				func(code int) {
+					assert.Equal(t, 0, code, "graceful shutdown must exit 0")
+					order = append(order, "exit")
+					close(done)
+				})
+
+			signals <- syscall.SIGTERM
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("watchShutdown never exited after the signal")
+			}
+			assert.Equal(t, []string{"flush", "exit"}, order, "buffered events must be flushed before the process exits")
+			if tc.wantWarn {
+				assert.Contains(t, warnBuf.String(), "sentry flush timed out at shutdown",
+					"silently dropped events at shutdown must leave a trace in the logs")
+			} else {
+				assert.NotContains(t, warnBuf.String(), "flush timed out", "a clean flush must not warn")
+			}
+		})
+	}
 }

--- a/servers/sentry_test.go
+++ b/servers/sentry_test.go
@@ -1,0 +1,71 @@
+package servers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupSentry_NoDSN_Disabled(t *testing.T) {
+	viper.Set("SENTRY_DSN", "")
+	defer viper.Set("SENTRY_DSN", "")
+
+	enabled := setupSentry()
+
+	assert.False(t, enabled, "setupSentry must be a no-op when SENTRY_DSN is unset")
+	assert.Nil(t, sentry.CurrentHub().Client(), "no client may be bound without a DSN")
+}
+
+func TestSetupSentry_WithDSN_InitialisesErrorsOnlyClientWithRelease(t *testing.T) {
+	viper.Set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1")
+	defer func() {
+		viper.Set("SENTRY_DSN", "")
+		sentry.CurrentHub().BindClient(nil)
+	}()
+
+	enabled := setupSentry()
+
+	assert.True(t, enabled)
+	client := sentry.CurrentHub().Client()
+	require.NotNil(t, client, "a client must be bound when SENTRY_DSN is set")
+	assert.Equal(t, version, client.Options().Release, "release must reuse the build-time version injection")
+	assert.False(t, client.Options().EnableTracing, "errors only — no tracing")
+	assert.NotNil(t, client.Options().BeforeSend, "scrubber must be wired so bearer material can never leave the process")
+}
+
+func TestScrubEvent_StripsBearerAndCookieMaterial(t *testing.T) {
+	event := sentry.NewEvent()
+	event.Request = &sentry.Request{
+		Method: "GET",
+		URL:    "/api/v1/roster",
+		Headers: map[string]string{
+			"Authorization": "Bearer cav7_supersecrettoken",
+			"cookie":        "session=abc123",
+			"User-Agent":    "test-agent",
+		},
+		Cookies: "session=abc123",
+	}
+
+	scrubbed := scrubEvent(event, nil)
+
+	require.NotNil(t, scrubbed, "scrubbing must sanitise, never drop, the event")
+	payload, err := json.Marshal(scrubbed)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "cav7_supersecrettoken", "bearer material must never appear in any event payload")
+	assert.NotContains(t, string(payload), "session=abc123", "cookie material must never appear in any event payload")
+	assert.Contains(t, string(payload), "test-agent", "non-sensitive headers stay for debugging value")
+}
+
+func TestScrubEvent_NoRequest_PassesThrough(t *testing.T) {
+	event := sentry.NewEvent()
+	event.Message = "plain event"
+
+	scrubbed := scrubEvent(event, nil)
+
+	require.NotNil(t, scrubbed)
+	assert.Equal(t, "plain event", scrubbed.Message)
+}

--- a/servers/server.go
+++ b/servers/server.go
@@ -157,8 +157,14 @@ func (server *MicroServer) Start() {
 	// note: commenting out the creds option, because internally (nginx <-> golang) traffic is not encrypted.
 	// 		 If this needed to change in the future, then we will need to refactor this method
 	opts := []grpc.ServerOption{
-		// Intercept request to check the token.
-		grpc.UnaryInterceptor(grpcServices.NewAuthInterceptor(ds)),
+		// Intercept request to check the token; Sentry sits inside auth so
+		// it only sees authenticated requests, with the API key already on
+		// ctx for key-id tagging. No SENTRY_DSN → the inner interceptor is
+		// a pass-through.
+		grpc.ChainUnaryInterceptor(
+			grpcServices.NewAuthInterceptor(ds),
+			grpcServices.NewSentryInterceptor(),
+		),
 		//grpc.Creds(creds),
 	}
 

--- a/servers/server.go
+++ b/servers/server.go
@@ -167,7 +167,11 @@ func (server *MicroServer) Start() {
 		// Intercept request to check the token; Sentry sits inside auth so
 		// it only sees authenticated requests, with the API key already on
 		// ctx for key-id tagging. No SENTRY_DSN → the inner interceptor is
-		// a pass-through.
+		// a pass-through. Sentry-inside-auth also means auth-layer
+		// infrastructure failures (e.g. a datastore outage producing mass
+		// Unauthenticated rejections) generate no Sentry events by design —
+		// accepted for Phase 0, revisit in the Phase 3 first-class wiring
+		// (#130–#132).
 		grpc.ChainUnaryInterceptor(
 			grpcServices.NewAuthInterceptor(ds),
 			grpcServices.NewSentryInterceptor(),

--- a/servers/server.go
+++ b/servers/server.go
@@ -136,6 +136,13 @@ func (server *MicroServer) Start() {
 
 	Info.Println("Starting 7Cav API version:", version)
 
+	// Phase 0 observability (PRD #112): errors-only Sentry capture, gated on
+	// SENTRY_DSN. Disabled (local/dev) this is a complete no-op — no signal
+	// handler either, so shutdown behaves exactly as before.
+	if setupSentry() {
+		flushSentryOnShutdown()
+	}
+
 	//create TLS listener for TCP connections
 	grpcL, err := net.Listen("tcp", "0.0.0.0:10000")
 	httpL, err := net.Listen("tcp", "0.0.0.0:11000")

--- a/servers/server.go
+++ b/servers/server.go
@@ -137,8 +137,12 @@ func (server *MicroServer) Start() {
 	Info.Println("Starting 7Cav API version:", version)
 
 	// Phase 0 observability (PRD #112): errors-only Sentry capture, gated on
-	// SENTRY_DSN. Disabled (local/dev) this is a complete no-op — no signal
-	// handler either, so shutdown behaves exactly as before.
+	// SENTRY_DSN. Disabled (local/dev) nothing is initialised — one Info line,
+	// no client, no signal handler, so shutdown behaves exactly as before.
+	// Enabled, this BLOCKS boot before any listener opens: the dial pre-check
+	// (≤3s on an unreachable host) plus the startup-probe flush window (≤5s)
+	// — a worst-case ~8s delay on a degraded network, by design, so a broken
+	// pipeline is visible before traffic flows.
 	if setupSentry() {
 		flushSentryOnShutdown()
 	}
@@ -164,18 +168,7 @@ func (server *MicroServer) Start() {
 	// note: commenting out the creds option, because internally (nginx <-> golang) traffic is not encrypted.
 	// 		 If this needed to change in the future, then we will need to refactor this method
 	opts := []grpc.ServerOption{
-		// Intercept request to check the token; Sentry sits inside auth so
-		// it only sees authenticated requests, with the API key already on
-		// ctx for key-id tagging. No SENTRY_DSN → the inner interceptor is
-		// a pass-through. Sentry-inside-auth also means auth-layer
-		// infrastructure failures (e.g. a datastore outage producing mass
-		// Unauthenticated rejections) generate no Sentry events by design —
-		// accepted for Phase 0, revisit in the Phase 3 first-class wiring
-		// (#130–#132).
-		grpc.ChainUnaryInterceptor(
-			grpcServices.NewAuthInterceptor(ds),
-			grpcServices.NewSentryInterceptor(),
-		),
+		grpc.ChainUnaryInterceptor(apiUnaryInterceptors(ds)...),
 		//grpc.Creds(creds),
 	}
 
@@ -184,6 +177,25 @@ func (server *MicroServer) Start() {
 	go servHTTP(server, httpL, ds)
 	Info.Println("Starting GRPC listener")
 	servGRPC(server, grpcL, opts, ds)
+}
+
+// apiUnaryInterceptors is the gRPC unary interceptor chain, in the
+// outermost-first order consumed by grpc.ChainUnaryInterceptor: auth outer,
+// sentry inner. Sentry sits inside auth so it only sees authenticated
+// requests, with the API key already on ctx for key-id tagging. No SENTRY_DSN
+// → the inner interceptor is a pass-through. Sentry-inside-auth also means
+// auth-layer infrastructure failures (e.g. a datastore outage producing mass
+// Unauthenticated rejections) generate no Sentry events by design — accepted
+// for Phase 0, revisit in the Phase 3 observability slices (#130–#132).
+//
+// Package-level (not inlined in Start) so the chain order is a tested
+// contract — see TestAPIUnaryInterceptors_AuthOuterSentryInner_KeyIDReachesEvent
+// — mirroring buildAPIHandler on the HTTP side.
+func apiUnaryInterceptors(ds datastores.Datastore) []grpc.UnaryServerInterceptor {
+	return []grpc.UnaryServerInterceptor{
+		grpcServices.NewAuthInterceptor(ds),
+		grpcServices.NewSentryInterceptor(),
+	}
 }
 
 func servGRPC(server *MicroServer, lis net.Listener, grpcOpts []grpc.ServerOption, ds datastores.Datastore) {


### PR DESCRIPTION
## Summary

Wires `sentry-go` (v0.46.2) into the current stack before Phases 1–2 change behavior underneath it (PRD #112, Phase 0 — observe first). Errors only, no tracing. No `SENTRY_DSN` → complete no-op: no init, no signal handler, byte-identical request path.

- **gRPC**: `ChainUnaryInterceptor(auth, sentry)` via extracted `apiUnaryInterceptors`; panics captured → synchronously flushed → re-raised (grpc-go has no recovery layer); Internal-class errors (the grpc-gateway 5xx-mapping set, exactly matched) captured, fingerprinted by code+method to prevent grouping collapse
- **HTTP**: `buildAPIHandler` = auth(sentry(cache(compression))); 5xx responses + panics captured; status observed via a Write-latching recorder; 5xx events fingerprinted against path-param issue fan-out
- **Tags**: release (reuses existing ldflags version injection), key_id, route — bearer material never in payloads, pinned by whole-payload JSON assertions including the query-string vector; BeforeSend scrubber (auth headers / cookies / query) as second layer
- **Boot**: startup probe scoped to honest drain semantics (`Flush()==true` proves queue drain, not delivery), DSN-host dial pre-check catches NXDOMAIN/refused, `SENTRY_DEBUG` env-gated SDK diagnostics; flush-on-shutdown with timeout warning
- **Accepted Phase 0 tradeoff** (documented at both wiring sites): sentry sits inside auth, so auth-layer infrastructure failures (e.g. DB outage → mass 401) produce no events; revisit in the Phase 3 observability slices (#130–#132)

## Review

3 supervised rounds, 9 reviewer agents total, including sentry-go source verification and adversarial mutation probes. Round-1 critical (silent delivery failures) + 8 importants and the round-2 flush-semantics cluster all closed; 9 mutation pins verified red→green.

Note: the "events observed arriving from prod" acceptance criterion is post-deploy verification — the DSN is already inert in the prod compose (#113), so this ships without a coordinated deploy.

Follow-up: #138 (post-merge cache-seam alignment with #114's interface).

## Test plan

- [x] `go build && go vet && go test ./... && go mod tidy` clean
- [x] `-race -count=3 -shuffle=on` green on ./servers/...
- [x] Merged-tree preflight with the #114 branch: build + full suite + race/shuffle green

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)