### PR TITLE
Phase 1: dockerized MariaDB integration harness with forum-shaped schema and fixtures

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,10 +43,24 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v6.0.2
-    - name: Test (no harness — integration tests must skip)
+    # The service container is up for the whole job; this step is "no
+    # harness" only in the sense that TESTDB_ADDR is left unset.
+    - name: Test (TESTDB_ADDR unset — integration tests must skip)
       run: go test ./...
+    # `go test ./...` prints identical output whether the integration
+    # tests ran or all skipped, so env-wiring drift would silently turn
+    # the harness suite into a no-op forever. Surface the ./testdb
+    # verdicts verbosely and fail loudly on any skip before running the
+    # full suite.
     - name: Test with MariaDB harness
-      run: go test ./...
+      run: |
+        set -euo pipefail
+        go test -v ./testdb 2>&1 | tee testdb-harness.log
+        if grep -q -- '--- SKIP' testdb-harness.log; then
+          echo "::error::testdb integration tests skipped despite TESTDB_ADDR being set — env wiring has drifted and the harness suite degraded to a no-op"
+          exit 1
+        fi
+        go test ./...
       env:
         TESTDB_ADDR: 127.0.0.1:3310
   lint:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,33 @@ jobs:
       run: go mod tidy
     - name: Build
       run: go build -v ./...
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        # Matches the forum's major version and testdb/compose.yaml.
+        image: mariadb:11.5
+        env:
+          # Throwaway credential for disposable fixture data; mirrored in
+          # testdb/testdb.go and testdb/compose.yaml.
+          MARIADB_ROOT_PASSWORD: harness
+        ports:
+          - 3310:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=24
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6.0.2
+    - name: Test (no harness — integration tests must skip)
+      run: go test ./...
+    - name: Test with MariaDB harness
+      run: go test ./...
+      env:
+        TESTDB_ADDR: 127.0.0.1:3310
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,3 +106,20 @@ service. Each token carries a set of named scopes. Current scopes:
 
 Scope membership is checked per-handler; a token with `read` cannot
 read tickets, and vice versa.
+
+## SQL seam (integration-test harness)
+
+`testdb/` is the dockerized MariaDB harness — the "SQL seam" from PRD
+#112's testing decisions. `testdb.Open(t)` hands a test its own
+disposable database (forum-shaped schema + fixtures, embedded in the
+package) on a MariaDB 11.5 server; tests opt in via `TESTDB_ADDR` and
+skip without it. Run locally with `make test-integration`.
+
+Two properties of the harness are load-bearing:
+
+- The schema deliberately omits the four indexes PRD #112 proposes, so
+  "red" EXPLAIN plans stay reproducible (each test may CREATE INDEX in
+  its own database to observe the flip).
+- The fixtures include a member whose milpac `relation_id` collides
+  with another member's forum `user_id` (205), keeping the by-id
+  profile route's frozen relation-key semantic testable.

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,20 @@ test:
 
 # Dockerized MariaDB integration harness (testdb/). Tests opt into the
 # real database via TESTDB_ADDR; without it they skip.
+# The compose project is unique per checkout and the host port ephemeral
+# (discovered via `docker compose port`), so parallel worktrees can run
+# harnesses side by side.
+TESTDB_PROJECT ?= testdb-$(notdir $(CURDIR))
+TESTDB_COMPOSE := docker compose -p $(TESTDB_PROJECT) -f testdb/compose.yaml
+
 testdb-up:
-	docker compose -f testdb/compose.yaml up -d --wait
+	$(TESTDB_COMPOSE) up -d --wait
 
 testdb-down:
-	docker compose -f testdb/compose.yaml down -v
+	$(TESTDB_COMPOSE) down -v
 
 test-integration: testdb-up
-	TESTDB_ADDR=127.0.0.1:3310 go test ./...
+	TESTDB_ADDR=$$($(TESTDB_COMPOSE) port mariadb 3306) go test ./...
 
 lint:
 	buf lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
 generate:
 	buf generate
 
+test:
+	go test ./...
+
+# Dockerized MariaDB integration harness (testdb/). Tests opt into the
+# real database via TESTDB_ADDR; without it they skip.
+testdb-up:
+	docker compose -f testdb/compose.yaml up -d --wait
+
+testdb-down:
+	docker compose -f testdb/compose.yaml down -v
+
+test-integration: testdb-up
+	TESTDB_ADDR=127.0.0.1:3310 go test ./...
+
 lint:
 	buf lint
 	buf breaking --against 'https://github.com/7cav/api.git#branch=develop'

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/bufbuild/buf v1.70.0
 	github.com/getsentry/sentry-go v0.46.2
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/redis/go-redis/v9 v9.20.0
 	github.com/spf13/cobra v1.10.2
@@ -59,7 +60,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/cel-go v0.28.1 // indirect

--- a/magefile.go
+++ b/magefile.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 // Generate protobufs
@@ -29,14 +31,26 @@ func Test() error {
 	return run("go", "test", "./...")
 }
 
