### PR TITLE
Phase 1: idempotent index DDL script and EXPLAIN-plan red-to-green tests

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,3 +123,22 @@ Two properties of the harness are load-bearing:
 - The fixtures include a member whose milpac `relation_id` collides
   with another member's forum `user_id` (205), keeping the by-id
   profile route's frozen relation-key semantic testable.
+
+## Index script (PRD #112 Phase 1)
+
+`testdb/indexes.sql` is the in-repo source of truth for the four
+indexes backing the hot read paths (composite `user_id_post_date` on
+`xf_post` for the loose-index-scan last-post aggregation; relation-id
+and user-id indexes on the rosters tables for the profile preloads).
+The EXPLAIN-plan tests in `testdb/indexes_test.go` pin the flip
+red→green: the unindexed schema must full-scan, the script must
+produce a loose index scan and index-backed preloads — a query or
+schema change that silently reintroduces a full scan fails a test, not
+a production latency budget.
+
+The API never executes DDL. The script is applied manually by the DB
+admin (`mysql xenforo < testdb/indexes.sql`, human-gated in #122) and
+re-applied with the same one command after any forum add-on upgrade
+that rebuilds the tables (idempotent: `ADD INDEX IF NOT EXISTS`). The
+long-term home for re-application is the ApiKeyManager add-on's schema
+step (per PRD #112) — documented intent only, not implemented.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,13 +128,16 @@ Two properties of the harness are load-bearing:
 
 `testdb/indexes.sql` is the in-repo source of truth for the four
 indexes backing the hot read paths (composite `user_id_post_date` on
-`xf_post` for the loose-index-scan last-post aggregation; relation-id
-and user-id indexes on the rosters tables for the profile preloads).
-The EXPLAIN-plan tests in `testdb/indexes_test.go` pin the flip
-red→green: the unindexed schema must full-scan, the script must
-produce a loose index scan and index-backed preloads — a query or
-schema change that silently reintroduces a full scan fails a test, not
-a production latency budget.
+`xf_post` serving two distinct aggregations — a loose index scan for
+the last-post aggregation and a covering index scan for the AWOL
+report's variant, whose extra `MAX(post_id)` disqualifies the loose
+scan; relation-id and user-id indexes on the rosters tables for the
+profile preloads). The EXPLAIN-plan tests in `testdb/indexes_test.go`
+pin each flip red→green: the unindexed schema must full-scan, the
+script must produce the loose scan, the covering scan, and
+index-backed preloads — a query or schema change that silently
+reintroduces a full scan fails a test, not a production latency
+budget.
 
 The API never executes DDL. The script is applied manually by the DB
 admin (`mysql xenforo < testdb/indexes.sql`, human-gated in #122) and

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -563,6 +563,24 @@ func getLatestAwardDate(profile milpacs.Profile) string {
 	return time.Unix(latestTimestamp, 0).Format("2006-01-02 15:04:05")
 }
 
+// HotLastPostAggregation and AwolLastPostAggregation are the
+// derived-table bodies of the two xf_post GROUP BY hotspots (PRD #112).
+// They are exported so the EXPLAIN-plan tests in testdb/indexes_test.go
+// pin the exact strings production executes — editing a query here
+// re-points the corresponding test automatically instead of leaving it
+// green against a stale copy. The SQL is frozen per PRD #112: index,
+// don't refactor.
+const (
+	// HotLastPostAggregation feeds getLatestForumPostDates (the
+	// last-forum-post column on lite rosters and full profiles). With
+	// the user_id_post_date composite it plans a loose index scan.
+	HotLastPostAggregation = "SELECT user_id, MAX(post_date) as date FROM xf_post GROUP BY user_id"
+	// AwolLastPostAggregation feeds FindAwol. The extra MAX(post_id)
+	// disqualifies the loose scan; the same composite instead serves a
+	// covering index scan.
+	AwolLastPostAggregation = "SELECT user_id, MAX(post_date) as date, MAX(post_id) as post_id FROM xf_post GROUP BY user_id"
+)
+
 // bear witness to my despair, as i try to optimize queries to a table with a gazillion rows
 func (ds Mysql) getLatestForumPostDates(profiles []milpacs.Profile) map[uint64]string {
 	dates := make(map[uint64]string)
@@ -574,7 +592,7 @@ func (ds Mysql) getLatestForumPostDates(profiles []milpacs.Profile) map[uint64]s
 
 	query := ds.Db.Table("xf_nf_rosters_user as milpacs").
 		Select("milpacs.user_id, posts.date").
-		Joins("LEFT JOIN (SELECT user_id, MAX(post_date) as date FROM xf_post GROUP BY user_id) as posts ON milpacs.user_id = posts.user_id").
+		Joins("LEFT JOIN ("+HotLastPostAggregation+") as posts ON milpacs.user_id = posts.user_id").
 		Where("milpacs.user_id IN ?", getUserIDs(profiles))
 
 	if err := query.Find(&results).Error; err != nil {
@@ -663,7 +681,7 @@ func (ds Mysql) FindAwol() ([]*proto.Awol, error) {
             posts.post_id,
             FROM_UNIXTIME(posts.date, '%Y-%m-%d') as human_date
         `).
-		Joins("LEFT JOIN (SELECT user_id, MAX(post_date) as date, MAX(post_id) as post_id FROM xf_post GROUP BY user_id) as posts ON milpacs.user_id = posts.user_id").
+		Joins("LEFT JOIN ("+AwolLastPostAggregation+") as posts ON milpacs.user_id = posts.user_id").
 		Joins("LEFT JOIN xf_user as users ON milpacs.user_id = users.user_id").
 		Joins("INNER JOIN xf_nf_rosters_rank as ranks ON milpacs.rank_id = ranks.rank_id").
 		Joins("INNER JOIN xf_nf_rosters_position position ON milpacs.position_id = position.position_id").

--- a/testdb/indexes.sql
+++ b/testdb/indexes.sql
@@ -3,7 +3,9 @@
 -- Four indexes backing the API's hot read paths (mirror-measured):
 --   - xf_post user_id_post_date: flips the last-post aggregation
 --     (SELECT user_id, MAX(post_date) ... GROUP BY user_id) to a loose
---     index scan — 4,226ms -> 28ms; AWOL report 4,211ms -> 198ms.
+--     index scan — 4,226ms -> 28ms. The AWOL report's aggregation
+--     (extra MAX(post_id)) cannot loose-scan; it instead plans a
+--     covering scan of the same composite — 4,211ms -> 198ms.
 --   - idx_relation_id on xf_nf_rosters_service_record and
 --     xf_nf_rosters_user_award: index-backs the profile preloads
 --     (WHERE relation_id IN (...)) — 44ms -> ~0ms.

--- a/testdb/indexes.sql
+++ b/testdb/indexes.sql
@@ -1,4 +1,7 @@
 -- PRD #112 ("Goodbye gRPC") Phase 1 index script — SOURCE OF TRUTH.
+-- Requires MariaDB: ADD INDEX IF NOT EXISTS is MariaDB-only syntax,
+-- Oracle MySQL rejects it. The forum runs MariaDB 11.5; verifying the
+-- production engine is part of the human-gated apply (issue #122).
 --
 -- Four indexes backing the API's hot read paths (mirror-measured):
 --   - xf_post user_id_post_date: flips the last-post aggregation

--- a/testdb/indexes.sql
+++ b/testdb/indexes.sql
@@ -1,0 +1,38 @@
+-- PRD #112 ("Goodbye gRPC") Phase 1 index script — SOURCE OF TRUTH.
+--
+-- Four indexes backing the API's hot read paths (mirror-measured):
+--   - xf_post user_id_post_date: flips the last-post aggregation
+--     (SELECT user_id, MAX(post_date) ... GROUP BY user_id) to a loose
+--     index scan — 4,226ms -> 28ms; AWOL report 4,211ms -> 198ms.
+--   - idx_relation_id on xf_nf_rosters_service_record and
+--     xf_nf_rosters_user_award: index-backs the profile preloads
+--     (WHERE relation_id IN (...)) — 44ms -> ~0ms.
+--   - idx_user_id on xf_nf_rosters_user: index-backs roster member
+--     lookups by forum user id.
+--
+-- The API never executes DDL. This script is applied in exactly two
+-- ways:
+--   1. By the EXPLAIN-plan tests in testdb/indexes_test.go, against
+--      their own disposable harness databases.
+--   2. Manually by the DB admin against production (human-gated,
+--      tracked in issue #122):
+--
+--        mysql xenforo < testdb/indexes.sql
+--
+-- Re-apply procedure: a forum add-on upgrade that rebuilds any of
+-- these tables silently drops the indexes. Restoring them is the same
+-- one command — the script is idempotent (ADD INDEX IF NOT EXISTS), so
+-- re-running it against a database that already carries some or all of
+-- the indexes is safe and changes nothing. Long-term (per PRD #112)
+-- the re-application belongs in the ApiKeyManager add-on's schema
+-- step, so forum upgrades restore the indexes automatically; that is
+-- deliberately NOT implemented here — until then, re-apply manually
+-- after any add-on upgrade that touches xf_post or the rosters tables.
+--
+-- Do NOT fold these into testdb/schema.sql: the harness schema stays
+-- unindexed so the red EXPLAIN plans remain reproducible.
+
+ALTER TABLE xf_post ADD INDEX IF NOT EXISTS user_id_post_date (user_id, post_date);
+ALTER TABLE xf_nf_rosters_service_record ADD INDEX IF NOT EXISTS idx_relation_id (relation_id);
+ALTER TABLE xf_nf_rosters_user_award ADD INDEX IF NOT EXISTS idx_relation_id (relation_id);
+ALTER TABLE xf_nf_rosters_user ADD INDEX IF NOT EXISTS idx_user_id (user_id);

--- a/testdb/indexes_test.go
+++ b/testdb/indexes_test.go
@@ -23,6 +23,21 @@ func applyIndexDDL(t *testing.T, db *sql.DB) {
 // keystone (post-date aggregation 4,226ms -> 28ms on the mirror).
 const looseScan = "Using index for group-by"
 
+// hotLastPostAggregation is the derived-table body driving the
+// lite-roster last-forum-post column and the AWOL report (verbatim
+// from datastores/mysql.go) — the PRD's measured hotspot. The query
+// stays as written: the indexed derived table measured faster than a
+// correlated rewrite on the mirror. Index, don't refactor.
+const hotLastPostAggregation = `SELECT user_id, MAX(post_date) as date FROM xf_post GROUP BY user_id`
+
+// groupByOptimization returns the Extra column of the EXPLAIN row for
+// the hot aggregation, which is where MariaDB reports loose index
+// scans.
+func groupByOptimization(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	return explainFirstRow(t, db, hotLastPostAggregation)["Extra"]
+}
+
 // The PRD #112 index script must flip the hot last-post aggregation
 // from a full scan to a loose index scan. Red half: the unindexed
 // harness schema must NOT already plan a loose scan (keeps the red

--- a/testdb/indexes_test.go
+++ b/testdb/indexes_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/testdb"
 )
 
@@ -30,8 +31,9 @@ const looseScan = "Using index for group-by"
 // hotspot. The AWOL report uses a different aggregation, pinned
 // separately below. The query stays as written: the indexed derived
 // table measured faster than a correlated rewrite on the mirror.
-// Index, don't refactor.
-const hotLastPostAggregation = `SELECT user_id, MAX(post_date) as date FROM xf_post GROUP BY user_id`
+// Index, don't refactor. Aliases the exported const so the test
+// always EXPLAINs the exact string production executes.
+const hotLastPostAggregation = datastores.HotLastPostAggregation
 
 // groupByOptimization returns the Extra column of the EXPLAIN row for
 // the hot aggregation, which is where MariaDB reports loose index
@@ -70,7 +72,9 @@ const coveringScan = "Using index"
 // (verbatim from datastores/mysql.go FindAwol). The extra MAX(post_id)
 // disqualifies the loose index scan; instead the composite plans a
 // covering index scan — the PRD's "AWOL 4,211ms -> 198ms" keystone.
-const awolLastPostAggregation = `SELECT user_id, MAX(post_date) as date, MAX(post_id) as post_id FROM xf_post GROUP BY user_id`
+// Aliases the exported const so the test always EXPLAINs the exact
+// string production executes.
+const awolLastPostAggregation = datastores.AwolLastPostAggregation
 
 // The index script must flip the AWOL aggregation from a full table
 // scan to a covering scan of user_id_post_date. It can never plan a

--- a/testdb/indexes_test.go
+++ b/testdb/indexes_test.go
@@ -76,6 +76,38 @@ func TestIndexDDL_RelationPreloadsGoIndexBacked(t *testing.T) {
 	}
 }
 
+// The re-apply procedure is "run the same one command again" — e.g.
+// after a forum add-on upgrade rebuilt a table and dropped the
+// indexes. The script must therefore be idempotent: applying it to a
+// database that already carries the indexes succeeds and leaves
+// exactly one of each.
+func TestIndexDDL_IsIdempotent(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	applyIndexDDL(t, db)
+	applyIndexDDL(t, db)
+
+	for _, idx := range []struct{ table, index string }{
+		{"xf_post", "user_id_post_date"},
+		{"xf_nf_rosters_service_record", "idx_relation_id"},
+		{"xf_nf_rosters_user_award", "idx_relation_id"},
+		{"xf_nf_rosters_user", "idx_user_id"},
+	} {
+		var n int
+		err := db.QueryRow(
+			`SELECT COUNT(DISTINCT index_name) FROM information_schema.statistics
+			 WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+			idx.table, idx.index,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("checking index %s.%s: %v", idx.table, idx.index, err)
+		}
+		if n != 1 {
+			t.Errorf("expected exactly one index %s on %s after double apply, got %d", idx.index, idx.table, n)
+		}
+	}
+}
+
 // explainFirstRow returns the first EXPLAIN row of the query as a
 // column-name -> value map (NULLs become empty strings).
 func explainFirstRow(t *testing.T, db *sql.DB, query string) map[string]string {

--- a/testdb/indexes_test.go
+++ b/testdb/indexes_test.go
@@ -43,3 +43,67 @@ func TestIndexDDL_HotAggregationFlipsToLooseIndexScan(t *testing.T) {
 		t.Errorf("after the index script the hot aggregation must plan a loose index scan, got Extra=%q", extra)
 	}
 }
+
+// preloadLookups are the relation-shaped lookups the datastore issues
+// when hydrating profiles: gorm preloads service records and awards by
+// relation_id, and resolves roster members by forum user_id (e.g. the
+// last-post-date map). Each must go index-backed once the script runs.
+var preloadLookups = []struct{ label, query, index string }{
+	{"service records", `SELECT * FROM xf_nf_rosters_service_record WHERE relation_id IN (201, 205)`, "idx_relation_id"},
+	{"awards", `SELECT * FROM xf_nf_rosters_user_award WHERE relation_id IN (201, 205)`, "idx_relation_id"},
+	{"roster members by user id", `SELECT * FROM xf_nf_rosters_user WHERE user_id IN (100, 150)`, "idx_user_id"},
+}
+
+// The relation-id preloads must flip from full table scans (type=ALL,
+// no usable key) to index-backed lookups on the script's indexes.
+func TestIndexDDL_RelationPreloadsGoIndexBacked(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	for _, l := range preloadLookups {
+		row := explainFirstRow(t, db, l.query)
+		if row["type"] != "ALL" {
+			t.Errorf("red plan not reproducible: %s lookup should full-scan on the unindexed schema, got type=%q key=%q", l.label, row["type"], row["key"])
+		}
+	}
+
+	applyIndexDDL(t, db)
+
+	for _, l := range preloadLookups {
+		row := explainFirstRow(t, db, l.query)
+		if row["key"] != l.index {
+			t.Errorf("after the index script the %s lookup must use %s, got type=%q key=%q", l.label, l.index, row["type"], row["key"])
+		}
+	}
+}
+
+// explainFirstRow returns the first EXPLAIN row of the query as a
+// column-name -> value map (NULLs become empty strings).
+func explainFirstRow(t *testing.T, db *sql.DB, query string) map[string]string {
+	t.Helper()
+	rows, err := db.Query(`EXPLAIN ` + query)
+	if err != nil {
+		t.Fatalf("explaining %q: %v", query, err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("reading EXPLAIN columns: %v", err)
+	}
+	if !rows.Next() {
+		t.Fatalf("EXPLAIN returned no rows for %q", query)
+	}
+	vals := make([]sql.NullString, len(cols))
+	scan := make([]any, len(cols))
+	for i := range vals {
+		scan[i] = &vals[i]
+	}
+	if err := rows.Scan(scan...); err != nil {
+		t.Fatalf("scanning EXPLAIN row: %v", err)
+	}
+	row := make(map[string]string, len(cols))
+	for i, c := range cols {
+		row[c] = vals[i].String
+	}
+	return row
+}

--- a/testdb/indexes_test.go
+++ b/testdb/indexes_test.go
@@ -23,11 +23,14 @@ func applyIndexDDL(t *testing.T, db *sql.DB) {
 // keystone (post-date aggregation 4,226ms -> 28ms on the mirror).
 const looseScan = "Using index for group-by"
 
-// hotLastPostAggregation is the derived-table body driving the
-// lite-roster last-forum-post column and the AWOL report (verbatim
-// from datastores/mysql.go) — the PRD's measured hotspot. The query
-// stays as written: the indexed derived table measured faster than a
-// correlated rewrite on the mirror. Index, don't refactor.
+// hotLastPostAggregation is the derived-table body of
+// getLatestForumPostDates (verbatim from datastores/mysql.go), driving
+// the last-forum-post column on lite rosters AND full profiles
+// (processProfiles calls it too, mysql.go) — the PRD's measured
+// hotspot. The AWOL report uses a different aggregation, pinned
+// separately below. The query stays as written: the indexed derived
+// table measured faster than a correlated rewrite on the mirror.
+// Index, don't refactor.
 const hotLastPostAggregation = `SELECT user_id, MAX(post_date) as date FROM xf_post GROUP BY user_id`
 
 // groupByOptimization returns the Extra column of the EXPLAIN row for
@@ -56,6 +59,36 @@ func TestIndexDDL_HotAggregationFlipsToLooseIndexScan(t *testing.T) {
 
 	if extra := groupByOptimization(t, db); !strings.Contains(extra, looseScan) {
 		t.Errorf("after the index script the hot aggregation must plan a loose index scan, got Extra=%q", extra)
+	}
+}
+
+// coveringScan is the EXPLAIN Extra marker for a covering index scan:
+// the aggregation is answered from the index alone, no row lookups.
+const coveringScan = "Using index"
+
+// awolLastPostAggregation is the derived-table body of the AWOL report
+// (verbatim from datastores/mysql.go FindAwol). The extra MAX(post_id)
+// disqualifies the loose index scan; instead the composite plans a
+// covering index scan — the PRD's "AWOL 4,211ms -> 198ms" keystone.
+const awolLastPostAggregation = `SELECT user_id, MAX(post_date) as date, MAX(post_id) as post_id FROM xf_post GROUP BY user_id`
+
+// The index script must flip the AWOL aggregation from a full table
+// scan to a covering scan of user_id_post_date. It can never plan a
+// loose index scan (MAX(post_id) is not part of the composite), so the
+// hot-aggregation test above does not cover it — without this test a
+// regression of the AWOL keystone fails nothing.
+func TestIndexDDL_AwolAggregationFlipsToCoveringIndexScan(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	if row := explainFirstRow(t, db, awolLastPostAggregation); row["type"] != "ALL" {
+		t.Fatalf("red plan not reproducible: unindexed schema should full-scan the AWOL aggregation, got type=%q key=%q", row["type"], row["key"])
+	}
+
+	applyIndexDDL(t, db)
+
+	row := explainFirstRow(t, db, awolLastPostAggregation)
+	if row["key"] != "user_id_post_date" || !strings.Contains(row["Extra"], coveringScan) {
+		t.Errorf("after the index script the AWOL aggregation must covering-scan user_id_post_date, got type=%q key=%q Extra=%q", row["type"], row["key"], row["Extra"])
 	}
 }
 

--- a/testdb/indexes_test.go
+++ b/testdb/indexes_test.go
@@ -1,0 +1,45 @@
+package testdb_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/7cav/api/testdb"
+)
+
+// applyIndexDDL runs the in-repo index script against a disposable
+// harness database, exactly as the DB admin runs it against production
+// (mysql xenforo < testdb/indexes.sql).
+func applyIndexDDL(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(testdb.IndexDDL); err != nil {
+		t.Fatalf("applying index script: %v", err)
+	}
+}
+
+// looseScan is what MariaDB's EXPLAIN Extra column reports when the
+// GROUP BY aggregation runs as a loose index scan — the PRD #112
+// keystone (post-date aggregation 4,226ms -> 28ms on the mirror).
+const looseScan = "Using index for group-by"
+
+// The PRD #112 index script must flip the hot last-post aggregation
+// from a full scan to a loose index scan. Red half: the unindexed
+// harness schema must NOT already plan a loose scan (keeps the red
+// plan reproducible). Green half: after applying the in-repo script,
+// the very same query must plan one — a future query or schema change
+// that silently reintroduces the full scan fails here instead of a
+// production latency budget.
+func TestIndexDDL_HotAggregationFlipsToLooseIndexScan(t *testing.T) {
+	db, _ := testdb.Open(t)
+
+	if extra := groupByOptimization(t, db); strings.Contains(extra, looseScan) {
+		t.Fatalf("red plan not reproducible: unindexed schema already plans a loose index scan (Extra=%q)", extra)
+	}
+
+	applyIndexDDL(t, db)
+
+	if extra := groupByOptimization(t, db); !strings.Contains(extra, looseScan) {
+		t.Errorf("after the index script the hot aggregation must plan a loose index scan, got Extra=%q", extra)
+	}
+}

--- a/testdb/testdb.go
+++ b/testdb/testdb.go
@@ -49,6 +49,17 @@ const (
 //go:embed schema.sql
 var schemaSQL string
 
+// IndexDDL is the PRD #112 Phase 1 index script (testdb/indexes.sql),
+// embedded verbatim. The file is the in-repo source of truth that the
+// DB admin applies manually to production (issue #122); tests apply it
+// to their own disposable databases to assert the green EXPLAIN plans.
+// It is idempotent (ADD INDEX IF NOT EXISTS) and deliberately separate
+// from the schema: the harness stays unindexed so red plans stay
+// reproducible. The API binary never executes it.
+//
+//go:embed indexes.sql
+var IndexDDL string
+
 //go:embed fixtures.sql
 var fixturesSQL string
 

--- a/testdb/testdb.go
+++ b/testdb/testdb.go
@@ -120,10 +120,10 @@ func Open(t *testing.T) (*sql.DB, string) {
 }
 
 // dsn builds a go-sql-driver DSN for the harness server. multiStatements
-// lets the embedded schema and fixture scripts run as single Exec calls.
-// The timeouts keep a black-holed TESTDB_ADDR from hanging until the go
-// test panic dump: the connection errors promptly instead, so Open's
-// well-worded t.Fatalf messages fire.
+// lets the embedded schema, fixture, and index scripts run as single
+// Exec calls. The timeouts keep a black-holed TESTDB_ADDR from hanging
+// until the go test panic dump: the connection errors promptly instead,
+// so Open's well-worded t.Fatalf messages fire.
 func dsn(addr, database string) string {
 	cfg := mysql.NewConfig()
 	cfg.User = "root"

--- a/testdb/testdb_test.go
+++ b/testdb/testdb_test.go
@@ -1,8 +1,6 @@
 package testdb_test
 
 import (
-	"database/sql"
-	"strings"
 	"testing"
 
 	"github.com/7cav/api/testdb"
@@ -216,51 +214,10 @@ func TestSchema_CarriesNoPRDIndexes(t *testing.T) {
 	}
 }
 
-// hotLastPostAggregation is the subquery driving the lite-roster
-// last-forum-post column and the AWOL report — the PRD's measured
-// hotspot (4.2s -> 28ms once MariaDB can run it as a loose index scan).
-const hotLastPostAggregation = `SELECT user_id, MAX(post_date) FROM xf_post GROUP BY user_id`
-
-// groupByOptimization returns the Extra column of the EXPLAIN row for
-// the hot aggregation, which is where MariaDB reports loose index scans
-// ("Using index for group-by").
-func groupByOptimization(t *testing.T, db *sql.DB) string {
-	t.Helper()
-	rows, err := db.Query(`EXPLAIN ` + hotLastPostAggregation)
-	if err != nil {
-		t.Fatalf("explaining hot aggregation: %v", err)
-	}
-	defer rows.Close()
-
-	cols, err := rows.Columns()
-	if err != nil {
-		t.Fatalf("reading EXPLAIN columns: %v", err)
-	}
-	if !rows.Next() {
-		t.Fatal("EXPLAIN returned no rows")
-	}
-	vals := make([]sql.NullString, len(cols))
-	scan := make([]any, len(cols))
-	for i := range vals {
-		scan[i] = &vals[i]
-	}
-	if err := rows.Scan(scan...); err != nil {
-		t.Fatalf("scanning EXPLAIN row: %v", err)
-	}
-	for i, c := range cols {
-		if c == "Extra" {
-			return vals[i].String
-		}
-	}
-	t.Fatal("EXPLAIN output has no Extra column")
-	return ""
-}
-
 // The post fixtures must be voluminous enough that the loose-index-scan
-// vs full-scan distinction is observable: the seeded schema (no PRD
-// composite) must NOT plan a loose index scan, and adding the composite
-// in a throwaway database must flip the very same query to one.
-func TestFixtures_HotAggregationRedPlanReproducible(t *testing.T) {
+// vs full-scan distinction of the EXPLAIN tests (indexes_test.go) is
+// observable rather than an artifact of an empty table.
+func TestFixtures_PostVolumeMakesPlansMeaningful(t *testing.T) {
 	db, _ := testdb.Open(t)
 
 	var posts int
@@ -269,22 +226,6 @@ func TestFixtures_HotAggregationRedPlanReproducible(t *testing.T) {
 	}
 	if posts < 10000 {
 		t.Errorf("expected at least 10000 seeded posts for meaningful plans, got %d", posts)
-	}
-
-	const looseScan = "Using index for group-by"
-
-	if extra := groupByOptimization(t, db); strings.Contains(extra, looseScan) {
-		t.Errorf("red plan not reproducible: hot aggregation already runs as loose index scan (Extra=%q)", extra)
-	}
-
-	// Sanity in this test's own disposable database: the PRD composite
-	// flips the same query to a loose index scan, proving the fixture
-	// volume makes the distinction meaningful.
-	if _, err := db.Exec(`CREATE INDEX user_id_post_date ON xf_post (user_id, post_date)`); err != nil {
-		t.Fatalf("creating PRD composite in disposable database: %v", err)
-	}
-	if extra := groupByOptimization(t, db); !strings.Contains(extra, looseScan) {
-		t.Errorf("with the PRD composite the hot aggregation should plan a loose index scan, got Extra=%q", extra)
 	}
 }
 


### PR DESCRIPTION
Closes #119. Part of #112 (PRD: Goodbye gRPC) — Phase 1. **Stacked on #141** (base = `agent/issue-115`; GitHub retargets to `develop` when #141 merges).

## What

1. **`testdb/indexes.sql`** — the four PRD `ALTER TABLE ... ADD INDEX IF NOT EXISTS` statements, byte-identical to the PRD. In-repo source of truth for the manual prod apply (#122): one command, `mysql xenforo < testdb/indexes.sql`, idempotent — same command re-applies after a forum add-on upgrade rebuilds tables. MariaDB-only syntax documented (forum runs MariaDB 11.5); long-term re-apply home (ApiKeyManager schema step) documented, not implemented. Also embedded as `testdb.IndexDDL` for the tests.
2. **EXPLAIN red→green tests** (`testdb/indexes_test.go`) — the permanent plan-regression net:
   - Hot last-post aggregation: red pins the full scan on the unindexed schema, green pins `Using index for group-by` (loose index scan) after applying the script in-test.
   - **AWOL variant** (extra `MAX(post_id)` — loose-scan-ineligible): red `type=ALL`, green covering scan (`key=user_id_post_date`, `Using index`). Guards the PRD's 4,211ms→198ms keystone separately.
   - Relation-id preloads + roster user lookup: red `type=ALL`, green index-backed.
   - Idempotency: double apply succeeds, all four indexes present.
3. **Query strings tied to production**: `datastores.HotLastPostAggregation` / `AwolLastPostAggregation` exported and used by both the gorm call sites and the tests — editing a prod query re-points its EXPLAIN test instead of leaving it green against a stale copy. Extraction byte-identical (SQL frozen per the PRD: index, don't refactor).

No DDL execution path in the API binary: `testdb` is imported by zero non-test files.

## Test plan

- [x] Red proven by demonstration: green assertions run before the apply step fail (`type=ALL`, filesort); idempotency proven by stripping `IF NOT EXISTS` → `Error 1061`
- [x] `make test-integration` green, `-count=2` stable
- [x] `go test ./...` docker-free skips clean
- [x] Harness schema stays unindexed (`TestSchema_CarriesNoPRDIndexes` still guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)