-// Spin up the dockerized MariaDB harness and run the full test suite against it
+// Spin up the dockerized MariaDB harness and run the full test suite against it.
+// The compose project is unique per checkout and the host port ephemeral
+// (discovered via `docker compose port`), so parallel worktrees can run
+// harnesses side by side. Mirrors the Makefile's testdb targets.
 func TestIntegration() error {
 	fmt.Println("Running integration tests against the MariaDB harness...")
-	if err := run("docker", "compose", "-f", "testdb/compose.yaml", "up", "-d", "--wait"); err != nil {
+	wd, err := os.Getwd()
+	if err != nil {
 		return err
 	}
+	compose := []string{"compose", "-p", "testdb-" + strings.ToLower(filepath.Base(wd)), "-f", "testdb/compose.yaml"}
+	if err := run("docker", append(compose, "up", "-d", "--wait")...); err != nil {
+		return err
+	}
+	out, err := exec.Command("docker", append(compose, "port", "mariadb", "3306")...).Output()
+	if err != nil {
+		return fmt.Errorf("discovering harness port: %w", err)
+	}
 	cmd := exec.Command("go", "test", "./...")
-	cmd.Env = append(os.Environ(), "TESTDB_ADDR=127.0.0.1:3310")
+	cmd.Env = append(os.Environ(), "TESTDB_ADDR="+strings.TrimSpace(string(out)))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -23,6 +23,28 @@ func Lint() error {
 	return run("buf", "breaking", "--against", "https://github.com/7cav/api.git#branch=develop")
 }
 
+// Run the test suite (MariaDB integration tests skip unless TESTDB_ADDR is set)
+func Test() error {
+	fmt.Println("Running tests...")
+	return run("go", "test", "./...")
+}
+
+// Spin up the dockerized MariaDB harness and run the full test suite against it
+func TestIntegration() error {
+	fmt.Println("Running integration tests against the MariaDB harness...")
+	if err := run("docker", "compose", "-f", "testdb/compose.yaml", "up", "-d", "--wait"); err != nil {
+		return err
+	}
+	cmd := exec.Command("go", "test", "./...")
+	cmd.Env = append(os.Environ(), "TESTDB_ADDR=127.0.0.1:3310")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("integration tests failed: %w", err)
+	}
+	return nil
+}
+
 // Install dependencies and tools
 func Install() error {
 	fmt.Println("Installing dependencies and tools...")

--- a/testdb/compose.yaml
+++ b/testdb/compose.yaml
@@ -7,16 +7,20 @@
 # Matches the forum's major version (MariaDB 11.5). Data lives on tmpfs:
 # every `up` starts empty; the testdb package creates a fresh database
 # per test and seeds it from its embedded schema/fixtures.
+# Container and network names derive from the compose project, which the
+# make/mage targets set uniquely per checkout (testdb-<dirname>), and the
+# host port is ephemeral — so parallel worktrees can each run their own
+# harness. Discover the port with:
+#   docker compose -p testdb-<dirname> -f testdb/compose.yaml port mariadb 3306
 services:
   mariadb:
     image: mariadb:11.5
-    container_name: 7cav-api-testdb
     environment:
       # Throwaway credential for disposable fixture data; mirrored in
       # testdb.go and .github/workflows/go.yml.
       MARIADB_ROOT_PASSWORD: harness
     ports:
-      - "3310:3306"
+      - "127.0.0.1::3306"
     tmpfs:
       - /var/lib/mysql
     healthcheck:

--- a/testdb/compose.yaml
+++ b/testdb/compose.yaml
@@ -1,0 +1,26 @@
+# Disposable MariaDB server for the integration-test harness (testdb).
+#
+#   make testdb-up     start (waits for healthy)
+#   make test-integration  start + run the full test suite against it
+#   make testdb-down   stop and discard
+#
+# Matches the forum's major version (MariaDB 11.5). Data lives on tmpfs:
+# every `up` starts empty; the testdb package creates a fresh database
+# per test and seeds it from its embedded schema/fixtures.
+services:
+  mariadb:
+    image: mariadb:11.5
+    container_name: 7cav-api-testdb
+    environment:
+      # Throwaway credential for disposable fixture data; mirrored in
+      # testdb.go and .github/workflows/go.yml.
+      MARIADB_ROOT_PASSWORD: harness
+    ports:
+      - "3310:3306"
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -241,3 +241,27 @@ INSERT INTO xf_nf_tickets_ticket_field_value (ticket_id, field_id, field_value) 
   (1, 'discordId', '111111111111111111'),
   (2, 'milpacId',  '1'),
   (3, 'gameServer', 'arma3-tac1');
+
+-- ---------------------------------------------------------------------
+-- API keys (Cav7 ApiKeyManager)
+-- ---------------------------------------------------------------------
+-- Raw key material is the testdb package's public contract
+-- (testdb.ActiveAPIKey / testdb.RevokedAPIKey); only hashes are stored,
+-- matching the datastore's UNHEX(SHA2(?, 256)) lookup. Scope 3 is an
+-- inactive scope attached to the active key: it must NOT surface.
+INSERT INTO xf_cav7_api_key_scope_def
+  (scope_id, scope_name, title, description, is_active) VALUES
+  (1, 'read',         'Read',         'Read milpacs data',  1),
+  (2, 'read:tickets', 'Read tickets', 'Read tickets data',  1),
+  (3, 'admin',        'Admin',        'Retired scope',      0);
+
+INSERT INTO xf_cav7_api_key
+  (key_id, user_id, key_hash, key_prefix, is_active, created_date) VALUES
+  (1, 401, UNHEX(SHA2('cav7_harness_active', 256)),  'cav7_harness', 1, 1740000000),
+  (2, 400, UNHEX(SHA2('cav7_harness_revoked', 256)), 'cav7_harness', 0, 1740000000);
+
+INSERT INTO xf_cav7_api_key_scope (key_id, scope_id) VALUES
+  (1, 1),
+  (1, 2),
+  (1, 3),
+  (2, 1);

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -130,13 +130,17 @@ FROM seq_1_to_20000;
 -- Targeted posts for roster members outside the bulk poster pool:
 -- Trooper.C (150) and Trooper.D (205) post recently; Reservist.E (300)
 -- last posted long ago (AWOL-shaped); Discharged.F (301) never posted
--- (left-join NULL case).
+-- (left-join NULL case). The "recent" rows are seeded RELATIVE to the
+-- wall clock because FindAwol computes its cutoff from now-7d — fixed
+-- epochs would silently go stale and break the recent-vs-AWOL contrast
+-- (pinned by TestFixtures_AwolContrastHoldsRelativeToNow). The ancient
+-- row stays fixed: its distance from any future "now" only grows.
 INSERT INTO xf_post
   (post_id, thread_id, user_id, username, post_date, message, position,
    type_data, reaction_users, vote_score) VALUES
-  (20001, 1, 150, 'Trooper.C',   1750000000, 'recent post', 0, '', '', 0),
-  (20002, 1, 150, 'Trooper.C',   1750000600, 'most recent post', 1, '', '', 0),
-  (20003, 1, 205, 'Trooper.D',   1750001200, 'recent post', 2, '', '', 0),
+  (20001, 1, 150, 'Trooper.C',   UNIX_TIMESTAMP() - 7200, 'recent post', 0, '', '', 0),
+  (20002, 1, 150, 'Trooper.C',   UNIX_TIMESTAMP() - 3600, 'most recent post', 1, '', '', 0),
+  (20003, 1, 205, 'Trooper.D',   UNIX_TIMESTAMP() - 1800, 'recent post', 2, '', '', 0),
   (20004, 2, 300, 'Reservist.E', 1600000000, 'ancient post', 0, '', '', 0);
 
 -- ---------------------------------------------------------------------

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -138,3 +138,106 @@ INSERT INTO xf_post
   (20002, 1, 150, 'Trooper.C',   1750000600, 'most recent post', 1, '', '', 0),
   (20003, 1, 205, 'Trooper.D',   1750001200, 'recent post', 2, '', '', 0),
   (20004, 2, 300, 'Reservist.E', 1600000000, 'ancient post', 0, '', '', 0);
+
+-- ---------------------------------------------------------------------
+-- Tickets (NF Tickets)
+-- ---------------------------------------------------------------------
+
+-- Nested-set category tree: Admin Office (1) contains Recruiting (2);
+-- Tech Support (3) is a sibling root. Subtree expansion of [1] must
+-- yield [1, 2].
+INSERT INTO xf_nf_tickets_category
+  (ticket_category_id, title, description, parent_category_id, depth, lft, rgt,
+   display_order, ticket_count, last_ticket_title, breadcrumb_data, field_cache,
+   category_emails, prefix_cache, notify_emails) VALUES
+  (1, 'Admin Office',  'General admin requests', 0, 0, 1, 4, 10, 3, '', '', '', '', '', ''),
+  (2, 'Recruiting',    'Enlistment paperwork',   1, 1, 2, 3, 10, 2, '', '', '', '', '', ''),
+  (3, 'Tech Support',  'TeamSpeak and game tech',0, 0, 5, 6, 20, 2, '', '', '', '', '', '');
+
+-- Phrases backing the reference cache: status / priority / prefix names.
+INSERT INTO xf_phrase (language_id, title, phrase_text) VALUES
+  (0, 'nf_tickets_ticket_status.1',   'Awaiting Support'),
+  (0, 'nf_tickets_ticket_status.2',   'In Progress'),
+  (0, 'nf_tickets_ticket_status.3',   'Closed'),
+  (0, 'nf_tickets_ticket_priority.1', 'Low'),
+  (0, 'nf_tickets_ticket_priority.2', 'Normal'),
+  (0, 'nf_tickets_ticket_priority.3', 'High'),
+  (0, 'nf_tickets_ticket_prefix.1',   'Urgent'),
+  (0, 'nf_tickets_ticket_status_no_id', 'edge: no trailing id');
+
+-- Tickets span categories 1/2/3, statuses 1/2/3, all three states, and
+-- include one deleted (hidden) ticket. last_modified_date strictly
+-- descends with ticket_id ascending so cursor pagination is exercised
+-- against a deterministic order; tickets 6 and 7 share a
+-- last_modified_date to exercise the tuple-comparison tie-break.
+INSERT INTO xf_nf_tickets_ticket
+  (ticket_id, ticket_ref, title, user_id, username, user_name, user_email, password,
+   start_date, first_message_id, first_message_date, priority, status_id, ticket_state,
+   discussion_state, assigned_user_id, assigned_username, ticket_category_id,
+   last_message_id, last_message_date, last_message_user_id, last_message_username,
+   last_modified_date, reply_count, prefix_id, custom_fields,
+   starter_user_id, starter_username) VALUES
+  (1, 'AA-0001', 'Cannot access milpacs',  400, 'TicketGuy.G', '', '', '',
+   1740000000, 3001, 1740000000, 2, 1, 'open',
+   'visible', 401, 'Helpdesk.H', 1,
+   3003, 1740001200, 401, 'Helpdesk.H',
+   1740700000, 2, 0, '', 400, 'TicketGuy.G'),
+  (2, 'RE-0002', 'Enlistment paperwork',   100, 'Trooper.A', '', '', '',
+   1740100000, 3004, 1740100000, 1, 2, 'pending',
+   'visible', 401, 'Helpdesk.H', 2,
+   3004, 1740100000, 100, 'Trooper.A',
+   1740600000, 0, 1, '', 100, 'Trooper.A'),
+  (3, 'TS-0003', 'TeamSpeak unreachable',  150, 'Trooper.C', '', '', '',
+   1740200000, 3005, 1740200000, 3, 1, 'open',
+   'visible', 0, '', 3,
+   3005, 1740200000, 150, 'Trooper.C',
+   1740500000, 0, 0, '', 150, 'Trooper.C'),
+  (4, 'AA-0004', 'Discharge request',      300, 'Reservist.E', '', '', '',
+   1740300000, 3006, 1740300000, 2, 3, 'resolved',
+   'visible', 401, 'Helpdesk.H', 1,
+   3007, 1740310000, 401, 'Helpdesk.H',
+   1740400000, 1, 0, '', 300, 'Reservist.E'),
+  (5, 'TS-0005', 'Spam ticket',            205, 'Trooper.D', '', '', '',
+   1740350000, 3008, 1740350000, 1, 1, 'open',
+   'deleted', 0, '', 3,
+   3008, 1740350000, 205, 'Trooper.D',
+   1740300000, 0, 0, '', 205, 'Trooper.D'),
+  (6, 'RE-0006', 'Transfer request',       105, 'Trooper.B', '', '', '',
+   1740360000, 3009, 1740360000, 2, 2, 'pending',
+   'visible', 401, 'Helpdesk.H', 2,
+   3009, 1740360000, 105, 'Trooper.B',
+   1740200000, 0, 0, '', 105, 'Trooper.B'),
+  (7, 'AA-0007', 'Award citation query',   301, 'Discharged.F', '', '', '',
+   1740370000, 3010, 1740370000, 1, 3, 'resolved',
+   'visible', 401, 'Helpdesk.H', 1,
+   3010, 1740370000, 301, 'Discharged.F',
+   1740200000, 0, 1, '', 301, 'Discharged.F');
+
+-- Messages for ticket 1 include a hidden reply between two visible ones
+-- (positions stay dense and unique per ticket); single openers for the
+-- other conversational fixtures.
+INSERT INTO xf_nf_tickets_message
+  (message_id, ticket_id, user_id, username, user_name, user_email,
+   message_date, message, message_state, position, reaction_users) VALUES
+  (3001, 1, 400, 'TicketGuy.G', '', '', 1740000000, 'I cannot see my milpacs page.',  'visible', 0, ''),
+  (3002, 1, 401, 'Helpdesk.H',  '', '', 1740000600, '(internal note: checking logs)', 'hidden',  1, ''),
+  (3003, 1, 401, 'Helpdesk.H',  '', '', 1740001200, 'Fixed, please retry.',           'visible', 2, ''),
+  (3004, 2, 100, 'Trooper.A',   '', '', 1740100000, 'Enlistment forms attached.',     'visible', 0, ''),
+  (3005, 3, 150, 'Trooper.C',   '', '', 1740200000, 'TS3 timing out since patch.',    'visible', 0, ''),
+  (3006, 4, 300, 'Reservist.E', '', '', 1740300000, 'Requesting discharge.',          'visible', 0, ''),
+  (3007, 4, 401, 'Helpdesk.H',  '', '', 1740310000, 'Processed. o7',                  'visible', 1, ''),
+  (3008, 5, 205, 'Trooper.D',   '', '', 1740350000, 'buy gold now',                   'visible', 0, ''),
+  (3009, 6, 105, 'Trooper.B',   '', '', 1740360000, 'Requesting transfer to Bravo.',  'visible', 0, ''),
+  (3010, 7, 301, 'Discharged.F','', '', 1740370000, 'Where is my citation?',          'visible', 0, '');
+
+INSERT INTO xf_nf_tickets_ticket_participant (ticket_id, user_id, last_read_date) VALUES
+  (1, 400, 1740001200),
+  (1, 401, 1740001200),
+  (2, 100, 1740100000),
+  (4, 300, 1740310000),
+  (4, 401, 1740310000);
+
+INSERT INTO xf_nf_tickets_ticket_field_value (ticket_id, field_id, field_value) VALUES
+  (1, 'discordId', '111111111111111111'),
+  (2, 'milpacId',  '1'),
+  (3, 'gameServer', 'arma3-tac1');

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -104,3 +104,37 @@ INSERT INTO xf_user_connected_account (user_id, provider, provider_key, extra_da
 INSERT INTO xf_nf_rosters_field_value (relation_id, field_id, field_value) VALUES
   (  1, 'consoleGamertag', 'AlphaGamer'),
   (205, 'consoleGamertag', 'CharlieZulu');
+
+-- ---------------------------------------------------------------------
+-- Forum posts
+-- ---------------------------------------------------------------------
+-- Bulk volume for the hot last-post aggregation
+-- (SELECT user_id, MAX(post_date) FROM xf_post GROUP BY user_id):
+-- 20k posts over 40 distinct posters makes the loose-index-scan vs
+-- full-scan distinction observable in EXPLAIN. Generated through
+-- MariaDB's sequence engine, deterministic by seq.
+INSERT INTO xf_post
+  (post_id, thread_id, user_id, username, post_date, message, position,
+   type_data, reaction_users, vote_score)
+SELECT
+  seq,
+  1 + (seq MOD 200),
+  100 + (seq MOD 40),
+  CONCAT('poster.', 100 + (seq MOD 40)),
+  1500000000 + seq * 60,
+  CONCAT('post body ', seq),
+  seq MOD 50,
+  '', '', 0
+FROM seq_1_to_20000;
+
+-- Targeted posts for roster members outside the bulk poster pool:
+-- Trooper.C (150) and Trooper.D (205) post recently; Reservist.E (300)
+-- last posted long ago (AWOL-shaped); Discharged.F (301) never posted
+-- (left-join NULL case).
+INSERT INTO xf_post
+  (post_id, thread_id, user_id, username, post_date, message, position,
+   type_data, reaction_users, vote_score) VALUES
+  (20001, 1, 150, 'Trooper.C',   1750000000, 'recent post', 0, '', '', 0),
+  (20002, 1, 150, 'Trooper.C',   1750000600, 'most recent post', 1, '', '', 0),
+  (20003, 1, 205, 'Trooper.D',   1750001200, 'recent post', 2, '', '', 0),
+  (20004, 2, 300, 'Reservist.E', 1600000000, 'ancient post', 0, '', '', 0);

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -1,0 +1,26 @@
+-- Fixture data for the MariaDB integration harness (issue #115).
+--
+-- Shaped to exercise the behaviors the downstream test families need:
+--   * members whose milpac relation_id differs from their forum user_id
+--     (the by-id profile route's frozen semantic),
+--   * a post table bulky enough for meaningful EXPLAIN plans on the hot
+--     last-post aggregation,
+--   * tickets spread across categories, statuses, states and visibility,
+--   * active and inactive API keys/scopes.
+
+-- ---------------------------------------------------------------------
+-- Forum users
+-- ---------------------------------------------------------------------
+
+INSERT INTO xf_user
+  (user_id, username, email, language_id, style_id, timezone,
+   user_group_id, secondary_group_ids, permission_combination_id, secret_key)
+VALUES
+  (100, 'Trooper.A',   'a@example.test', 1, 0, 'UTC', 2, '', 1, 'k100'),
+  (105, 'Trooper.B',   'b@example.test', 1, 0, 'UTC', 2, '', 1, 'k105'),
+  (150, 'Trooper.C',   'c@example.test', 1, 0, 'UTC', 2, '', 1, 'k150'),
+  (205, 'Trooper.D',   'd@example.test', 1, 0, 'UTC', 2, '', 1, 'k205'),
+  (300, 'Reservist.E', 'e@example.test', 1, 0, 'UTC', 2, '', 1, 'k300'),
+  (301, 'Discharged.F','f@example.test', 1, 0, 'UTC', 2, '', 1, 'k301'),
+  (400, 'TicketGuy.G', 'g@example.test', 1, 0, 'UTC', 2, '', 1, 'k400'),
+  (401, 'Helpdesk.H',  'h@example.test', 1, 0, 'UTC', 2, '', 1, 'k401');

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -170,10 +170,11 @@ INSERT INTO xf_phrase (language_id, title, phrase_text) VALUES
   (0, 'nf_tickets_ticket_status_no_id', 'edge: no trailing id');
 
 -- Tickets span categories 1/2/3, statuses 1/2/3, all three states, and
--- include one deleted (hidden) ticket. last_modified_date strictly
--- descends with ticket_id ascending so cursor pagination is exercised
--- against a deterministic order; tickets 6 and 7 share a
--- last_modified_date to exercise the tuple-comparison tie-break.
+-- include one deleted (hidden) ticket. last_modified_date descends
+-- (non-strictly) with ticket_id ascending so cursor pagination is
+-- exercised against a deterministic order; tickets 6 and 7 deliberately
+-- share a value to exercise the tuple-comparison tie-break (pinned by
+-- TestFixtures_TicketCursorOrderingInvariant).
 INSERT INTO xf_nf_tickets_ticket
   (ticket_id, ticket_ref, title, user_id, username, user_name, user_email, password,
    start_date, first_message_id, first_message_date, priority, status_id, ticket_state,

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -24,3 +24,83 @@ VALUES
   (301, 'Discharged.F','f@example.test', 1, 0, 'UTC', 2, '', 1, 'k301'),
   (400, 'TicketGuy.G', 'g@example.test', 1, 0, 'UTC', 2, '', 1, 'k400'),
   (401, 'Helpdesk.H',  'h@example.test', 1, 0, 'UTC', 2, '', 1, 'k401');
+
+-- ---------------------------------------------------------------------
+-- Milpacs (NF Rosters)
+-- ---------------------------------------------------------------------
+
+INSERT INTO xf_nf_rosters_rank (rank_id, title, rank_image, display_order, extra_group_ids) VALUES
+  ( 5, 'Sergeant Major',   5, 50,  ''),
+  (15, 'Sergeant',        15, 150, ''),
+  (24, 'Specialist',      24, 240, ''),
+  (27, 'Private',         27, 270, '');
+
+INSERT INTO xf_nf_rosters_position_group (position_group_id, title, display_order) VALUES
+  (1, 'Regimental HQ',              10),
+  (2, 'New Recruits',               20),
+  (3, 'Alpha Company',              30),
+  (4, 'Extended Leave Of Absence',  40);
+
+INSERT INTO xf_nf_rosters_position
+  (position_id, position_title, position_group_id, display_order, extra_group_ids, possible_secondary) VALUES
+  (10, 'Rifleman',         3, 10, '', 0),
+  (11, 'Squad Leader',     3, 20, '', 0),
+  (20, 'Military Police',  1, 30, '', 1),
+  (30, 'Recruit',          2, 40, '', 0),
+  (40, 'ELOA',             4, 50, '', 0);
+
+-- Roster ids follow proto.RosterType: 1 combat, 2 reserve, 6 past members.
+--
+-- The crossing pair is the load-bearing fixture: relation 205 belongs to
+-- forum user 150, while forum user 205 belongs to relation 310. A by-id
+-- lookup of "205" returns different members depending on which key the
+-- query uses — the frozen semantic of the by-id profile route resolves
+-- against relation_id.
+INSERT INTO xf_nf_rosters_user
+  (relation_id, roster_id, user_id, username, position_id, secondary_position_ids,
+   rank_id, bio, uniform_date, added_date, custom_fields) VALUES
+  (  1, 1, 100, 'Trooper.A',    11, '20', 5, '', 1700000000, 1500000000,
+     '{"realName":"Alpha Smith","joinDate":"2015-03-01","promoDate":"2023-05-01","mos":"11B","consoleGamertag":"AlphaGamer"}'),
+  (105, 1, 105, 'Trooper.B',    10, '',  24, '', 0, 1600000000,
+     '{"realName":"Bravo Jones","joinDate":"2019-07-15","promoDate":"2022-01-10","mos":"11B","consoleGamertag":""}'),
+  (205, 1, 150, 'Trooper.C',    10, '',  24, '', 0, 1650000000,
+     '{"realName":"Charlie Brown","joinDate":"2020-02-20","promoDate":"2024-03-12","mos":"68W","consoleGamertag":"CharlieZulu"}'),
+  (310, 1, 205, 'Trooper.D',    30, '',  27, '', 0, 1690000000,
+     '{"realName":"Delta Green","joinDate":"2023-11-05","promoDate":"","mos":"","consoleGamertag":""}'),
+  (320, 2, 300, 'Reservist.E',  40, '',  15, '', 0, 1620000000,
+     '{"realName":"Echo White","joinDate":"2018-06-30","promoDate":"2021-08-19","mos":"11B","consoleGamertag":""}'),
+  (330, 6, 301, 'Discharged.F', 10, '',  27, '', 0, 1550000000,
+     '{"realName":"Foxtrot Black","joinDate":"2016-01-12","promoDate":"2017-02-28","mos":"11B","consoleGamertag":""}');
+
+INSERT INTO xf_nf_rosters_service_record
+  (record_id, relation_id, details, record_date, citation_date, record_type_id) VALUES
+  (1001,   1, 'Promoted to Sergeant Major',    1683000000, 1683000000, 1),
+  (1002,   1, 'Assigned to Squad Leader',      1684000000, 1684000000, 2),
+  (1003, 205, 'Graduated basic training',      1582000000, 1582000000, 5),
+  (1004, 205, 'Promoted to Specialist',        1710000000, 1710000000, 1),
+  (1005, 310, 'Enlisted',                      1699000000, 1699000000, 5),
+  (1006, 320, 'Transferred to reserve',        1630000000, 1630000000, 2),
+  (1007, 330, 'Honorably discharged',          1556000000, 1556000000, 3);
+
+INSERT INTO xf_nf_rosters_award (award_id, title, award_image, award_group_id, display_order) VALUES
+  (1, 'Good Conduct Medal', 1, 1, 10),
+  (2, 'Purple Heart',       2, 1, 20),
+  (3, 'World War I Victory Medal', 3, 2, 30);
+
+INSERT INTO xf_nf_rosters_user_award
+  (record_id, relation_id, award_id, from_user_id, details, award_date, citation_date) VALUES
+  (2001,   1, 1, 401, 'For exemplary conduct',     1685000000, 1685000000),
+  (2002,   1, 2, 401, 'Wounded in action',         1686000000, 1686000000),
+  (2003, 205, 1, 401, 'For exemplary conduct',     1711000000, 1711000000),
+  (2004, 320, 3, 401, 'Campaign participation',    1632000000, 1632000000);
+
+INSERT INTO xf_user_connected_account (user_id, provider, provider_key, extra_data) VALUES
+  (100, 'nfDiscord', '111111111111111111', ''),
+  (100, 'keycloak',  '6f1c0000-aaaa-bbbb-cccc-000000000100', ''),
+  (150, 'nfDiscord', '222222222222222222', ''),
+  (150, 'keycloak',  '6f1c0000-aaaa-bbbb-cccc-000000000150', ''),
+  (205, 'nfDiscord', '333333333333333333', '');
+
+INSERT INTO xf_nf_rosters_field_value (relation_id, field_id, field_value) VALUES
+  (  1, 'consoleGamertag', 'AlphaGamer'),
+  (205, 'consoleGamertag', 'CharlieZulu');

--- a/testdb/schema.sql
+++ b/testdb/schema.sql
@@ -94,3 +94,104 @@ CREATE TABLE `xf_user` (
   KEY `siropu_donation_amount` (`siropu_donation_amount`),
   KEY `siropu_donation_date` (`siropu_donation_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_user_connected_account` (
+  `user_id` int(10) unsigned NOT NULL,
+  `provider` varbinary(25) NOT NULL,
+  `provider_key` varbinary(150) NOT NULL,
+  `extra_data` mediumblob NOT NULL,
+  PRIMARY KEY (`user_id`,`provider`),
+  UNIQUE KEY `provider` (`provider`,`provider_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------
+-- NF Rosters add-on (milpacs)
+-- ---------------------------------------------------------------------
+
+-- NOTE: production carries no index on user_id (PRD #112 proposes
+-- idx_user_id). Do not add one here.
+CREATE TABLE `xf_nf_rosters_user` (
+  `relation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `roster_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `username` text NOT NULL,
+  `position_id` int(10) unsigned NOT NULL,
+  `secondary_position_ids` blob NOT NULL,
+  `rank_id` int(10) unsigned NOT NULL,
+  `bio` text NOT NULL,
+  `uniform_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `added_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `custom_fields` mediumblob NOT NULL,
+  PRIMARY KEY (`relation_id`),
+  KEY `idx_roster_id` (`roster_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_rosters_rank` (
+  `rank_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(50) NOT NULL,
+  `rank_image` int(10) unsigned NOT NULL DEFAULT 0,
+  `display_order` int(10) unsigned NOT NULL DEFAULT 0,
+  `extra_group_ids` blob NOT NULL,
+  PRIMARY KEY (`rank_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_rosters_position` (
+  `position_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `position_title` varchar(50) NOT NULL,
+  `position_group_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `display_order` int(10) unsigned NOT NULL DEFAULT 0,
+  `materialized_order` int(10) unsigned NOT NULL DEFAULT 0,
+  `extra_group_ids` blob NOT NULL,
+  `possible_secondary` tinyint(3) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`position_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_rosters_position_group` (
+  `position_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(50) NOT NULL,
+  `display_order` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`position_group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_rosters_award` (
+  `award_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(150) NOT NULL,
+  `award_image` int(10) unsigned NOT NULL DEFAULT 0,
+  `award_group_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `display_order` int(10) unsigned NOT NULL DEFAULT 0,
+  `materialized_order` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`award_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- NOTE: production carries no secondary index (PRD #112 proposes
+-- idx_relation_id). Do not add one here.
+CREATE TABLE `xf_nf_rosters_user_award` (
+  `record_id` int(11) NOT NULL AUTO_INCREMENT,
+  `relation_id` int(11) NOT NULL,
+  `award_id` int(11) NOT NULL,
+  `from_user_id` int(11) NOT NULL,
+  `details` text NOT NULL,
+  `award_date` int(11) NOT NULL DEFAULT 0,
+  `citation_date` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`record_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- NOTE: production carries no secondary index (PRD #112 proposes
+-- idx_relation_id). Do not add one here.
+CREATE TABLE `xf_nf_rosters_service_record` (
+  `record_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `relation_id` int(10) unsigned NOT NULL,
+  `details` text DEFAULT NULL,
+  `record_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `citation_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `record_type_id` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`record_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_rosters_field_value` (
+  `relation_id` int(10) unsigned NOT NULL,
+  `field_id` varbinary(25) NOT NULL,
+  `field_value` mediumtext NOT NULL,
+  PRIMARY KEY (`relation_id`,`field_id`),
+  KEY `field_id` (`field_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/testdb/schema.sql
+++ b/testdb/schema.sql
@@ -95,6 +95,41 @@ CREATE TABLE `xf_user` (
   KEY `siropu_donation_date` (`siropu_donation_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- NOTE: stock XenForo indexes only. Production carries no
+-- (user_id, post_date) composite — PRD #112 proposes one
+-- (user_id_post_date) to unlock the loose index scan on the hot
+-- last-post aggregation. Do not add it here.
+CREATE TABLE `xf_post` (
+  `post_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `thread_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `username` varchar(50) NOT NULL,
+  `post_date` int(10) unsigned NOT NULL,
+  `message` mediumtext NOT NULL,
+  `ip_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `message_state` enum('visible','moderated','deleted') NOT NULL DEFAULT 'visible',
+  `attach_count` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `position` int(10) unsigned NOT NULL,
+  `type_data` mediumblob NOT NULL,
+  `reaction_score` int(11) NOT NULL DEFAULT 0,
+  `reactions` blob DEFAULT NULL,
+  `reaction_users` blob NOT NULL,
+  `vote_score` int(11) NOT NULL,
+  `vote_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `warning_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `warning_message` varchar(255) NOT NULL DEFAULT '',
+  `last_edit_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_edit_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `edit_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `embed_metadata` blob DEFAULT NULL,
+  PRIMARY KEY (`post_id`),
+  KEY `thread_id_post_date` (`thread_id`,`post_date`),
+  KEY `thread_id_position` (`thread_id`,`position`),
+  KEY `thread_id_score_date` (`thread_id`,`vote_score`,`post_date`),
+  KEY `user_id` (`user_id`),
+  KEY `post_date` (`post_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 CREATE TABLE `xf_user_connected_account` (
   `user_id` int(10) unsigned NOT NULL,
   `provider` varbinary(25) NOT NULL,

--- a/testdb/schema.sql
+++ b/testdb/schema.sql
@@ -1,0 +1,96 @@
+-- Forum-shaped schema for the MariaDB integration harness (issue #115).
+--
+-- Tables are cribbed from the production XenForo database (MariaDB 11.5)
+-- and cover exactly what the API reads: the NF Rosters add-on tables, the
+-- NF Tickets add-on tables, the Cav7 ApiKeyManager tables, and the core
+-- xf_user / xf_user_connected_account / xf_post / xf_phrase tables.
+--
+-- Index fidelity matters here: the harness carries production's stock
+-- indexes and must NOT carry the four indexes proposed by PRD #112
+-- (xf_post user_id_post_date; idx_relation_id on
+-- xf_nf_rosters_service_record and xf_nf_rosters_user_award;
+-- idx_user_id on xf_nf_rosters_user). Their absence is what makes the
+-- "red" EXPLAIN plans of the index slice (#119) reproducible. Do not add
+-- them to this file.
+
+-- ---------------------------------------------------------------------
+-- Core XenForo
+-- ---------------------------------------------------------------------
+
+CREATE TABLE `xf_user` (
+  `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `username` varchar(50) NOT NULL,
+  `username_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `username_date_visible` int(10) unsigned NOT NULL DEFAULT 0,
+  `email` varchar(120) NOT NULL,
+  `custom_title` varchar(50) NOT NULL DEFAULT '',
+  `language_id` int(10) unsigned NOT NULL,
+  `style_id` int(10) unsigned NOT NULL COMMENT '0 = use system default',
+  `style_variation` varchar(50) NOT NULL DEFAULT '',
+  `timezone` varchar(50) NOT NULL COMMENT 'Example: ''Europe/London''',
+  `visible` tinyint(3) unsigned NOT NULL DEFAULT 1 COMMENT 'Show browsing activity to others',
+  `activity_visible` tinyint(3) unsigned NOT NULL DEFAULT 1,
+  `user_group_id` int(10) unsigned NOT NULL,
+  `secondary_group_ids` varbinary(255) NOT NULL,
+  `display_style_group_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'User group ID that provides user styling',
+  `permission_combination_id` int(10) unsigned NOT NULL,
+  `message_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `question_solution_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `conversations_unread` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `register_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_activity` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_summary_email_date` int(10) unsigned DEFAULT NULL,
+  `trophy_points` int(10) unsigned NOT NULL DEFAULT 0,
+  `alerts_unviewed` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `alerts_unread` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `avatar_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `avatar_width` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `avatar_height` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `avatar_highdpi` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `avatar_optimized` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `gravatar` varchar(120) NOT NULL DEFAULT '',
+  `user_state` enum('valid','email_confirm','email_confirm_edit','moderated','email_bounce','rejected','disabled') NOT NULL DEFAULT 'valid',
+  `security_lock` enum('','change','reset') NOT NULL DEFAULT '',
+  `is_moderator` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `is_admin` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `is_banned` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `reaction_score` int(11) NOT NULL DEFAULT 0,
+  `vote_score` int(11) NOT NULL DEFAULT 0,
+  `warning_points` int(10) unsigned NOT NULL DEFAULT 0,
+  `is_staff` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `secret_key` varbinary(32) NOT NULL,
+  `privacy_policy_accepted` int(10) unsigned NOT NULL DEFAULT 0,
+  `terms_accepted` int(10) unsigned NOT NULL DEFAULT 0,
+  `nf_calendar_event_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `teamspeak_identity_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `dbtech_donate_total` double(10,2) NOT NULL DEFAULT 0.00,
+  `dbtech_donate_public` double(10,2) NOT NULL DEFAULT 0.00,
+  `dbtech_donate_anonymous` double(10,2) NOT NULL DEFAULT 0.00,
+  `nf_tickets_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `nf_tickets_unread` int(10) unsigned NOT NULL DEFAULT 0,
+  `snog_forms` blob DEFAULT NULL,
+  `siropu_donation_count` int(10) unsigned NOT NULL DEFAULT 1,
+  `siropu_donation_amount` decimal(10,2) NOT NULL DEFAULT 0.00,
+  `siropu_donation_date` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `username` (`username`),
+  KEY `email` (`email`),
+  KEY `permission_combination_id` (`permission_combination_id`),
+  KEY `user_state` (`user_state`),
+  KEY `last_activity` (`last_activity`),
+  KEY `last_summary_email_date` (`last_summary_email_date`),
+  KEY `message_count` (`message_count`),
+  KEY `trophy_points` (`trophy_points`),
+  KEY `reaction_score` (`reaction_score`),
+  KEY `register_date` (`register_date`),
+  KEY `question_solution_count` (`question_solution_count`),
+  KEY `vote_score` (`vote_score`),
+  KEY `staff_username` (`is_staff`,`username`),
+  KEY `nf_calendar_event_count` (`nf_calendar_event_count`),
+  KEY `teamspeak_identity_count` (`teamspeak_identity_count`),
+  KEY `nf_tickets_count` (`nf_tickets_count`),
+  KEY `nf_tickets_unread` (`nf_tickets_unread`),
+  KEY `siropu_donation_count` (`siropu_donation_count`),
+  KEY `siropu_donation_amount` (`siropu_donation_amount`),
+  KEY `siropu_donation_date` (`siropu_donation_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/testdb/schema.sql
+++ b/testdb/schema.sql
@@ -380,3 +380,41 @@ CREATE TABLE `xf_phrase` (
   UNIQUE KEY `title` (`title`,`language_id`),
   KEY `language_id_global_cache` (`language_id`,`global_cache`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------
+-- Cav7 ApiKeyManager add-on
+-- ---------------------------------------------------------------------
+
+CREATE TABLE `xf_cav7_api_key` (
+  `key_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL,
+  `key_hash` varbinary(32) NOT NULL,
+  `key_prefix` varchar(12) NOT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  `created_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_used_date` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`key_id`),
+  UNIQUE KEY `key_hash` (`key_hash`),
+  UNIQUE KEY `user_id` (`user_id`),
+  KEY `is_active` (`is_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `xf_cav7_api_key_scope` (
+  `key_id` int(10) unsigned NOT NULL,
+  `scope_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`key_id`,`scope_id`),
+  KEY `scope_id` (`scope_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `xf_cav7_api_key_scope_def` (
+  `scope_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `scope_name` varchar(50) NOT NULL,
+  `title` varchar(100) NOT NULL,
+  `description` text NOT NULL,
+  `is_active` tinyint(1) NOT NULL DEFAULT 1,
+  `display_order` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_group_ids` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`scope_id`),
+  UNIQUE KEY `scope_name` (`scope_name`),
+  KEY `is_active_display_order` (`is_active`,`display_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/testdb/schema.sql
+++ b/testdb/schema.sql
@@ -230,3 +230,153 @@ CREATE TABLE `xf_nf_rosters_field_value` (
   PRIMARY KEY (`relation_id`,`field_id`),
   KEY `field_id` (`field_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------
+-- NF Tickets add-on
+-- ---------------------------------------------------------------------
+
+CREATE TABLE `xf_nf_tickets_ticket` (
+  `ticket_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `ticket_ref` varchar(25) NOT NULL,
+  `title` varchar(150) NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `username` varchar(50) NOT NULL,
+  `user_name` varchar(50) NOT NULL,
+  `user_email` varchar(120) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `start_date` int(10) unsigned NOT NULL,
+  `first_message_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `first_message_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `first_message_reaction_score` int(11) NOT NULL DEFAULT 0,
+  `first_message_reactions` blob DEFAULT NULL,
+  `priority` tinyint(3) unsigned DEFAULT NULL,
+  `status_id` int(10) unsigned NOT NULL,
+  `ticket_state` enum('open','pending','resolved') NOT NULL,
+  `ticket_locked` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `discussion_state` enum('visible','moderated','deleted','shadow_ban') NOT NULL DEFAULT 'visible',
+  `discussion_type` varchar(25) NOT NULL DEFAULT '',
+  `assigned_user_id` int(10) unsigned NOT NULL,
+  `assigned_username` varchar(50) NOT NULL DEFAULT ' ',
+  `ticket_category_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_message_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_message_date` int(10) unsigned NOT NULL,
+  `last_message_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_message_username` varchar(50) NOT NULL DEFAULT '',
+  `last_modified_date` int(10) unsigned NOT NULL,
+  `last_modified_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_modified_username` varchar(50) NOT NULL DEFAULT '',
+  `last_status_change_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `reply_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `prefix_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `custom_fields` mediumblob NOT NULL,
+  `thread_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `starter_user_id` int(10) unsigned NOT NULL,
+  `starter_username` varchar(50) NOT NULL,
+  `assigner_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `assigner_username` varchar(50) NOT NULL DEFAULT ' ',
+  PRIMARY KEY (`ticket_id`),
+  KEY `ticket_ref` (`ticket_ref`),
+  KEY `last_modified_date` (`last_modified_date`),
+  KEY `ticket_category_assigned_user` (`ticket_category_id`,`assigned_user_id`),
+  KEY `user_id_modified` (`last_modified_user_id`,`last_modified_date`),
+  KEY `thread_id` (`thread_id`),
+  KEY `starter_user_last_message_date` (`starter_user_id`,`last_message_date`),
+  KEY `user_last_message_date` (`user_id`,`last_message_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_tickets_message` (
+  `message_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `ticket_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `username` varchar(50) NOT NULL,
+  `user_name` varchar(50) NOT NULL,
+  `user_email` varchar(120) NOT NULL,
+  `message_date` int(10) unsigned NOT NULL,
+  `message` mediumtext NOT NULL,
+  `ip_id` bigint(20) unsigned NOT NULL DEFAULT 0,
+  `message_state` enum('visible','hidden','moderated','deleted') NOT NULL,
+  `attach_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `position` int(10) unsigned NOT NULL,
+  `reaction_score` int(11) NOT NULL DEFAULT 0,
+  `reactions` blob DEFAULT NULL,
+  `reaction_users` blob NOT NULL,
+  `warning_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `warning_message` varchar(255) NOT NULL DEFAULT '',
+  `last_edit_date` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_edit_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `edit_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `embed_metadata` blob DEFAULT NULL,
+  `anonymized` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `user_agent` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`message_id`),
+  KEY `message_id_position` (`position`,`message_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_tickets_ticket_participant` (
+  `ticket_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL,
+  `last_read_date` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`ticket_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_tickets_ticket_field_value` (
+  `ticket_id` int(10) unsigned NOT NULL,
+  `field_id` varbinary(25) NOT NULL,
+  `field_value` mediumtext NOT NULL,
+  PRIMARY KEY (`ticket_id`,`field_id`),
+  KEY `field_id` (`field_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_nf_tickets_category` (
+  `ticket_category_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(100) NOT NULL,
+  `description` text NOT NULL,
+  `parent_category_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `depth` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `lft` int(10) unsigned NOT NULL DEFAULT 0,
+  `rgt` int(10) unsigned NOT NULL DEFAULT 0,
+  `display_order` int(10) unsigned NOT NULL DEFAULT 0,
+  `ticket_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_ticket` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_ticket_title` varchar(150) NOT NULL,
+  `last_ticket_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `breadcrumb_data` blob NOT NULL,
+  `thread_node_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `thread_prefix_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `field_cache` mediumblob NOT NULL,
+  `priority_selection` int(10) unsigned NOT NULL DEFAULT 1,
+  `empty_message_allowed` int(10) unsigned NOT NULL DEFAULT 0,
+  `hide_message_field` int(10) unsigned NOT NULL DEFAULT 0,
+  `category_emails` text NOT NULL,
+  `incoming_ticket_email_settings` mediumblob DEFAULT NULL,
+  `prefix_cache` mediumblob NOT NULL,
+  `default_prefix_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `require_prefix` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `anonymous_user_id` int(10) unsigned DEFAULT NULL,
+  `count_messages` tinyint(3) unsigned NOT NULL DEFAULT 1,
+  `nf_discord_channel_id` varbinary(255) NOT NULL DEFAULT '',
+  `nf_discord_include_replies` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `open_ticket_count` int(10) unsigned NOT NULL DEFAULT 0,
+  `display_in_chooser` tinyint(3) unsigned NOT NULL DEFAULT 1,
+  `allow_opening` tinyint(3) unsigned NOT NULL DEFAULT 1,
+  `notify_emails` text NOT NULL,
+  `ess_limit_autocomplete` enum('all','this','this_and_children','exclude','exclude_and_children') NOT NULL DEFAULT 'this_and_children',
+  PRIMARY KEY (`ticket_category_id`),
+  KEY `parent_category_id_lft` (`ticket_category_id`,`lft`),
+  KEY `lft_rgt` (`lft`,`rgt`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `xf_phrase` (
+  `phrase_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `language_id` int(10) unsigned NOT NULL,
+  `title` varbinary(100) NOT NULL,
+  `phrase_text` mediumtext NOT NULL,
+  `global_cache` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `addon_id` varbinary(50) NOT NULL DEFAULT '',
+  `version_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `version_string` varchar(30) NOT NULL DEFAULT '',
+  PRIMARY KEY (`phrase_id`),
+  UNIQUE KEY `title` (`title`,`language_id`),
+  KEY `language_id_global_cache` (`language_id`,`global_cache`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/testdb/seam_test.go
+++ b/testdb/seam_test.go
@@ -1,0 +1,57 @@
+package testdb_test
+
+import (
+	"testing"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/testdb"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// The harness is the SQL seam for the datastore test families. This
+// smoke runs the REAL datastore code path end-to-end against the seeded
+// schema, proving the schema's tables, columns and joins line up with
+// what the application actually queries — including the frozen by-id
+// semantic: profile id 205 resolves against the milpac relation key and
+// returns forum user 150, not forum user 205.
+func TestSeam_DatastoreResolvesProfileByRelationKey(t *testing.T) {
+	_, dsn := testdb.Open(t)
+
+	gormDB, err := gorm.Open(gormmysql.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("dialing harness database through gorm: %v", err)
+	}
+	ds := datastores.Mysql{Db: gormDB}
+
+	profiles, err := ds.FindProfilesById(205)
+	if err != nil {
+		t.Fatalf("FindProfilesById(205): %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("expected exactly one profile, got %d", len(profiles))
+	}
+
+	got := profiles[0]
+	if got.User.UserId != 150 {
+		t.Errorf("profile id 205 must resolve via relation key to forum user 150, got %d", got.User.UserId)
+	}
+	if got.User.Username != "Trooper.C" {
+		t.Errorf("expected username Trooper.C, got %q", got.User.Username)
+	}
+	if got.RealName != "Charlie Brown" {
+		t.Errorf("expected custom-field real name to unmarshal, got %q", got.RealName)
+	}
+	if len(got.Records) == 0 {
+		t.Error("expected preloaded service records")
+	}
+	if len(got.Awards) == 0 {
+		t.Error("expected preloaded awards")
+	}
+	if got.DiscordId == "" {
+		t.Error("expected connected-account discord id")
+	}
+}

--- a/testdb/testdb.go
+++ b/testdb/testdb.go
@@ -26,6 +26,7 @@ import (
 	"encoding/hex"
 	"os"
 	"testing"
+	"time"
 
 	_ "embed"
 
@@ -109,6 +110,9 @@ func Open(t *testing.T) (*sql.DB, string) {
 
 // dsn builds a go-sql-driver DSN for the harness server. multiStatements
 // lets the embedded schema and fixture scripts run as single Exec calls.
+// The timeouts keep a black-holed TESTDB_ADDR from hanging until the go
+// test panic dump: the connection errors promptly instead, so Open's
+// well-worded t.Fatalf messages fire.
 func dsn(addr, database string) string {
 	cfg := mysql.NewConfig()
 	cfg.User = "root"
@@ -117,6 +121,11 @@ func dsn(addr, database string) string {
 	cfg.Addr = addr
 	cfg.DBName = database
 	cfg.MultiStatements = true
+	cfg.Timeout = 5 * time.Second
+	// Generous ceilings: the slowest legitimate operation is seeding the
+	// 20k-row post fixture in one multi-statement Exec (<1s in practice).
+	cfg.ReadTimeout = 30 * time.Second
+	cfg.WriteTimeout = 30 * time.Second
 	return cfg.FormatDSN()
 }
 

--- a/testdb/testdb.go
+++ b/testdb/testdb.go
@@ -37,6 +37,14 @@ import (
 // guards nothing: the server only ever holds disposable fixture data.
 const rootPassword = "harness"
 
+// ActiveAPIKey is the raw bearer key seeded with active scopes
+// ("read", "read:tickets"); its hash lives in xf_cav7_api_key.
+// RevokedAPIKey is seeded inactive and must fail validation.
+const (
+	ActiveAPIKey  = "cav7_harness_active"
+	RevokedAPIKey = "cav7_harness_revoked"
+)
+
 //go:embed schema.sql
 var schemaSQL string
 

--- a/testdb/testdb.go
+++ b/testdb/testdb.go
@@ -79,7 +79,12 @@ func Open(t *testing.T) (*sql.DB, string) {
 		t.Fatalf("testdb: creating database %s on %s: %v", name, addr, err)
 	}
 	t.Cleanup(func() {
-		_, _ = admin.Exec("DROP DATABASE IF EXISTS " + name)
+		// A swallowed failure here leaks the database into the
+		// long-lived harness server's tmpfs until unrelated tests
+		// start failing; make the leak loud and attributable.
+		if _, err := admin.Exec("DROP DATABASE IF EXISTS " + name); err != nil {
+			t.Errorf("testdb: dropping database %s on %s (leaked into the harness server): %v", name, addr, err)
+		}
 		admin.Close()
 	})
 

--- a/testdb/testdb.go
+++ b/testdb/testdb.go
@@ -1,0 +1,117 @@
+// Package testdb is the dockerized MariaDB integration-test harness.
+//
+// It provides real-database seams for tests that need actual MariaDB
+// behavior (EXPLAIN plans, optimizer choices, SQL semantics) instead of
+// sqlmock. The schema is forum-shaped: it carries exactly the XenForo
+// and add-on tables the API reads, cribbed from production DDL, with
+// production's stock indexes — and deliberately WITHOUT the four indexes
+// proposed by the "Goodbye gRPC" PRD (#112), so that "red" EXPLAIN plans
+// stay reproducible:
+//
+//   - xf_post: no user_id_post_date composite
+//   - xf_nf_rosters_service_record: no idx_relation_id
+//   - xf_nf_rosters_user_award: no idx_relation_id
+//   - xf_nf_rosters_user: no idx_user_id
+//
+// Tests opt in via the TESTDB_ADDR environment variable (host:port of a
+// MariaDB server, e.g. 127.0.0.1:3310). When it is unset, Open skips the
+// calling test, so a plain `go test ./...` stays green without docker.
+// Use `make test-integration` to spin up the dockerized server and run
+// the full suite against it.
+package testdb
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	_ "embed"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// rootPassword is the throwaway root password of the harness MariaDB
+// server (set in testdb/compose.yaml and the CI service container). It
+// guards nothing: the server only ever holds disposable fixture data.
+const rootPassword = "harness"
+
+//go:embed schema.sql
+var schemaSQL string
+
+//go:embed fixtures.sql
+var fixturesSQL string
+
+// Open creates a fresh database on the harness MariaDB server, applies
+// the forum-shaped schema and fixtures, and returns an open handle plus
+// the DSN of the new database (for callers that dial their own
+// connection, e.g. through gorm). The database is uniquely named per
+// call, so tests may freely mutate it — including DDL such as CREATE
+// INDEX — without affecting other tests. It is dropped on test cleanup.
+//
+// Skips the calling test when TESTDB_ADDR is unset; fails it when the
+// variable is set but the server is unreachable or seeding fails.
+func Open(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+
+	addr := os.Getenv("TESTDB_ADDR")
+	if addr == "" {
+		t.Skip("TESTDB_ADDR not set; skipping MariaDB integration test (run `make test-integration`)")
+	}
+
+	name := "testdb_" + randomSuffix(t)
+
+	admin, err := sql.Open("mysql", dsn(addr, ""))
+	if err != nil {
+		t.Fatalf("testdb: opening admin connection: %v", err)
+	}
+	if _, err := admin.Exec("CREATE DATABASE " + name); err != nil {
+		admin.Close()
+		t.Fatalf("testdb: creating database %s on %s: %v", name, addr, err)
+	}
+	t.Cleanup(func() {
+		_, _ = admin.Exec("DROP DATABASE IF EXISTS " + name)
+		admin.Close()
+	})
+
+	dbDSN := dsn(addr, name)
+	db, err := sql.Open("mysql", dbDSN)
+	if err != nil {
+		t.Fatalf("testdb: opening database %s: %v", name, err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	for _, script := range []struct{ label, sql string }{
+		{"schema", schemaSQL},
+		{"fixtures", fixturesSQL},
+	} {
+		if _, err := db.Exec(script.sql); err != nil {
+			t.Fatalf("testdb: applying %s: %v", script.label, err)
+		}
+	}
+
+	return db, dbDSN
+}
+
+// dsn builds a go-sql-driver DSN for the harness server. multiStatements
+// lets the embedded schema and fixture scripts run as single Exec calls.
+func dsn(addr, database string) string {
+	cfg := mysql.NewConfig()
+	cfg.User = "root"
+	cfg.Passwd = rootPassword
+	cfg.Net = "tcp"
+	cfg.Addr = addr
+	cfg.DBName = database
+	cfg.MultiStatements = true
+	return cfg.FormatDSN()
+}
+
+func randomSuffix(t *testing.T) string {
+	t.Helper()
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("testdb: generating database name: %v", err)
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -1,6 +1,8 @@
 package testdb_test
 
 import (
+	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/7cav/api/testdb"
@@ -82,5 +84,104 @@ func TestFixtures_MemberRelationsResolve(t *testing.T) {
 		if n == 0 {
 			t.Errorf("expected seeded %s, got none", q.label)
 		}
+	}
+}
+
+// The harness schema must not pre-create the four indexes proposed by
+// PRD #112 — their absence is what keeps the "red" EXPLAIN plans of the
+// index slice reproducible.
+func TestSchema_CarriesNoPRDIndexes(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	for _, idx := range []struct{ table, index string }{
+		{"xf_post", "user_id_post_date"},
+		{"xf_nf_rosters_service_record", "idx_relation_id"},
+		{"xf_nf_rosters_user_award", "idx_relation_id"},
+		{"xf_nf_rosters_user", "idx_user_id"},
+	} {
+		var n int
+		err := db.QueryRow(
+			`SELECT COUNT(*) FROM information_schema.statistics
+			 WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+			idx.table, idx.index,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("checking index %s.%s: %v", idx.table, idx.index, err)
+		}
+		if n != 0 {
+			t.Errorf("PRD index %s on %s must not exist in the harness schema", idx.index, idx.table)
+		}
+	}
+}
+
+// hotLastPostAggregation is the subquery driving the lite-roster
+// last-forum-post column and the AWOL report — the PRD's measured
+// hotspot (4.2s -> 28ms once MariaDB can run it as a loose index scan).
+const hotLastPostAggregation = `SELECT user_id, MAX(post_date) FROM xf_post GROUP BY user_id`
+
+// groupByOptimization returns the Extra column of the EXPLAIN row for
+// the hot aggregation, which is where MariaDB reports loose index scans
+// ("Using index for group-by").
+func groupByOptimization(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	rows, err := db.Query(`EXPLAIN ` + hotLastPostAggregation)
+	if err != nil {
+		t.Fatalf("explaining hot aggregation: %v", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("reading EXPLAIN columns: %v", err)
+	}
+	if !rows.Next() {
+		t.Fatal("EXPLAIN returned no rows")
+	}
+	vals := make([]sql.NullString, len(cols))
+	scan := make([]any, len(cols))
+	for i := range vals {
+		scan[i] = &vals[i]
+	}
+	if err := rows.Scan(scan...); err != nil {
+		t.Fatalf("scanning EXPLAIN row: %v", err)
+	}
+	for i, c := range cols {
+		if c == "Extra" {
+			return vals[i].String
+		}
+	}
+	t.Fatal("EXPLAIN output has no Extra column")
+	return ""
+}
+
+// The post fixtures must be voluminous enough that the loose-index-scan
+// vs full-scan distinction is observable: the seeded schema (no PRD
+// composite) must NOT plan a loose index scan, and adding the composite
+// in a throwaway database must flip the very same query to one.
+func TestFixtures_HotAggregationRedPlanReproducible(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	var posts int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM xf_post`).Scan(&posts); err != nil {
+		t.Fatalf("counting posts: %v", err)
+	}
+	if posts < 10000 {
+		t.Errorf("expected at least 10000 seeded posts for meaningful plans, got %d", posts)
+	}
+
+	const looseScan = "Using index for group-by"
+
+	if extra := groupByOptimization(t, db); strings.Contains(extra, looseScan) {
+		t.Errorf("red plan not reproducible: hot aggregation already runs as loose index scan (Extra=%q)", extra)
+	}
+
+	// Sanity in this test's own disposable database: the PRD composite
+	// flips the same query to a loose index scan, proving the fixture
+	// volume makes the distinction meaningful.
+	if _, err := db.Exec(`CREATE INDEX user_id_post_date ON xf_post (user_id, post_date)`); err != nil {
+		t.Fatalf("creating PRD composite in disposable database: %v", err)
+	}
+	if extra := groupByOptimization(t, db); !strings.Contains(extra, looseScan) {
+		t.Errorf("with the PRD composite the hot aggregation should plan a loose index scan, got Extra=%q", extra)
 	}
 }

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -138,6 +138,35 @@ func TestFixtures_ApiKeysResolveScopes(t *testing.T) {
 	}
 }
 
+// Each Open call must yield its own database so tests can run DDL
+// (e.g. CREATE INDEX for green-plan comparisons) without leaking into
+// sibling tests.
+func TestOpen_IsolatesDatabasesPerCall(t *testing.T) {
+	db1, dsn1 := testdb.Open(t)
+	db2, dsn2 := testdb.Open(t)
+
+	if dsn1 == dsn2 {
+		t.Fatalf("two Open calls returned the same DSN: %s", dsn1)
+	}
+
+	if _, err := db1.Exec(`CREATE INDEX idx_relation_id ON xf_nf_rosters_service_record (relation_id)`); err != nil {
+		t.Fatalf("creating index in first database: %v", err)
+	}
+
+	var n int
+	if err := db2.QueryRow(
+		`SELECT COUNT(*) FROM information_schema.statistics
+		 WHERE table_schema = DATABASE()
+		   AND table_name = 'xf_nf_rosters_service_record'
+		   AND index_name = 'idx_relation_id'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("checking second database: %v", err)
+	}
+	if n != 0 {
+		t.Error("DDL in one Open database leaked into another")
+	}
+}
+
 // The harness schema must not pre-create the four indexes proposed by
 // PRD #112 — their absence is what keeps the "red" EXPLAIN plans of the
 // index slice reproducible.

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -138,6 +138,28 @@ func TestFixtures_ApiKeysResolveScopes(t *testing.T) {
 	}
 }
 
+// testdb.RevokedAPIKey and the seeded inactive key row are duplicated
+// raw strings (constant in testdb.go, literal in fixtures.sql). If they
+// drift, downstream negative-path tests pass for the wrong reason: the
+// key fails validation because it's unknown, not because it's revoked.
+// Pin them together: the exported constant must hash to exactly one
+// seeded INACTIVE row.
+func TestFixtures_RevokedAPIKeyResolvesToInactiveRow(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM xf_cav7_api_key
+		 WHERE key_hash = UNHEX(SHA2(?, 256)) AND is_active = 0`,
+		testdb.RevokedAPIKey,
+	).Scan(&n); err != nil {
+		t.Fatalf("resolving revoked key: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("testdb.RevokedAPIKey must hash to exactly one inactive seeded row, got %d (constant and fixtures.sql drifted?)", n)
+	}
+}
+
 // Each Open call must yield its own database so tests can run DDL
 // (e.g. CREATE INDEX for green-plan comparisons) without leaking into
 // sibling tests.

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -1,0 +1,20 @@
+package testdb_test
+
+import (
+	"testing"
+
+	"github.com/7cav/api/testdb"
+)
+
+// Tracer: Open hands back a connection to a seeded, forum-shaped database.
+func TestOpen_YieldsSeededDatabase(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM xf_user`).Scan(&n); err != nil {
+		t.Fatalf("querying xf_user: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected seeded xf_user rows, got none")
+	}
+}

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -185,3 +185,93 @@ func TestFixtures_HotAggregationRedPlanReproducible(t *testing.T) {
 		t.Errorf("with the PRD composite the hot aggregation should plan a loose index scan, got Extra=%q", extra)
 	}
 }
+
+// Ticket fixtures must span categories, statuses and states so the
+// tickets datastore tests (#120) can exercise every filter knob:
+// multiple categories (with a parent/child pair for subtree expansion),
+// multiple status_ids, all three ticket_states, and at least one
+// non-visible ticket for the include_hidden switch.
+func TestFixtures_TicketsSpanCategoriesAndStatuses(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	counts := map[string]string{
+		"distinct ticket categories":   `SELECT COUNT(DISTINCT ticket_category_id) FROM xf_nf_tickets_ticket`,
+		"distinct status ids":          `SELECT COUNT(DISTINCT status_id) FROM xf_nf_tickets_ticket`,
+		"distinct ticket states":       `SELECT COUNT(DISTINCT ticket_state) FROM xf_nf_tickets_ticket`,
+		"child categories (depth > 0)": `SELECT COUNT(*) FROM xf_nf_tickets_category WHERE parent_category_id > 0`,
+	}
+	for label, q := range counts {
+		var n int
+		if err := db.QueryRow(q).Scan(&n); err != nil {
+			t.Fatalf("counting %s: %v", label, err)
+		}
+		if n < 2 && label != "child categories (depth > 0)" {
+			t.Errorf("expected at least 2 %s, got %d", label, n)
+		}
+		if n < 1 {
+			t.Errorf("expected at least 1 of %s, got %d", label, n)
+		}
+	}
+
+	var hidden int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM xf_nf_tickets_ticket WHERE discussion_state <> 'visible'`,
+	).Scan(&hidden); err != nil {
+		t.Fatalf("counting hidden tickets: %v", err)
+	}
+	if hidden == 0 {
+		t.Error("expected at least one non-visible ticket for the include_hidden switch")
+	}
+
+	// Nested-set integrity: every child sits inside its parent's lft/rgt
+	// span — the reference cache's subtree expansion depends on it.
+	var broken int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM xf_nf_tickets_category c
+		 JOIN xf_nf_tickets_category p ON p.ticket_category_id = c.parent_category_id
+		 WHERE c.lft <= p.lft OR c.rgt >= p.rgt`,
+	).Scan(&broken); err != nil {
+		t.Fatalf("checking nested-set integrity: %v", err)
+	}
+	if broken != 0 {
+		t.Errorf("%d categories violate nested-set containment", broken)
+	}
+}
+
+// Every ticket must resolve its reference-cached names: status,
+// priority and prefix phrases, plus its category row. Messages must
+// include a hidden one (message_state filter), and participants and
+// field values must be present.
+func TestFixtures_TicketRelationsResolve(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	for _, q := range []struct{ label, sql string }{
+		{"status phrase", `SELECT COUNT(*) FROM xf_nf_tickets_ticket tk LEFT JOIN xf_phrase ph ON ph.title = CONCAT('nf_tickets_ticket_status.', tk.status_id) WHERE ph.phrase_id IS NULL`},
+		{"category row", `SELECT COUNT(*) FROM xf_nf_tickets_ticket tk LEFT JOIN xf_nf_tickets_category c ON c.ticket_category_id = tk.ticket_category_id WHERE c.ticket_category_id IS NULL`},
+	} {
+		var n int
+		if err := db.QueryRow(q.sql).Scan(&n); err != nil {
+			t.Fatalf("checking %s linkage: %v", q.label, err)
+		}
+		if n != 0 {
+			t.Errorf("%d tickets with unresolvable %s", n, q.label)
+		}
+	}
+
+	for _, q := range []struct{ label, sql string }{
+		{"visible messages", `SELECT COUNT(*) FROM xf_nf_tickets_message WHERE message_state = 'visible'`},
+		{"hidden messages", `SELECT COUNT(*) FROM xf_nf_tickets_message WHERE message_state <> 'visible'`},
+		{"participants", `SELECT COUNT(*) FROM xf_nf_tickets_ticket_participant`},
+		{"ticket field values", `SELECT COUNT(*) FROM xf_nf_tickets_ticket_field_value`},
+		{"priority phrases", `SELECT COUNT(*) FROM xf_phrase WHERE title LIKE 'nf_tickets_ticket_priority.%'`},
+		{"prefix phrases", `SELECT COUNT(*) FROM xf_phrase WHERE title LIKE 'nf_tickets_ticket_prefix.%'`},
+	} {
+		var n int
+		if err := db.QueryRow(q.sql).Scan(&n); err != nil {
+			t.Fatalf("counting %s: %v", q.label, err)
+		}
+		if n == 0 {
+			t.Errorf("expected seeded %s, got none", q.label)
+		}
+	}
+}

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -382,6 +382,55 @@ func TestFixtures_TicketsSpanCategoriesAndStatuses(t *testing.T) {
 	}
 }
 
+// Cursor pagination orders by (last_modified_date DESC, ticket_id) with
+// a tuple comparison for the tie-break. The fixtures promise a
+// deterministic shape for that: last_modified_date descends
+// (non-strictly) as ticket_id ascends, with exactly one deliberate tie
+// — tickets 6 and 7 — so the tie-break path is actually exercised.
+func TestFixtures_TicketCursorOrderingInvariant(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	rows, err := db.Query(
+		`SELECT ticket_id, last_modified_date FROM xf_nf_tickets_ticket ORDER BY ticket_id`,
+	)
+	if err != nil {
+		t.Fatalf("reading tickets: %v", err)
+	}
+	defer rows.Close()
+
+	type row struct{ id, modified uint64 }
+	var tickets []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.modified); err != nil {
+			t.Fatalf("scanning ticket: %v", err)
+		}
+		tickets = append(tickets, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating tickets: %v", err)
+	}
+	if len(tickets) < 2 {
+		t.Fatalf("expected multiple seeded tickets, got %d", len(tickets))
+	}
+
+	var ties [][2]uint64
+	for i := 1; i < len(tickets); i++ {
+		prev, cur := tickets[i-1], tickets[i]
+		if cur.modified > prev.modified {
+			t.Errorf("last_modified_date must descend (non-strictly) as ticket_id ascends: ticket %d (%d) > ticket %d (%d)",
+				cur.id, cur.modified, prev.id, prev.modified)
+		}
+		if cur.modified == prev.modified {
+			ties = append(ties, [2]uint64{prev.id, cur.id})
+		}
+	}
+
+	if len(ties) != 1 || ties[0] != [2]uint64{6, 7} {
+		t.Errorf("expected exactly one last_modified_date tie, between tickets 6 and 7 (the tuple-comparison tie-break fixture), got %v", ties)
+	}
+}
+
 // Every ticket must resolve its reference-cached names: status,
 // priority and prefix phrases, plus its category row. Messages must
 // include a hidden one (message_state filter), and participants and

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -18,3 +18,69 @@ func TestOpen_YieldsSeededDatabase(t *testing.T) {
 		t.Fatal("expected seeded xf_user rows, got none")
 	}
 }
+
+// The by-id profile route resolves its id against the milpac relation
+// key, not the forum user id. The fixtures must make the two seams
+// distinguishable: a relation_id that exists as some OTHER member's
+// user_id. Looking up "205" must yield different members depending on
+// which key is used.
+func TestFixtures_RelationKeyDiffersFromForumUserId(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	var byRelation, byUser uint64
+	if err := db.QueryRow(
+		`SELECT user_id FROM xf_nf_rosters_user WHERE relation_id = 205`,
+	).Scan(&byRelation); err != nil {
+		t.Fatalf("looking up member by relation_id 205: %v", err)
+	}
+	if err := db.QueryRow(
+		`SELECT relation_id FROM xf_nf_rosters_user WHERE user_id = 205`,
+	).Scan(&byUser); err != nil {
+		t.Fatalf("looking up member by user_id 205: %v", err)
+	}
+
+	if byRelation == 205 {
+		t.Error("member at relation_id 205 must have a different user_id, got 205")
+	}
+	if byUser == 205 {
+		t.Error("member with user_id 205 must have a different relation_id, got 205")
+	}
+}
+
+// Members must come with the relational payload the profile queries
+// preload: rank, position (with group), service records, awards (with
+// catalog row), connected accounts, and roster field values.
+func TestFixtures_MemberRelationsResolve(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	var orphans int
+	for _, q := range []struct{ label, sql string }{
+		{"rank", `SELECT COUNT(*) FROM xf_nf_rosters_user m LEFT JOIN xf_nf_rosters_rank r ON r.rank_id = m.rank_id WHERE r.rank_id IS NULL`},
+		{"position", `SELECT COUNT(*) FROM xf_nf_rosters_user m LEFT JOIN xf_nf_rosters_position p ON p.position_id = m.position_id WHERE p.position_id IS NULL`},
+		{"position group", `SELECT COUNT(*) FROM xf_nf_rosters_position p LEFT JOIN xf_nf_rosters_position_group g ON g.position_group_id = p.position_group_id WHERE g.position_group_id IS NULL`},
+		{"forum user", `SELECT COUNT(*) FROM xf_nf_rosters_user m LEFT JOIN xf_user u ON u.user_id = m.user_id WHERE u.user_id IS NULL`},
+		{"award catalog", `SELECT COUNT(*) FROM xf_nf_rosters_user_award ua LEFT JOIN xf_nf_rosters_award a ON a.award_id = ua.award_id WHERE a.award_id IS NULL`},
+	} {
+		if err := db.QueryRow(q.sql).Scan(&orphans); err != nil {
+			t.Fatalf("checking %s linkage: %v", q.label, err)
+		}
+		if orphans != 0 {
+			t.Errorf("%d member rows with dangling %s reference", orphans, q.label)
+		}
+	}
+
+	for _, q := range []struct{ label, sql string }{
+		{"service records", `SELECT COUNT(*) FROM xf_nf_rosters_service_record`},
+		{"awards", `SELECT COUNT(*) FROM xf_nf_rosters_user_award`},
+		{"connected accounts", `SELECT COUNT(*) FROM xf_user_connected_account`},
+		{"field values", `SELECT COUNT(*) FROM xf_nf_rosters_field_value`},
+	} {
+		var n int
+		if err := db.QueryRow(q.sql).Scan(&n); err != nil {
+			t.Fatalf("counting %s: %v", q.label, err)
+		}
+		if n == 0 {
+			t.Errorf("expected seeded %s, got none", q.label)
+		}
+	}
+}

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -87,6 +87,57 @@ func TestFixtures_MemberRelationsResolve(t *testing.T) {
 	}
 }
 
+// API-key fixtures must support both sides of bearer auth: the
+// well-known raw key resolves to active scopes through the same
+// UNHEX(SHA2(...)) shape the datastore uses, and revoked/inactive
+// material exists for the negative paths.
+func TestFixtures_ApiKeysResolveScopes(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	rows, err := db.Query(
+		`SELECT sd.scope_name
+		 FROM   xf_cav7_api_key k
+		 JOIN   xf_cav7_api_key_scope ks     ON ks.key_id   = k.key_id
+		 JOIN   xf_cav7_api_key_scope_def sd ON sd.scope_id = ks.scope_id
+		 WHERE  k.key_hash   = UNHEX(SHA2(?, 256))
+		   AND  k.is_active  = 1
+		   AND  sd.is_active = 1`, testdb.ActiveAPIKey)
+	if err != nil {
+		t.Fatalf("resolving scopes for active key: %v", err)
+	}
+	defer rows.Close()
+	scopes := map[string]bool{}
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scanning scope: %v", err)
+		}
+		scopes[s] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating scopes: %v", err)
+	}
+	if len(scopes) < 2 {
+		t.Errorf("active key should carry at least 2 active scopes, got %v", scopes)
+	}
+	if scopes["admin"] {
+		t.Error("inactive scope 'admin' must not surface for the active key")
+	}
+
+	for _, neg := range []struct{ label, sql string }{
+		{"inactive key", `SELECT COUNT(*) FROM xf_cav7_api_key WHERE is_active = 0`},
+		{"inactive scope def", `SELECT COUNT(*) FROM xf_cav7_api_key_scope_def WHERE is_active = 0`},
+	} {
+		var n int
+		if err := db.QueryRow(neg.sql).Scan(&n); err != nil {
+			t.Fatalf("counting %s: %v", neg.label, err)
+		}
+		if n == 0 {
+			t.Errorf("expected at least one %s for negative-path tests", neg.label)
+		}
+	}
+}
+
 // The harness schema must not pre-create the four indexes proposed by
 // PRD #112 — their absence is what keeps the "red" EXPLAIN plans of the
 // index slice reproducible.

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -266,6 +266,48 @@ func TestFixtures_HotAggregationRedPlanReproducible(t *testing.T) {
 	}
 }
 
+// The AWOL report (datastores FindAwol) computes its cutoff from the
+// wall clock (now - 7 days), so the fixtures' recent-vs-AWOL contrast
+// must hold relative to NOW, not to a fixed epoch:
+//   - Discharged.F (301) never posted (left-join NULL case),
+//   - Reservist.E (300) last posted far beyond any plausible cutoff,
+//   - Trooper.C (150) and Trooper.D (205) posted within the last day.
+func TestFixtures_AwolContrastHoldsRelativeToNow(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	var neverPosted int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM xf_post WHERE user_id = 301`,
+	).Scan(&neverPosted); err != nil {
+		t.Fatalf("counting posts for never-posted member 301: %v", err)
+	}
+	if neverPosted != 0 {
+		t.Errorf("member 301 must have zero posts (left-join NULL case), got %d", neverPosted)
+	}
+
+	var ancientOK bool
+	if err := db.QueryRow(
+		`SELECT MAX(post_date) < UNIX_TIMESTAMP() - 30*86400 FROM xf_post WHERE user_id = 300`,
+	).Scan(&ancientOK); err != nil {
+		t.Fatalf("checking ancient poster 300: %v", err)
+	}
+	if !ancientOK {
+		t.Error("member 300's last post must predate any plausible AWOL cutoff (older than 30 days)")
+	}
+
+	for _, userID := range []int{150, 205} {
+		var recentOK bool
+		if err := db.QueryRow(
+			`SELECT MAX(post_date) > UNIX_TIMESTAMP() - 86400 FROM xf_post WHERE user_id = ?`, userID,
+		).Scan(&recentOK); err != nil {
+			t.Fatalf("checking recent poster %d: %v", userID, err)
+		}
+		if !recentOK {
+			t.Errorf("member %d's last post must be within the last day so FindAwol's now-7d cutoff never flags it", userID)
+		}
+	}
+}
+
 // Ticket fixtures must span categories, statuses and states so the
 // tickets datastore tests (#120) can exercise every filter knob:
 // multiple categories (with a parent/child pair for subtree expansion),


### PR DESCRIPTION
Closes #115. Part of #112 (PRD: Goodbye gRPC) — Phase 1; carries the Phase 3 SQL seam.

## What

`testdb/` — a dockerized MariaDB 11.5 integration harness, the home for the EXPLAIN-plan assertions (#119) and the datastore behavior tests (#120):

- **One public seam**: `testdb.Open(t) (*sql.DB, string)` — env-guarded by `TESTDB_ADDR` (unset → skip; plain `go test ./...` stays docker-free). Each call creates a uniquely named database, applies embedded `schema.sql` + `fixtures.sql`, drops on cleanup — tests can run DDL in isolation.
- **Schema** derived from the queries the API actually issues (8 rosters tables, xf_user, connected accounts, xf_post, xf_phrase, 5 tickets tables, 3 api-key tables). Deliberately carries **none of the four PRD indexes** (pinned by test) so red EXPLAIN plans stay reproducible; stock XF indexes kept to match prod.
- **Fixtures**: relation-key ≠ user-id crossing pair (relation 205 → user 150, user 205 → relation 310; exercised end-to-end through the real `FindProfilesById`), 20k posts for meaningful EXPLAIN plans, AWOL contrast seeded **relative to wall clock**, tickets across categories/statuses/states incl. the cursor tie-break pair, active/revoked API keys.
- **CI**: MariaDB 11.5 service container; the harness step self-verifies (fails on unexpected `--- SKIP`), plus a TESTDB_ADDR-unset step proving the suite skips clean.
- **Parallel-safe**: unique compose project per checkout + ephemeral host port — multiple worktrees run harnesses side by side.

## Review hardening (multi-agent review applied)

- AWOL fixtures relative-to-now + invariant pins (never-posted member, ancient poster, recent posters)
- `RevokedAPIKey` pinned to its seeded row via the real `UNHEX(SHA2(...))` shape
- Tickets cursor-ordering invariant pinned (non-strict descent + deliberate 6/7 tie)
- Cleanup `DROP DATABASE` failures reported loudly (`t.Errorf`) instead of swallowed
- 5s dial / 30s read-write DSN timeouts (black-holed addr fatals in 5s, not 10min)

## Test plan

- [x] `go test ./...` green without docker (skips clean)
- [x] `make test-integration` green (twice, no flakes)
- [x] Two worktree harnesses verified running concurrently
- [x] No PRD indexes in schema (test-enforced); no real credentials in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)