### PR TITLE
Phase 3: golden contract corpus recorded from the current stack (red suite)

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -13,9 +13,11 @@ One file per battery case (`battery.go` → `Cases()`), named
 - the request (method, path, auth tier — see `Auth` in `golden.go`),
 - the response **status code**,
 - the **contract-relevant headers** — allowlist in `golden.go`
-  (`Content-Type`, `X-Content-Type-Options`); everything else
-  (`Date`, `Content-Length`, `X-Cache`, `Grpc-Metadata-*`) is infrastructure
-  of the current stack, not contract,
+  (`Content-Type`, `X-Content-Type-Options`, `WWW-Authenticate`); everything
+  else (`Date`, `Content-Length`, `X-Cache`, `Grpc-Metadata-*`) is
+  infrastructure of the current stack, not contract. `WWW-Authenticate` pins
+  an *absence*: #106 froze the 401 tiers as challenge-free, so no golden
+  records it and a stack that adds it diffs red,
 - the response **body**: canonicalized JSON (`body`) or, for the plain-text
   401 tier pinned by #106, the verbatim text (`bodyText`).
 

--- a/contract/README.md
+++ b/contract/README.md
@@ -1,0 +1,109 @@
+# Golden contract corpus
+
+The recorded contract of the public HTTP API (PRD #112, issue #116). These
+goldens are the red suite for the stdlib `net/http` rewrite and live on
+permanently as the contract regression net: any stack that serves these
+routes must reproduce every golden in `goldens/`.
+
+## What a golden is
+
+One file per battery case (`battery.go` → `Cases()`), named
+`goldens/<case>.golden.json`. Each records:
+
+- the request (method, path, auth tier — see `Auth` in `golden.go`),
+- the response **status code**,
+- the **contract-relevant headers** — allowlist in `golden.go`
+  (`Content-Type`, `X-Content-Type-Options`); everything else
+  (`Date`, `Content-Length`, `X-Cache`, `Grpc-Metadata-*`) is infrastructure
+  of the current stack, not contract,
+- the response **body**: canonicalized JSON (`body`) or, for the plain-text
+  401 tier pinned by #106, the verbatim text (`bodyText`).
+
+## Comparison is semantic, never byte-based
+
+`protojson` randomizes whitespace per build, so today's API is already not
+byte-stable. Replay therefore parses both sides, canonicalizes
+(`Canonicalize`), and diffs structurally (`Diff` / `CompareGolden`):
+
+- object key order never matters;
+- array order and length matter;
+- number *form* matters: protojson emits 64-bit integers as JSON strings and
+  32-bit integers as JSON numbers — `"3"` ≠ `3`;
+- `null`, `{}`/`[]`, and an absent key are three distinct states
+  (emit-everything semantics are part of the contract);
+- byte-level output is informational only (printed on failure for debugging).
+
+## The single transform: `StripKeycloakID`
+
+Exactly one transform sits between the wire and the goldens: every object key
+named `keycloakId`, at any depth, is removed (`StripKeycloakID` in
+`canon.go`). The field — like the keycloak lookup route — is deleted at
+cutover; goldens record the truth the new stack must reproduce, and the
+transform documents the break. It is applied symmetrically: to responses at
+record time and at replay time, so the corpus stays green against the old
+stack while it remains in-tree. **No other transform exists.**
+
+The keycloak lookup route (`/api/v1/milpac/keycloak/{keycloak_id}`) is
+deliberately **not** recorded — it dies at cutover, so there is no golden to
+hold it to. That leaves the 16 surviving public routes, all covered
+(enumerated on `Cases()` in `battery.go`; coverage enforced by
+`TestBatteryIsWellFormed`).
+
+## How the corpus was recorded
+
+`TestMain` (`harness_test.go`) mounts the **current production stack**
+in-process: the real `gateway.Service.Server()` handler (auth middleware,
+sentry, cache, compression, `/api` routing, grpc-gateway mux) dialing a real
+`grpc.Server` over TCP with the production interceptor chain, over a seeded
+deterministic fake datastore (`fake_datastore_test.go`). No MySQL, no Redis,
+no docker: the Redis client points at an always-erroring local stub, so every
+request takes the cache-miss path (the cache layer leaves at Phase 2, #123).
+
+Seed highlights (all referenced by path literals in the battery):
+
+- **relation 1 ↔ user 3** (`Jarvis.A`): the by-id profile route's path value
+  is the milpac *relation* key, not the forum user id — mirrors
+  `datastores.Mysql.FindProfilesById`, which keys `First()` on the
+  `milpacs.Profile` primary key (`relation_id`). The
+  `milpacs/profile_by_id_happy` golden proves relation wins.
+- relation 2 ↔ user 8 (`John.Doe`): the sparse profile — unset nested
+  message (`primary: null`), empty collections, empty strings.
+- tickets 42/43/44 with distinct categories (5 is a child of 1), states,
+  statuses and timestamps, so every list filter selects a distinguishable
+  subset; cursors are the stack's real base64url forms.
+- injected outages: profile id `777` and `ROSTER_TYPE_ARLINGTON` produce the
+  Internal-error (500) goldens with their leaked wrapped messages — frozen.
+- position search returns hits only for the exact title
+  `Regimental Technical Aide`; everything else is the frozen `{"profiles":{}}`
+  empty result (#137).
+
+## Replaying
+
+```
+go test ./contract/...
+```
+
+Runs the whole battery against the in-process current stack and compares
+every response to its committed golden. Plain `go test`, no docker, no
+network beyond loopback, sub-second after build.
+
+To replay against a *future* stack: mount its `http.Handler`, then for each
+`Cases()` entry run `RunCase(handler, c)` and `CompareGolden` the result
+against `LoadGolden("contract/goldens", c.Name)`. The new stack's test seed
+must reproduce the logical seed above (the goldens themselves are the
+authoritative value reference) and accept the battery's bearer tokens
+(`authHeader` in `golden.go`).
+
+## Re-recording
+
+Possible only while the old stack remains in-tree:
+
+```
+go test ./contract -run TestContractCorpus -update
+```
+
+This overwrites `goldens/` from the live current stack. Review the diff like
+any other code change — a re-record that changes bodies is a contract change
+and needs the same scrutiny as one. `TestCorpusHasNoOrphanGoldens` fails if a
+golden loses its battery case; delete orphaned files as part of the same
+change that removes a case.

--- a/contract/README.md
+++ b/contract/README.md
@@ -61,7 +61,8 @@ needs one. The exported surface is exactly five entries:
 
 1. `Cases() []Case` / `Case` — the recorded request battery.
 2. `Auth` and its constants (`AuthNone`, `AuthRawKey`, `AuthInvalidKey`,
-   `AuthRead`, `AuthReadTickets`, `AuthNoScopes`) — credential tiers.
+   `AuthRead`, `AuthReadTickets`, `AuthNoScopes`) plus `Auth.Valid()` —
+   credential tiers.
 3. `Golden` — the recorded contract for one case.
 4. `RunCase(http.Handler, Case)` — drive one case through a mounted stack,
    returning the observed `Golden` (canonicalized, transform applied).

--- a/contract/README.md
+++ b/contract/README.md
@@ -22,8 +22,8 @@ One file per battery case (`battery.go` → `Cases()`), named
 ## Comparison is semantic, never byte-based
 
 `protojson` randomizes whitespace per build, so today's API is already not
-byte-stable. Replay therefore parses both sides, canonicalizes
-(`Canonicalize`), and diffs structurally (`Diff` / `CompareGolden`):
+byte-stable. Replay therefore parses both sides, canonicalizes, and diffs
+structurally (`CompareGolden`; the canonicalizer and differ are internal):
 
 - object key order never matters;
 - array order and length matter;
@@ -33,11 +33,11 @@ byte-stable. Replay therefore parses both sides, canonicalizes
   (emit-everything semantics are part of the contract);
 - byte-level output is informational only (printed on failure for debugging).
 
-## The single transform: `StripKeycloakID`
+## The single transform: `stripKeycloakID`
 
 Exactly one transform sits between the wire and the goldens: every object key
-named `keycloakId`, at any depth, is removed (`StripKeycloakID` in
-`canon.go`). The field — like the keycloak lookup route — is deleted at
+named `keycloakId`, at any depth, is removed (`stripKeycloakID` in
+`canon.go`, applied automatically inside `RunCase`). The field — like the keycloak lookup route — is deleted at
 cutover; goldens record the truth the new stack must reproduce, and the
 transform documents the break. It is applied symmetrically: to responses at
 record time and at replay time, so the corpus stays green against the old
@@ -48,6 +48,23 @@ deliberately **not** recorded — it dies at cutover, so there is no golden to
 hold it to. That leaves the 16 surviving public routes, all covered
 (enumerated on `Cases()` in `battery.go`; coverage enforced by
 `TestBatteryIsWellFormed`).
+
+## Public surface
+
+The package is a deep module: a small frozen API for the Phase 3 replay
+consumers (#125–#129), with the canonicalizer and differ kept internal
+(`canonicalize`, `marshalCanonical`, `stripKeycloakID`, `diff` in `canon.go`).
+Re-exporting any of them later is a non-breaking change if a consumer ever
+needs one. The exported surface is exactly five entries:
+
+1. `Cases() []Case` / `Case` — the recorded request battery.
+2. `Auth` and its constants (`AuthNone`, `AuthRawKey`, `AuthInvalidKey`,
+   `AuthRead`, `AuthReadTickets`, `AuthNoScopes`) — credential tiers.
+3. `Golden` — the recorded contract for one case.
+4. `RunCase(http.Handler, Case)` — drive one case through a mounted stack,
+   returning the observed `Golden` (canonicalized, transform applied).
+5. `CompareGolden(want, got)` / `SaveGolden` / `LoadGolden` — semantic
+   comparison and golden persistence.
 
 ## How the corpus was recorded
 

--- a/contract/battery.go
+++ b/contract/battery.go
@@ -1,0 +1,207 @@
+package contract
+
+// Cases returns the full recorded request battery: every surviving public
+// route × happy/edge/error/auth cases, both enum path forms, repeated-filter
+// and dual-spelling query combinations on tickets.
+//
+// 16 surviving public routes (the keycloak lookup route
+// /api/v1/milpac/keycloak/{keycloak_id} is deliberately NOT recorded — it
+// dies at cutover, so there is no golden to hold it to):
+//
+//  1. GET /api/v1/milpacs/profile/id/{user_id}
+//  2. GET /api/v1/milpacs/profile/username/{username}
+//  3. GET /api/v1/milpac/discord/{discord_id}
+//  4. GET /api/v1/milpac/gamertag/{gamertag}
+//  5. GET /api/v1/roster/{roster}
+//  6. GET /api/v1/roster/{roster}/lite
+//  7. GET /api/v1/s1/uniforms/{roster}
+//  8. GET /api/v1/milpacs/position/search/{position_query=**}
+//  9. GET /api/v1/milpacs/ranks
+//  10. GET /api/v1/milpacs/position/groups
+//  11. GET /api/v1/milpacs/awol
+//  12. GET /api/v1/tickets
+//  13. GET /api/v1/tickets/{ticket_id}
+//  14. GET /api/v1/tickets/ref/{ticket_ref}
+//  15. GET /api/v1/tickets/{ticket_id}/messages
+//  16. GET /api/v1/tickets/categories
+//
+// Path literals reference the recording seed (see fake_datastore_test.go and
+// contract/README.md): relation 1 ↔ user 3 (Jarvis.A), relation 2 ↔ user 8
+// (John.Doe), tickets 42/43/44, injected-outage ids 777 (profile) and
+// ROSTER_TYPE_ARLINGTON (roster). Cursor literals are base64url of the
+// deterministic seed cursors, exactly as the stack emits them.
+func Cases() []Case {
+	const (
+		// base64url("1748700000:44") — next_cursor after page 1 of
+		// /api/v1/tickets?per_page=1 against the seed.
+		ticketsPage2Cursor = "MTc0ODcwMDAwMDo0NA"
+		// base64url("1") — next_cursor after page 1 of
+		// /api/v1/tickets/42/messages?per_page=1 against the seed.
+		messagesPage2Cursor = "MQ"
+	)
+
+	return []Case{
+		// --- Auth tiers (pinned by #106): plain-text two-tier 401s, no
+		// WWW-Authenticate; scope failures surface as gRPC-status JSON 403s.
+		{Name: "auth/milpacs_missing_header", Method: "GET", Path: "/api/v1/milpacs/profile/id/1", Auth: AuthNone,
+			Notes: "No Authorization header: plain-text 401 naming the Bearer scheme."},
+		{Name: "auth/milpacs_raw_key", Method: "GET", Path: "/api/v1/milpacs/profile/id/1", Auth: AuthRawKey,
+			Notes: "Raw key without 'Bearer ' prefix: same scheme-error 401 tier."},
+		{Name: "auth/milpacs_invalid_key", Method: "GET", Path: "/api/v1/milpacs/profile/id/1", Auth: AuthInvalidKey,
+			Notes: "Well-formed Bearer token, unknown key: generic 'Unauthorized', leaks nothing."},
+		{Name: "auth/milpacs_wrong_scope", Method: "GET", Path: "/api/v1/milpacs/profile/id/1", Auth: AuthReadTickets,
+			Notes: "Valid key lacking 'read': PermissionDenied JSON via gRPC status mapping."},
+		{Name: "auth/milpacs_no_scopes", Method: "GET", Path: "/api/v1/milpacs/profile/id/1", Auth: AuthNoScopes,
+			Notes: "Valid key with empty scope set: same PermissionDenied surface."},
+		{Name: "auth/tickets_missing_header", Method: "GET", Path: "/api/v1/tickets", Auth: AuthNone,
+			Notes: "Tickets surface, no Authorization header: plain-text scheme-error 401."},
+		{Name: "auth/tickets_raw_key", Method: "GET", Path: "/api/v1/tickets", Auth: AuthRawKey,
+			Notes: "Tickets surface, raw key: scheme-error 401."},
+		{Name: "auth/tickets_invalid_key", Method: "GET", Path: "/api/v1/tickets", Auth: AuthInvalidKey,
+			Notes: "Tickets surface, unknown key: generic 'Unauthorized'."},
+		{Name: "auth/tickets_wrong_scope", Method: "GET", Path: "/api/v1/tickets", Auth: AuthRead,
+			Notes: "'read' does not imply 'read:tickets': PermissionDenied JSON."},
+		{Name: "auth/unknown_path_authenticated", Method: "GET", Path: "/api/v1/does/not/exist", Auth: AuthRead,
+			Notes: "Unknown path under the API prefix with valid auth: JSON 404 body from the gateway mux."},
+		{Name: "auth/unknown_path_unauthenticated", Method: "GET", Path: "/api/v1/does/not/exist", Auth: AuthNone,
+			Notes: "Auth runs before routing: unknown path without auth is the 401 tier, not 404."},
+
+		// --- Profile by id / username -----------------------------------
+		{Name: "milpacs/profile_by_id_happy", Method: "GET", Path: "/api/v1/milpacs/profile/id/1", Auth: AuthRead,
+			Notes: "Path value is the MILPAC RELATION key, not the forum user id: seed diverges (relation 1 ↔ user 3) and this golden proves relation wins (user.userId is \"3\"). keycloakId stripped by the corpus transform."},
+		{Name: "milpacs/profile_by_id_sparse", Method: "GET", Path: "/api/v1/milpacs/profile/id/2", Auth: AuthRead,
+			Notes: "Emit-everything semantics: unset nested message is null (primary), empty collections are [], unset strings are \"\", 64-bit ints are strings."},
+		{Name: "milpacs/profile_by_id_not_found", Method: "GET", Path: "/api/v1/milpacs/profile/id/999", Auth: AuthRead,
+			Notes: "NotFound: handler-specific message string, verbatim."},
+		{Name: "milpacs/profile_by_id_zero", Method: "GET", Path: "/api/v1/milpacs/profile/id/0", Auth: AuthRead,
+			Notes: "id 0 parses but is the proto zero value: 'no username or user ID provided'."},
+		{Name: "milpacs/profile_by_id_parse_error", Method: "GET", Path: "/api/v1/milpacs/profile/id/abc", Auth: AuthRead,
+			Notes: "Non-numeric id: gateway type-mismatch error leaks parse-error text. Frozen."},
+		{Name: "milpacs/profile_by_id_internal_error", Method: "GET", Path: "/api/v1/milpacs/profile/id/777", Auth: AuthRead,
+			Notes: "Datastore failure: Internal JSON with the wrapped error message leaked. Frozen."},
+		{Name: "milpacs/profile_by_username_happy", Method: "GET", Path: "/api/v1/milpacs/profile/username/Jarvis.A", Auth: AuthRead,
+			Notes: "Username binding of the same RPC."},
+		{Name: "milpacs/profile_by_username_not_found", Method: "GET", Path: "/api/v1/milpacs/profile/username/Ghost.User", Auth: AuthRead,
+			Notes: "NotFound message names the username."},
+
+		// --- Discord / gamertag lookups ----------------------------------
+		{Name: "milpacs/discord_happy", Method: "GET", Path: "/api/v1/milpac/discord/112233445566778899", Auth: AuthRead,
+			Notes: "Full profile via Discord snowflake."},
+		{Name: "milpacs/discord_not_found", Method: "GET", Path: "/api/v1/milpac/discord/999000999", Auth: AuthRead,
+			Notes: "NotFound message names the discord id."},
+		{Name: "milpacs/gamertag_happy", Method: "GET", Path: "/api/v1/milpac/gamertag/CavGamer77", Auth: AuthRead,
+			Notes: "Full profile via console gamertag."},
+		{Name: "milpacs/gamertag_not_found", Method: "GET", Path: "/api/v1/milpac/gamertag/GhostTag", Auth: AuthRead,
+			Notes: "NotFound message names the gamertag."},
+
+		// --- Reference lists ---------------------------------------------
+		{Name: "milpacs/ranks", Method: "GET", Path: "/api/v1/milpacs/ranks", Auth: AuthRead,
+			Notes: "Rank reference list; 64-bit rankId as string, 32-bit displayOrder as number."},
+		{Name: "milpacs/position_groups", Method: "GET", Path: "/api/v1/milpacs/position/groups", Auth: AuthRead,
+			Notes: "Nested groups → positions, including false booleans emitted."},
+		{Name: "milpacs/awol", Method: "GET", Path: "/api/v1/milpacs/awol", Auth: AuthRead,
+			Notes: "AWOL list; uint64 timestamp/postId/milpacId emitted as strings."},
+
+		// --- Roster: both enum path forms, empty, errors -------------------
+		{Name: "roster/combat_by_name", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_COMBAT", Auth: AuthRead,
+			Notes: "Enum NAME path form. Map keyed by relation id (string keys in JSON)."},
+		{Name: "roster/combat_by_number", Method: "GET", Path: "/api/v1/roster/1", Auth: AuthRead,
+			Notes: "Enum NUMBER path form: same payload as combat_by_name."},
+		{Name: "roster/reserve_empty", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_RESERVE", Auth: AuthRead,
+			Notes: "Roster with no members: {\"profiles\":{}}."},
+		{Name: "roster/unspecified_by_name", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_UNSPECIFIED", Auth: AuthRead,
+			Notes: "Explicit zero enum: 'cannot request null roster type'."},
+		{Name: "roster/unspecified_by_number", Method: "GET", Path: "/api/v1/roster/0", Auth: AuthRead,
+			Notes: "Numeric zero: same InvalidArgument."},
+		{Name: "roster/bogus_enum", Method: "GET", Path: "/api/v1/roster/IMAGINARY_ROSTER", Auth: AuthRead,
+			Notes: "Unknown enum literal: gateway parse error leaks enum-parse text. Frozen."},
+		{Name: "roster/internal_error", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_ARLINGTON", Auth: AuthRead,
+			Notes: "Datastore failure: Internal JSON; message embeds the enum name and wrapped error."},
+		{Name: "roster/unknown_query_param_ignored", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_COMBAT?totally_unknown=1&alsoUnknown=x", Auth: AuthRead,
+			Notes: "Unknown query parameters are ignored: identical payload to combat_by_name."},
+
+		// --- Lite roster ----------------------------------------------------
+		{Name: "roster/lite_combat_by_name", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_COMBAT/lite", Auth: AuthRead,
+			Notes: "Lite profile shape (no records/awards arrays)."},
+		{Name: "roster/lite_combat_by_number", Method: "GET", Path: "/api/v1/roster/1/lite", Auth: AuthRead,
+			Notes: "Number form of the lite roster."},
+		{Name: "roster/lite_reserve_empty", Method: "GET", Path: "/api/v1/roster/2/lite", Auth: AuthRead,
+			Notes: "Empty lite roster: {\"profiles\":{}}."},
+		{Name: "roster/lite_unspecified", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_UNSPECIFIED/lite", Auth: AuthRead,
+			Notes: "Zero enum on the lite binding."},
+
+		// --- S1 uniforms ----------------------------------------------------
+		{Name: "s1/uniforms_combat_by_name", Method: "GET", Path: "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", Auth: AuthRead,
+			Notes: "S1 uniforms shape, enum name form."},
+		{Name: "s1/uniforms_combat_by_number", Method: "GET", Path: "/api/v1/s1/uniforms/1", Auth: AuthRead,
+			Notes: "S1 uniforms, enum number form: same payload."},
+		{Name: "s1/uniforms_unspecified", Method: "GET", Path: "/api/v1/s1/uniforms/0", Auth: AuthRead,
+			Notes: "Zero enum on the uniforms binding."},
+
+		// --- Position search (multi-segment glob) --------------------------
+		{Name: "position/search_happy", Method: "GET", Path: "/api/v1/milpacs/position/search/Regimental%20Technical%20Aide", Auth: AuthRead,
+			Notes: "URL-encoded spaces decode before reaching the handler; exact title hits."},
+		{Name: "position/search_empty_result", Method: "GET", Path: "/api/v1/milpacs/position/search/squad%20leader", Auth: AuthRead,
+			Notes: "Plausible query, no rows: {\"profiles\":{}} with 200 — frozen as-is, see #137."},
+		{Name: "position/search_multi_segment", Method: "GET", Path: "/api/v1/milpacs/position/search/Platoon/Leader", Auth: AuthRead,
+			Notes: "{position_query=**} swallows slashes: multi-segment query routes, returns empty."},
+		{Name: "position/search_trailing_slash", Method: "GET", Path: "/api/v1/milpacs/position/search/", Auth: AuthRead,
+			Notes: "Bare search path: the ** glob matches the empty segment and the handler rejects it — 'position query cannot be empty'."},
+
+		// --- Tickets: list -------------------------------------------------
+		{Name: "tickets/list_default", Method: "GET", Path: "/api/v1/tickets", Auth: AuthReadTickets,
+			Notes: "All seeded tickets, last_modified DESC; empty next_cursor, has_more false."},
+		{Name: "tickets/list_repeated_status_filter", Method: "GET", Path: "/api/v1/tickets?status_id=1&status_id=5", Auth: AuthReadTickets,
+			Notes: "Repeated query params build a repeated field: tickets 43 and 42 only."},
+		{Name: "tickets/list_state_filter", Method: "GET", Path: "/api/v1/tickets?ticket_state=resolved", Auth: AuthReadTickets,
+			Notes: "String filter: resolved only."},
+		{Name: "tickets/list_category_includes_subcategories", Method: "GET", Path: "/api/v1/tickets?category_id=1", Auth: AuthReadTickets,
+			Notes: "Category filter expands the subtree by default: parent 1 pulls in child category 5."},
+		{Name: "tickets/list_category_exclude_subcategories", Method: "GET", Path: "/api/v1/tickets?category_id=1&exclude_subcategories=true", Auth: AuthReadTickets,
+			Notes: "exclude_subcategories=true matches the exact category only."},
+		{Name: "tickets/list_starter_filter", Method: "GET", Path: "/api/v1/tickets?starter_user_id=8", Auth: AuthReadTickets,
+			Notes: "Starter filter; forum user id (8), not relation key."},
+		{Name: "tickets/list_per_page_snake", Method: "GET", Path: "/api/v1/tickets?per_page=1", Auth: AuthReadTickets,
+			Notes: "snake_case query key; page 1 with next_cursor and has_more true."},
+		{Name: "tickets/list_per_page_camel", Method: "GET", Path: "/api/v1/tickets?perPage=1", Auth: AuthReadTickets,
+			Notes: "camelCase spelling of the same key: identical payload to list_per_page_snake."},
+		{Name: "tickets/list_page_two", Method: "GET", Path: "/api/v1/tickets?per_page=1&after_cursor=" + ticketsPage2Cursor, Auth: AuthReadTickets,
+			Notes: "Round-tripped cursor: page 2 holds ticket 43 and a further cursor."},
+		{Name: "tickets/list_invalid_cursor_camel", Method: "GET", Path: "/api/v1/tickets?afterCursor=bogus", Auth: AuthReadTickets,
+			Notes: "Malformed cursor (camelCase key): InvalidArgument 'invalid after_cursor'."},
+		{Name: "tickets/list_unknown_param_ignored", Method: "GET", Path: "/api/v1/tickets?utterly_unknown=42", Auth: AuthReadTickets,
+			Notes: "Unknown query parameter ignored: identical payload to list_default."},
+
+		// --- Tickets: get by id / ref ---------------------------------------
+		{Name: "tickets/get_by_id_happy", Method: "GET", Path: "/api/v1/tickets/42", Auth: AuthReadTickets,
+			Notes: "Ticket + firstMessages + deprecated top-level totalMessageCount duplicating ticket.totalMessageCount."},
+		{Name: "tickets/get_by_id_not_found", Method: "GET", Path: "/api/v1/tickets/9999", Auth: AuthReadTickets,
+			Notes: "NotFound names the numeric id."},
+		{Name: "tickets/get_by_id_parse_error", Method: "GET", Path: "/api/v1/tickets/abc", Auth: AuthReadTickets,
+			Notes: "Non-numeric id under {ticket_id}: leaked parse-error text. Frozen."},
+		{Name: "tickets/get_by_ref_happy", Method: "GET", Path: "/api/v1/tickets/ref/MF1UI9HE", Auth: AuthReadTickets,
+			Notes: "Ref binding returns the same GetTicketResponse shape."},
+		{Name: "tickets/get_by_ref_not_found", Method: "GET", Path: "/api/v1/tickets/ref/NOPE9999", Auth: AuthReadTickets,
+			Notes: "NotFound quotes the ref."},
+
+		// --- Tickets: messages ----------------------------------------------
+		{Name: "tickets/messages_default", Method: "GET", Path: "/api/v1/tickets/42/messages", Auth: AuthReadTickets,
+			Notes: "Full thread, position ascending; BBCode and &/<> characters unescaped in JSON strings."},
+		{Name: "tickets/messages_per_page_snake", Method: "GET", Path: "/api/v1/tickets/42/messages?per_page=1", Auth: AuthReadTickets,
+			Notes: "Message pagination: 1 row, position-based next_cursor, has_more true."},
+		{Name: "tickets/messages_per_page_camel", Method: "GET", Path: "/api/v1/tickets/42/messages?perPage=1", Auth: AuthReadTickets,
+			Notes: "camelCase spelling: identical payload to messages_per_page_snake."},
+		{Name: "tickets/messages_page_two", Method: "GET", Path: "/api/v1/tickets/42/messages?per_page=1&after_cursor=" + messagesPage2Cursor, Auth: AuthReadTickets,
+			Notes: "Round-tripped message cursor: second message only."},
+		{Name: "tickets/messages_invalid_cursor_snake", Method: "GET", Path: "/api/v1/tickets/42/messages?after_cursor=bogus", Auth: AuthReadTickets,
+			Notes: "Malformed message cursor: InvalidArgument 'invalid after_cursor'."},
+		{Name: "tickets/messages_unknown_ticket", Method: "GET", Path: "/api/v1/tickets/555/messages", Auth: AuthReadTickets,
+			Notes: "Unknown ticket id: empty page, not 404. Frozen."},
+		{Name: "tickets/messages_parse_error", Method: "GET", Path: "/api/v1/tickets/abc/messages", Auth: AuthReadTickets,
+			Notes: "Non-numeric id on the messages binding: leaked parse-error text."},
+
+		// --- Tickets: categories ---------------------------------------------
+		{Name: "tickets/categories", Method: "GET", Path: "/api/v1/tickets/categories", Auth: AuthReadTickets,
+			Notes: "Category reference tree; literal 'categories' segment wins over {ticket_id}."},
+	}
+}

--- a/contract/canon.go
+++ b/contract/canon.go
@@ -1,0 +1,191 @@
+// Package contract holds the golden contract corpus for the public HTTP API
+// (PRD #112, issue #116) and the machinery that makes it executable: a
+// canonicalizer, a semantic JSON differ, and the recorded request battery.
+//
+// The corpus freezes the observable behavior of the current gRPC + gateway
+// stack — status codes, contract-relevant headers, and response bodies — so
+// the stdlib net/http rewrite can be driven red→green against it, and so it
+// can live on permanently as the contract regression net.
+//
+// Comparison is semantic JSON equality: parse → canonicalize → diff. Byte
+// equality is explicitly NOT the contract (protojson randomizes whitespace
+// per build, so today's API is already not byte-stable).
+//
+// Exactly one transform is applied between the wire and the goldens:
+// StripKeycloakID. See its doc comment.
+package contract
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Canonicalize parses raw JSON into a canonical in-memory form: objects are
+// map[string]any, arrays []any, numbers json.Number (preserving the exact
+// wire literal — critical because protojson emits 64-bit integers as strings
+// and 32-bit ones as numbers, and that distinction is part of the contract).
+// Trailing garbage after the document is rejected.
+func Canonicalize(raw []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("canonicalize: %w", err)
+	}
+	// Reject trailing non-whitespace so a JSON prefix of a text body can't
+	// masquerade as a JSON response.
+	if dec.More() {
+		return nil, fmt.Errorf("canonicalize: trailing data after JSON document")
+	}
+	return v, nil
+}
+
+// MarshalCanonical renders a canonical value as deterministic bytes: object
+// keys sorted (encoding/json sorts map keys), 2-space indent, HTML escaping
+// off so URLs stay readable. Two semantically equal documents always yield
+// identical bytes. Used for golden files and diff display only — equality is
+// decided by Diff, never by comparing these bytes.
+func MarshalCanonical(v any) []byte {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		// Canonical values come from Canonicalize and contain only JSON-safe
+		// types; failure here is a programming error.
+		panic(fmt.Sprintf("contract: marshal canonical: %v", err))
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}
+
+// StripKeycloakID is the single documented corpus transform (issue #116).
+//
+// The profile shapes (Profile, LiteProfile) carry a deprecated "keycloakId"
+// field that is removed at cutover, together with the keycloak lookup route.
+// Goldens record the truth the new stack must reproduce, so the field is
+// stripped — from recorded goldens at record time and from live responses at
+// replay time, keeping the comparison symmetric while the old stack still
+// emits it. It removes every object key named exactly "keycloakId" at any
+// depth and touches nothing else. No other transform exists.
+func StripKeycloakID(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if k == "keycloakId" {
+				continue
+			}
+			out[k] = StripKeycloakID(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = StripKeycloakID(val)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// Diff reports the semantic differences between two canonical values as
+// human-readable strings, each prefixed with the dot-joined path of the
+// mismatch. An empty result means the documents are contract-equal.
+//
+// Equality rules: object key sets and values must match (key order never
+// matters); array order and length matter; number form matters ("3" the
+// string and 3 the number are different — protojson's 64-bit string form is
+// part of the wire contract); null, empty object/array, and absent key are
+// three distinct states.
+func Diff(want, got any) []string {
+	var diffs []string
+	diffValue("$", want, got, &diffs)
+	return diffs
+}
+
+func diffValue(path string, want, got any, diffs *[]string) {
+	switch w := want.(type) {
+	case map[string]any:
+		g, ok := got.(map[string]any)
+		if !ok {
+			*diffs = append(*diffs, fmt.Sprintf("%s: want object, got %s", path, render(got)))
+			return
+		}
+		keys := make([]string, 0, len(w)+len(g))
+		for k := range w {
+			keys = append(keys, k)
+		}
+		for k := range g {
+			if _, dup := w[k]; !dup {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			wv, inW := w[k]
+			gv, inG := g[k]
+			kp := path + "." + k
+			switch {
+			case !inG:
+				*diffs = append(*diffs, fmt.Sprintf("%s: missing (want %s)", kp, render(wv)))
+			case !inW:
+				*diffs = append(*diffs, fmt.Sprintf("%s: unexpected key (got %s)", kp, render(gv)))
+			default:
+				diffValue(kp, wv, gv, diffs)
+			}
+		}
+	case []any:
+		g, ok := got.([]any)
+		if !ok {
+			*diffs = append(*diffs, fmt.Sprintf("%s: want array, got %s", path, render(got)))
+			return
+		}
+		if len(w) != len(g) {
+			*diffs = append(*diffs, fmt.Sprintf("%s: array length %d != %d", path, len(w), len(g)))
+			return
+		}
+		for i := range w {
+			diffValue(fmt.Sprintf("%s[%d]", path, i), w[i], g[i], diffs)
+		}
+	default:
+		if !scalarEqual(want, got) {
+			*diffs = append(*diffs, fmt.Sprintf("%s: want %s, got %s", path, render(want), render(got)))
+		}
+	}
+}
+
+// scalarEqual compares JSON scalars. json.Number compares by literal so the
+// wire form is preserved; types must match exactly (string "3" ≠ number 3).
+func scalarEqual(a, b any) bool {
+	switch av := a.(type) {
+	case json.Number:
+		bv, ok := b.(json.Number)
+		return ok && av == bv
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case nil:
+		return b == nil
+	default:
+		// Composites reaching here mean the caller compared mismatched kinds.
+		return false
+	}
+}
+
+// render shows a value compactly for diff messages.
+func render(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	if len(b) > 80 {
+		b = append(b[:77], "..."...)
+	}
+	return string(b)
+}

--- a/contract/canon.go
+++ b/contract/canon.go
@@ -12,7 +12,7 @@
 // per build, so today's API is already not byte-stable).
 //
 // Exactly one transform is applied between the wire and the goldens:
-// StripKeycloakID. See its doc comment.
+// stripKeycloakID. See its doc comment.
 package contract
 
 import (
@@ -22,12 +22,12 @@ import (
 	"sort"
 )
 
-// Canonicalize parses raw JSON into a canonical in-memory form: objects are
+// canonicalize parses raw JSON into a canonical in-memory form: objects are
 // map[string]any, arrays []any, numbers json.Number (preserving the exact
 // wire literal — critical because protojson emits 64-bit integers as strings
 // and 32-bit ones as numbers, and that distinction is part of the contract).
 // Trailing garbage after the document is rejected.
-func Canonicalize(raw []byte) (any, error) {
+func canonicalize(raw []byte) (any, error) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
 	var v any
@@ -42,25 +42,25 @@ func Canonicalize(raw []byte) (any, error) {
 	return v, nil
 }
 
-// MarshalCanonical renders a canonical value as deterministic bytes: object
+// marshalCanonical renders a canonical value as deterministic bytes: object
 // keys sorted (encoding/json sorts map keys), 2-space indent, HTML escaping
 // off so URLs stay readable. Two semantically equal documents always yield
 // identical bytes. Used for golden files and diff display only — equality is
-// decided by Diff, never by comparing these bytes.
-func MarshalCanonical(v any) []byte {
+// decided by diff, never by comparing these bytes.
+func marshalCanonical(v any) []byte {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(v); err != nil {
-		// Canonical values come from Canonicalize and contain only JSON-safe
+		// Canonical values come from canonicalize and contain only JSON-safe
 		// types; failure here is a programming error.
 		panic(fmt.Sprintf("contract: marshal canonical: %v", err))
 	}
 	return bytes.TrimRight(buf.Bytes(), "\n")
 }
 
-// StripKeycloakID is the single documented corpus transform (issue #116).
+// stripKeycloakID is the single documented corpus transform (issue #116).
 //
 // The profile shapes (Profile, LiteProfile) carry a deprecated "keycloakId"
 // field that is removed at cutover, together with the keycloak lookup route.
@@ -69,7 +69,7 @@ func MarshalCanonical(v any) []byte {
 // replay time, keeping the comparison symmetric while the old stack still
 // emits it. It removes every object key named exactly "keycloakId" at any
 // depth and touches nothing else. No other transform exists.
-func StripKeycloakID(v any) any {
+func stripKeycloakID(v any) any {
 	switch t := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(t))
@@ -77,13 +77,13 @@ func StripKeycloakID(v any) any {
 			if k == "keycloakId" {
 				continue
 			}
-			out[k] = StripKeycloakID(val)
+			out[k] = stripKeycloakID(val)
 		}
 		return out
 	case []any:
 		out := make([]any, len(t))
 		for i, val := range t {
-			out[i] = StripKeycloakID(val)
+			out[i] = stripKeycloakID(val)
 		}
 		return out
 	default:
@@ -91,7 +91,7 @@ func StripKeycloakID(v any) any {
 	}
 }
 
-// Diff reports the semantic differences between two canonical values as
+// diff reports the semantic differences between two canonical values as
 // human-readable strings, each prefixed with the dot-joined path of the
 // mismatch. An empty result means the documents are contract-equal.
 //
@@ -100,7 +100,7 @@ func StripKeycloakID(v any) any {
 // string and 3 the number are different — protojson's 64-bit string form is
 // part of the wire contract); null, empty object/array, and absent key are
 // three distinct states.
-func Diff(want, got any) []string {
+func diff(want, got any) []string {
 	var diffs []string
 	diffValue("$", want, got, &diffs)
 	return diffs

--- a/contract/canon_test.go
+++ b/contract/canon_test.go
@@ -1,0 +1,129 @@
+package contract
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalize_ParsesAndPreservesNumberForms(t *testing.T) {
+	// protojson emits 64-bit ints as strings and 32-bit ints as numbers.
+	// Canonicalization must keep each form exactly as the wire produced it:
+	// "3" must stay a string, 42 must stay the literal 42.
+	v, err := Canonicalize([]byte(`{"userId":"3", "ticketId":42, "big":9007199254740993}`))
+	require.NoError(t, err)
+
+	out := string(MarshalCanonical(v))
+	assert.Contains(t, out, `"userId": "3"`)
+	assert.Contains(t, out, `"ticketId": 42`)
+	// Numbers beyond float64 precision must round-trip verbatim.
+	assert.Contains(t, out, `"big": 9007199254740993`)
+}
+
+func TestCanonicalize_RejectsNonJSON(t *testing.T) {
+	_, err := Canonicalize([]byte("Unauthorized\n"))
+	require.Error(t, err)
+}
+
+func TestCanonicalize_RejectsTrailingGarbage(t *testing.T) {
+	_, err := Canonicalize([]byte(`{"a":1} trailing`))
+	require.Error(t, err)
+}
+
+func TestMarshalCanonical_SortsKeysAndIsWhitespaceStable(t *testing.T) {
+	a, err := Canonicalize([]byte(`{"b":1,"a":{"d":[1,2],"c":"x"}}`))
+	require.NoError(t, err)
+	b, err := Canonicalize([]byte("{\n  \"a\": {\"c\":\"x\", \"d\":[1, 2]},\n  \"b\": 1\n}"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(MarshalCanonical(a)), string(MarshalCanonical(b)),
+		"same semantic document must canonicalize to identical bytes")
+}
+
+func TestMarshalCanonical_DoesNotEscapeHTML(t *testing.T) {
+	v, err := Canonicalize([]byte(`{"url":"https://7cav.us/a?x=1&y=2"}`))
+	require.NoError(t, err)
+	assert.Contains(t, string(MarshalCanonical(v)), "x=1&y=2",
+		"URLs must stay readable; no \\u0026 escaping")
+}
+
+func TestStripKeycloakID_RemovesKeyAtAnyDepth(t *testing.T) {
+	// The single documented transform: profile shapes lose keycloakId at
+	// cutover, so goldens are recorded without it. Nothing else is touched.
+	v, err := Canonicalize([]byte(`{
+		"keycloakId": "top",
+		"user": {"keycloakId": "nested", "userId": "3"},
+		"profiles": {"1": {"keycloakId": "deep", "realName": "Adam"}},
+		"list": [{"keycloakId": "in-array", "keep": true}]
+	}`))
+	require.NoError(t, err)
+
+	out := string(MarshalCanonical(StripKeycloakID(v)))
+	assert.NotContains(t, out, "keycloakId")
+	assert.Contains(t, out, `"userId": "3"`)
+	assert.Contains(t, out, `"realName": "Adam"`)
+	assert.Contains(t, out, `"keep": true`)
+}
+
+func TestStripKeycloakID_LeavesValuesNamedKeycloakAlone(t *testing.T) {
+	v, err := Canonicalize([]byte(`{"note":"keycloakId lives in values"}`))
+	require.NoError(t, err)
+	out := string(MarshalCanonical(StripKeycloakID(v)))
+	assert.Contains(t, out, "keycloakId lives in values")
+}
+
+func TestDiff_EqualDocumentsRegardlessOfFormatting(t *testing.T) {
+	a, _ := Canonicalize([]byte(`{"x":[1,2,3],"y":{"z":"s"}}`))
+	b, _ := Canonicalize([]byte("{\"y\": {\"z\": \"s\"}, \"x\": [1, 2, 3]}"))
+	assert.Empty(t, Diff(a, b))
+}
+
+func TestDiff_ReportsPathOfMismatch(t *testing.T) {
+	a, _ := Canonicalize([]byte(`{"profiles":{"1":{"user":{"userId":"3"}}}}`))
+	b, _ := Canonicalize([]byte(`{"profiles":{"1":{"user":{"userId":"4"}}}}`))
+	diffs := Diff(a, b)
+	require.Len(t, diffs, 1)
+	assert.Contains(t, diffs[0], "profiles.1.user.userId")
+	assert.Contains(t, diffs[0], `"3"`)
+	assert.Contains(t, diffs[0], `"4"`)
+}
+
+func TestDiff_NumberFormMatters(t *testing.T) {
+	// "3" (string) vs 3 (number) is a contract break: protojson's 64-bit
+	// string form is part of the wire contract.
+	a, _ := Canonicalize([]byte(`{"id":"3"}`))
+	b, _ := Canonicalize([]byte(`{"id":3}`))
+	assert.NotEmpty(t, Diff(a, b))
+}
+
+func TestDiff_MissingAndExtraKeys(t *testing.T) {
+	a, _ := Canonicalize([]byte(`{"a":1,"b":2}`))
+	b, _ := Canonicalize([]byte(`{"a":1,"c":3}`))
+	diffs := Diff(a, b)
+	assert.Len(t, diffs, 2)
+}
+
+func TestDiff_ArrayLengthAndOrder(t *testing.T) {
+	a, _ := Canonicalize([]byte(`{"r":[1,2]}`))
+	b, _ := Canonicalize([]byte(`{"r":[2,1]}`))
+	assert.NotEmpty(t, Diff(a, b), "array order is part of the contract")
+
+	c, _ := Canonicalize([]byte(`{"r":[1]}`))
+	assert.NotEmpty(t, Diff(a, c))
+}
+
+func TestDiff_NullVersusAbsentVersusEmpty(t *testing.T) {
+	// Emit-everything semantics: null, {}, and absent are three distinct
+	// contract states.
+	null1, _ := Canonicalize([]byte(`{"primary":null}`))
+	empty, _ := Canonicalize([]byte(`{"primary":{}}`))
+	absent, _ := Canonicalize([]byte(`{}`))
+
+	assert.NotEmpty(t, Diff(null1, empty))
+	assert.NotEmpty(t, Diff(null1, absent))
+	assert.NotEmpty(t, Diff(empty, absent))
+
+	null2, _ := Canonicalize([]byte(`{"primary": null}`))
+	assert.Empty(t, Diff(null1, null2))
+}

--- a/contract/canon_test.go
+++ b/contract/canon_test.go
@@ -11,10 +11,10 @@ func TestCanonicalize_ParsesAndPreservesNumberForms(t *testing.T) {
 	// protojson emits 64-bit ints as strings and 32-bit ints as numbers.
 	// Canonicalization must keep each form exactly as the wire produced it:
 	// "3" must stay a string, 42 must stay the literal 42.
-	v, err := Canonicalize([]byte(`{"userId":"3", "ticketId":42, "big":9007199254740993}`))
+	v, err := canonicalize([]byte(`{"userId":"3", "ticketId":42, "big":9007199254740993}`))
 	require.NoError(t, err)
 
-	out := string(MarshalCanonical(v))
+	out := string(marshalCanonical(v))
 	assert.Contains(t, out, `"userId": "3"`)
 	assert.Contains(t, out, `"ticketId": 42`)
 	// Numbers beyond float64 precision must round-trip verbatim.
@@ -22,36 +22,36 @@ func TestCanonicalize_ParsesAndPreservesNumberForms(t *testing.T) {
 }
 
 func TestCanonicalize_RejectsNonJSON(t *testing.T) {
-	_, err := Canonicalize([]byte("Unauthorized\n"))
+	_, err := canonicalize([]byte("Unauthorized\n"))
 	require.Error(t, err)
 }
 
 func TestCanonicalize_RejectsTrailingGarbage(t *testing.T) {
-	_, err := Canonicalize([]byte(`{"a":1} trailing`))
+	_, err := canonicalize([]byte(`{"a":1} trailing`))
 	require.Error(t, err)
 }
 
 func TestMarshalCanonical_SortsKeysAndIsWhitespaceStable(t *testing.T) {
-	a, err := Canonicalize([]byte(`{"b":1,"a":{"d":[1,2],"c":"x"}}`))
+	a, err := canonicalize([]byte(`{"b":1,"a":{"d":[1,2],"c":"x"}}`))
 	require.NoError(t, err)
-	b, err := Canonicalize([]byte("{\n  \"a\": {\"c\":\"x\", \"d\":[1, 2]},\n  \"b\": 1\n}"))
+	b, err := canonicalize([]byte("{\n  \"a\": {\"c\":\"x\", \"d\":[1, 2]},\n  \"b\": 1\n}"))
 	require.NoError(t, err)
 
-	assert.Equal(t, string(MarshalCanonical(a)), string(MarshalCanonical(b)),
+	assert.Equal(t, string(marshalCanonical(a)), string(marshalCanonical(b)),
 		"same semantic document must canonicalize to identical bytes")
 }
 
 func TestMarshalCanonical_DoesNotEscapeHTML(t *testing.T) {
-	v, err := Canonicalize([]byte(`{"url":"https://7cav.us/a?x=1&y=2"}`))
+	v, err := canonicalize([]byte(`{"url":"https://7cav.us/a?x=1&y=2"}`))
 	require.NoError(t, err)
-	assert.Contains(t, string(MarshalCanonical(v)), "x=1&y=2",
+	assert.Contains(t, string(marshalCanonical(v)), "x=1&y=2",
 		"URLs must stay readable; no \\u0026 escaping")
 }
 
 func TestStripKeycloakID_RemovesKeyAtAnyDepth(t *testing.T) {
 	// The single documented transform: profile shapes lose keycloakId at
 	// cutover, so goldens are recorded without it. Nothing else is touched.
-	v, err := Canonicalize([]byte(`{
+	v, err := canonicalize([]byte(`{
 		"keycloakId": "top",
 		"user": {"keycloakId": "nested", "userId": "3"},
 		"profiles": {"1": {"keycloakId": "deep", "realName": "Adam"}},
@@ -59,7 +59,7 @@ func TestStripKeycloakID_RemovesKeyAtAnyDepth(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	out := string(MarshalCanonical(StripKeycloakID(v)))
+	out := string(marshalCanonical(stripKeycloakID(v)))
 	assert.NotContains(t, out, "keycloakId")
 	assert.Contains(t, out, `"userId": "3"`)
 	assert.Contains(t, out, `"realName": "Adam"`)
@@ -67,22 +67,22 @@ func TestStripKeycloakID_RemovesKeyAtAnyDepth(t *testing.T) {
 }
 
 func TestStripKeycloakID_LeavesValuesNamedKeycloakAlone(t *testing.T) {
-	v, err := Canonicalize([]byte(`{"note":"keycloakId lives in values"}`))
+	v, err := canonicalize([]byte(`{"note":"keycloakId lives in values"}`))
 	require.NoError(t, err)
-	out := string(MarshalCanonical(StripKeycloakID(v)))
+	out := string(marshalCanonical(stripKeycloakID(v)))
 	assert.Contains(t, out, "keycloakId lives in values")
 }
 
 func TestDiff_EqualDocumentsRegardlessOfFormatting(t *testing.T) {
-	a, _ := Canonicalize([]byte(`{"x":[1,2,3],"y":{"z":"s"}}`))
-	b, _ := Canonicalize([]byte("{\"y\": {\"z\": \"s\"}, \"x\": [1, 2, 3]}"))
-	assert.Empty(t, Diff(a, b))
+	a, _ := canonicalize([]byte(`{"x":[1,2,3],"y":{"z":"s"}}`))
+	b, _ := canonicalize([]byte("{\"y\": {\"z\": \"s\"}, \"x\": [1, 2, 3]}"))
+	assert.Empty(t, diff(a, b))
 }
 
 func TestDiff_ReportsPathOfMismatch(t *testing.T) {
-	a, _ := Canonicalize([]byte(`{"profiles":{"1":{"user":{"userId":"3"}}}}`))
-	b, _ := Canonicalize([]byte(`{"profiles":{"1":{"user":{"userId":"4"}}}}`))
-	diffs := Diff(a, b)
+	a, _ := canonicalize([]byte(`{"profiles":{"1":{"user":{"userId":"3"}}}}`))
+	b, _ := canonicalize([]byte(`{"profiles":{"1":{"user":{"userId":"4"}}}}`))
+	diffs := diff(a, b)
 	require.Len(t, diffs, 1)
 	assert.Contains(t, diffs[0], "profiles.1.user.userId")
 	assert.Contains(t, diffs[0], `"3"`)
@@ -92,38 +92,38 @@ func TestDiff_ReportsPathOfMismatch(t *testing.T) {
 func TestDiff_NumberFormMatters(t *testing.T) {
 	// "3" (string) vs 3 (number) is a contract break: protojson's 64-bit
 	// string form is part of the wire contract.
-	a, _ := Canonicalize([]byte(`{"id":"3"}`))
-	b, _ := Canonicalize([]byte(`{"id":3}`))
-	assert.NotEmpty(t, Diff(a, b))
+	a, _ := canonicalize([]byte(`{"id":"3"}`))
+	b, _ := canonicalize([]byte(`{"id":3}`))
+	assert.NotEmpty(t, diff(a, b))
 }
 
 func TestDiff_MissingAndExtraKeys(t *testing.T) {
-	a, _ := Canonicalize([]byte(`{"a":1,"b":2}`))
-	b, _ := Canonicalize([]byte(`{"a":1,"c":3}`))
-	diffs := Diff(a, b)
+	a, _ := canonicalize([]byte(`{"a":1,"b":2}`))
+	b, _ := canonicalize([]byte(`{"a":1,"c":3}`))
+	diffs := diff(a, b)
 	assert.Len(t, diffs, 2)
 }
 
 func TestDiff_ArrayLengthAndOrder(t *testing.T) {
-	a, _ := Canonicalize([]byte(`{"r":[1,2]}`))
-	b, _ := Canonicalize([]byte(`{"r":[2,1]}`))
-	assert.NotEmpty(t, Diff(a, b), "array order is part of the contract")
+	a, _ := canonicalize([]byte(`{"r":[1,2]}`))
+	b, _ := canonicalize([]byte(`{"r":[2,1]}`))
+	assert.NotEmpty(t, diff(a, b), "array order is part of the contract")
 
-	c, _ := Canonicalize([]byte(`{"r":[1]}`))
-	assert.NotEmpty(t, Diff(a, c))
+	c, _ := canonicalize([]byte(`{"r":[1]}`))
+	assert.NotEmpty(t, diff(a, c))
 }
 
 func TestDiff_NullVersusAbsentVersusEmpty(t *testing.T) {
 	// Emit-everything semantics: null, {}, and absent are three distinct
 	// contract states.
-	null1, _ := Canonicalize([]byte(`{"primary":null}`))
-	empty, _ := Canonicalize([]byte(`{"primary":{}}`))
-	absent, _ := Canonicalize([]byte(`{}`))
+	null1, _ := canonicalize([]byte(`{"primary":null}`))
+	empty, _ := canonicalize([]byte(`{"primary":{}}`))
+	absent, _ := canonicalize([]byte(`{}`))
 
-	assert.NotEmpty(t, Diff(null1, empty))
-	assert.NotEmpty(t, Diff(null1, absent))
-	assert.NotEmpty(t, Diff(empty, absent))
+	assert.NotEmpty(t, diff(null1, empty))
+	assert.NotEmpty(t, diff(null1, absent))
+	assert.NotEmpty(t, diff(empty, absent))
 
-	null2, _ := Canonicalize([]byte(`{"primary": null}`))
-	assert.Empty(t, Diff(null1, null2))
+	null2, _ := canonicalize([]byte(`{"primary": null}`))
+	assert.Empty(t, diff(null1, null2))
 }

--- a/contract/corpus_test.go
+++ b/contract/corpus_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -121,34 +122,47 @@ func TestBatteryIsWellFormed(t *testing.T) {
 		assert.NotEmpty(t, c.Notes, "%s: every case documents why it exists", c.Name)
 	}
 
-	// One representative path prefix (path-parameter cases vary the suffix)
-	// per surviving route.
-	routes := map[string]string{
-		"profile by id":       "/api/v1/milpacs/profile/id/",
-		"profile by username": "/api/v1/milpacs/profile/username/",
-		"discord lookup":      "/api/v1/milpac/discord/",
-		"gamertag lookup":     "/api/v1/milpac/gamertag/",
-		"roster":              "/api/v1/roster/ROSTER_TYPE_COMBAT",
-		"lite roster":         "/api/v1/roster/ROSTER_TYPE_COMBAT/lite",
-		"s1 uniforms":         "/api/v1/s1/uniforms/",
-		"position search":     "/api/v1/milpacs/position/search/",
-		"ranks":               "/api/v1/milpacs/ranks",
-		"position groups":     "/api/v1/milpacs/position/groups",
-		"awol":                "/api/v1/milpacs/awol",
-		"tickets list":        "/api/v1/tickets",
-		"ticket by id":        "/api/v1/tickets/42",
-		"ticket by ref":       "/api/v1/tickets/ref/",
-		"ticket messages":     "/api/v1/tickets/42/messages",
-		"ticket categories":   "/api/v1/tickets/categories",
+	// One anchored pattern per surviving route, ordered most-specific first:
+	// each case path (query string stripped) is classified to the FIRST
+	// matching route, so a literal segment (categories, ref, messages) can
+	// never satisfy a path-parameter sibling. Prefix matching would let
+	// tickets/42/messages stand in for deleted ticket-by-id cases.
+	routes := []struct {
+		label   string
+		pattern *regexp.Regexp
+	}{
+		{"ticket categories", regexp.MustCompile(`^/api/v1/tickets/categories$`)},
+		{"ticket by ref", regexp.MustCompile(`^/api/v1/tickets/ref/[^/]+$`)},
+		{"ticket messages", regexp.MustCompile(`^/api/v1/tickets/[^/]+/messages$`)},
+		{"ticket by id", regexp.MustCompile(`^/api/v1/tickets/[^/]+$`)},
+		{"tickets list", regexp.MustCompile(`^/api/v1/tickets$`)},
+		{"lite roster", regexp.MustCompile(`^/api/v1/roster/[^/]+/lite$`)},
+		{"roster", regexp.MustCompile(`^/api/v1/roster/[^/]+$`)},
+		{"s1 uniforms", regexp.MustCompile(`^/api/v1/s1/uniforms/[^/]+$`)},
+		{"position groups", regexp.MustCompile(`^/api/v1/milpacs/position/groups$`)},
+		{"position search", regexp.MustCompile(`^/api/v1/milpacs/position/search(/.*)?$`)},
+		{"ranks", regexp.MustCompile(`^/api/v1/milpacs/ranks$`)},
+		{"awol", regexp.MustCompile(`^/api/v1/milpacs/awol$`)},
+		{"profile by id", regexp.MustCompile(`^/api/v1/milpacs/profile/id/[^/]+$`)},
+		{"profile by username", regexp.MustCompile(`^/api/v1/milpacs/profile/username/[^/]+$`)},
+		{"discord lookup", regexp.MustCompile(`^/api/v1/milpac/discord/[^/]+$`)},
+		{"gamertag lookup", regexp.MustCompile(`^/api/v1/milpac/gamertag/[^/]+$`)},
 	}
-	for label, prefix := range routes {
-		found := false
-		for _, c := range cases {
-			if strings.HasPrefix(c.Path, prefix) {
-				found = true
+	counts := map[string]int{}
+	for _, c := range cases {
+		path := c.Path
+		if i := strings.IndexByte(path, '?'); i >= 0 {
+			path = path[:i]
+		}
+		for _, r := range routes {
+			if r.pattern.MatchString(path) {
+				counts[r.label]++
 				break
 			}
 		}
-		assert.True(t, found, "no battery case covers route: %s (%s)", label, prefix)
+	}
+	for _, r := range routes {
+		assert.Positive(t, counts[r.label],
+			"no battery case covers route: %s (%s)", r.label, r.pattern)
 	}
 }

--- a/contract/corpus_test.go
+++ b/contract/corpus_test.go
@@ -67,9 +67,9 @@ func TestContractCorpus(t *testing.T) {
 // the informational byte comparison isn't tripped by file formatting.
 func normalizeRaw(t *testing.T, raw []byte) []byte {
 	t.Helper()
-	v, err := Canonicalize(raw)
+	v, err := canonicalize(raw)
 	require.NoError(t, err)
-	return MarshalCanonical(v)
+	return marshalCanonical(v)
 }
 
 func truncateForLog(b []byte) string {

--- a/contract/corpus_test.go
+++ b/contract/corpus_test.go
@@ -1,0 +1,154 @@
+package contract
+
+import (
+	"bytes"
+	"flag"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Re-record the corpus from the current stack (only possible while the old
+// stack remains in-tree):
+//
+//	go test ./contract -run TestContractCorpus -update
+//
+// Review the goldens diff like any other code change before committing.
+var update = flag.Bool("update", false, "re-record contract goldens from the current stack")
+
+const goldensDir = "goldens"
+
+// TestContractCorpus replays the full battery against the in-process current
+// stack and compares each response semantically (parse → canonicalize → diff)
+// against the committed golden. Status code and allowlisted headers are part
+// of every comparison. Byte-level output is informational only.
+func TestContractCorpus(t *testing.T) {
+	h := currentStack(t)
+
+	for _, c := range Cases() {
+		t.Run(c.Name, func(t *testing.T) {
+			got, raw, err := RunCase(h, c)
+			require.NoError(t, err)
+
+			if *update {
+				require.NoError(t, SaveGolden(goldensDir, got))
+				return
+			}
+
+			want, err := LoadGolden(goldensDir, c.Name)
+			require.NoError(t, err,
+				"missing golden for %s — re-record with: go test ./contract -run TestContractCorpus -update", c.Name)
+
+			diffs := CompareGolden(want, got)
+			if len(diffs) > 0 {
+				for _, d := range diffs {
+					t.Error(d)
+				}
+				t.Logf("informational raw response (%d bytes, NOT the basis of comparison):\n%s",
+					len(raw), truncateForLog(raw))
+				return
+			}
+
+			// Informational byte-diff: semantic equality is the contract;
+			// canonical-byte drift (e.g. a hand-edited golden) is only noted.
+			if got.Body != nil && want.Body != nil && !bytes.Equal(normalizeRaw(t, want.Body), normalizeRaw(t, got.Body)) {
+				t.Logf("informational: golden bytes differ from observed canonical bytes (semantically equal)")
+			}
+		})
+	}
+}
+
+// normalizeRaw renders a stored golden body through the canonical encoder so
+// the informational byte comparison isn't tripped by file formatting.
+func normalizeRaw(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	v, err := Canonicalize(raw)
+	require.NoError(t, err)
+	return MarshalCanonical(v)
+}
+
+func truncateForLog(b []byte) string {
+	const max = 2000
+	if len(b) > max {
+		return string(b[:max]) + "…(truncated)"
+	}
+	return string(b)
+}
+
+// TestCorpusHasNoOrphanGoldens fails when a committed golden no longer has a
+// battery case — stale goldens would silently stop guarding anything.
+func TestCorpusHasNoOrphanGoldens(t *testing.T) {
+	if *update {
+		t.Skip("recording")
+	}
+	known := map[string]bool{}
+	for _, c := range Cases() {
+		known[c.Name] = true
+	}
+	err := filepath.WalkDir(goldensDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(goldensDir, path)
+		require.NoError(t, err)
+		name := strings.TrimSuffix(filepath.ToSlash(rel), ".golden.json")
+		assert.True(t, known[name], "orphan golden %s has no battery case", path)
+		return nil
+	})
+	if os.IsNotExist(err) {
+		t.Fatalf("goldens directory missing — record the corpus first")
+	}
+	require.NoError(t, err)
+}
+
+// TestBatteryIsWellFormed pins structural invariants of the battery itself:
+// unique names, GET-only, the keycloak route deliberately absent, and at
+// least one case per surviving public route (all 16).
+func TestBatteryIsWellFormed(t *testing.T) {
+	cases := Cases()
+	seen := map[string]bool{}
+	for _, c := range cases {
+		assert.False(t, seen[c.Name], "duplicate case name %s", c.Name)
+		seen[c.Name] = true
+		assert.Equal(t, "GET", c.Method, "%s: corpus is GET-only today", c.Name)
+		assert.NotContains(t, c.Path, "/milpac/keycloak/",
+			"%s: the keycloak route dies at cutover and must not be recorded", c.Name)
+		assert.NotEmpty(t, c.Notes, "%s: every case documents why it exists", c.Name)
+	}
+
+	// One representative path prefix (path-parameter cases vary the suffix)
+	// per surviving route.
+	routes := map[string]string{
+		"profile by id":       "/api/v1/milpacs/profile/id/",
+		"profile by username": "/api/v1/milpacs/profile/username/",
+		"discord lookup":      "/api/v1/milpac/discord/",
+		"gamertag lookup":     "/api/v1/milpac/gamertag/",
+		"roster":              "/api/v1/roster/ROSTER_TYPE_COMBAT",
+		"lite roster":         "/api/v1/roster/ROSTER_TYPE_COMBAT/lite",
+		"s1 uniforms":         "/api/v1/s1/uniforms/",
+		"position search":     "/api/v1/milpacs/position/search/",
+		"ranks":               "/api/v1/milpacs/ranks",
+		"position groups":     "/api/v1/milpacs/position/groups",
+		"awol":                "/api/v1/milpacs/awol",
+		"tickets list":        "/api/v1/tickets",
+		"ticket by id":        "/api/v1/tickets/42",
+		"ticket by ref":       "/api/v1/tickets/ref/",
+		"ticket messages":     "/api/v1/tickets/42/messages",
+		"ticket categories":   "/api/v1/tickets/categories",
+	}
+	for label, prefix := range routes {
+		found := false
+		for _, c := range cases {
+			if strings.HasPrefix(c.Path, prefix) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "no battery case covers route: %s (%s)", label, prefix)
+	}
+}

--- a/contract/fake_datastore_test.go
+++ b/contract/fake_datastore_test.go
@@ -1,0 +1,668 @@
+package contract
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/xenforo"
+	"gorm.io/gorm"
+)
+
+// errOutage is the injected failure used to record the Internal-error (HTTP
+// 500) goldens. The message leaks into the response body via the handlers'
+// status.Errorf wrapping — that leak is frozen behavior.
+var errOutage = errors.New("simulated datastore outage")
+
+// recordingDatastore is the seeded, fully deterministic Datastore the corpus
+// is recorded against. It follows the fake-datastore pattern from
+// servers/grpc/fake_datastore_test.go but carries fixed seed data instead of
+// per-test function fields, because the corpus needs one stable world:
+//
+//   - Profiles are keyed by MILPAC RELATION ID, not forum user id, mirroring
+//     datastores.Mysql.FindProfilesById (gorm First(&profile, id) keys on the
+//     milpacs.Profile primary key = relation_id). The seed makes the two
+//     diverge — relation 1 ↔ user 3 — so the by-id golden proves which wins.
+//   - Cursor formats mirror datastores/tickets.go exactly: base64url("ts:id")
+//     for tickets, base64url("position") for messages, same default/clamp
+//     rules for per_page (0 → 50, >100 → 100).
+//   - Position search returns an empty (non-nil) LiteRoster for any query
+//     that isn't an exact seeded title — mirroring the frozen #137 behavior
+//     where plausible queries yield {"profiles":{}}.
+//
+// The keycloak lookup panics: the route is deliberately not recorded (#116)
+// and the battery must never reach it.
+type recordingDatastore struct{}
+
+// --- API keys ----------------------------------------------------------
+
+func (recordingDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
+	switch rawKey {
+	case "cav7_readkey":
+		return &datastores.ApiKeyResult{KeyId: 101, UserId: 3, Scopes: scopeSet("read")}, nil
+	case "cav7_ticketskey":
+		return &datastores.ApiKeyResult{KeyId: 102, UserId: 8, Scopes: scopeSet("read:tickets")}, nil
+	case "cav7_noscopekey":
+		return &datastores.ApiKeyResult{KeyId: 103, UserId: 9, Scopes: scopeSet()}, nil
+	default:
+		return nil, nil // zero rows — generic Unauthorized, leaks nothing
+	}
+}
+
+func scopeSet(scopes ...string) map[string]struct{} {
+	m := map[string]struct{}{}
+	for _, s := range scopes {
+		m[s] = struct{}{}
+	}
+	return m
+}
+
+// --- Milpacs profiles ---------------------------------------------------
+
+// seedJarvis is the rich profile: every collection populated, relation id 1
+// diverging from user id 3 (matches the live-capture divergence for Jarvis.A).
+func seedJarvis() *proto.Profile {
+	return &proto.Profile{
+		User: &proto.User{UserId: 3, Username: "Jarvis.A"},
+		Rank: &proto.Rank{
+			RankShort:    "MG",
+			RankFull:     "Major General",
+			RankImageUrl: "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+			RankId:       4,
+		},
+		RealName:   "Adam Jarvis",
+		UniformUrl: "https://7cav.us/data/roster_uniforms/0/1.jpg",
+		Roster:     proto.RosterType_ROSTER_TYPE_COMBAT,
+		Primary:    &proto.Position{PositionTitle: "Regimental Technical Aide", PositionId: 773},
+		Secondaries: []*proto.Position{
+			{PositionTitle: "S6 Web Developer", PositionId: 812},
+		},
+		Records: []*proto.Record{
+			{
+				RecordDetails: "Promoted to Major General (O-8)",
+				RecordType:    proto.RecordType_RECORD_TYPE_PROMOTION,
+				RecordDate:    "2020-10-17",
+				RecordUid:     46,
+			},
+			{
+				RecordDetails: "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+				RecordType:    proto.RecordType_RECORD_TYPE_OPERATION,
+				RecordDate:    "2020-09-27",
+				RecordUid:     13863,
+			},
+		},
+		Awards: []*proto.Award{
+			{
+				AwardDetails:  "For technical excellence & dedication <est. 2014>",
+				AwardName:     "Commendation Medal",
+				AwardDate:     "2021-03-01",
+				AwardImageUrl: "https://7cav.us/data/awards/ccm.jpg",
+				AwardUid:      901,
+			},
+		},
+		JoinDate:          "2014-02-08",
+		PromotionDate:     "2020-10-17",
+		KeycloakId:        "3f8e2a10-dead-beef-cafe-0123456789ab",
+		DiscordId:         "112233445566778899",
+		LastForumPostDate: "2026-05-30",
+		Mos:               "11B",
+		ConsoleGamertag:   "",
+	}
+}
+
+// seedDoe is the sparse profile: unset nested messages stay nil (emitted as
+// null), collections stay empty (emitted as []), strings stay "" — the
+// emit-everything goldens hang off this profile. Relation 2 ↔ user 8.
+func seedDoe() *proto.Profile {
+	return &proto.Profile{
+		User:            &proto.User{UserId: 8, Username: "John.Doe"},
+		Rank:            &proto.Rank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "https://7cav.us/data/roster_ranks/0/22.jpg", RankId: 22},
+		RealName:        "John Doe",
+		UniformUrl:      "https://7cav.us/data/roster_uniforms/0/2.jpg",
+		Roster:          proto.RosterType_ROSTER_TYPE_COMBAT,
+		Primary:         nil, // → "primary": null
+		Secondaries:     []*proto.Position{},
+		Records:         []*proto.Record{},
+		Awards:          []*proto.Award{},
+		JoinDate:        "2026-01-15",
+		ConsoleGamertag: "CavGamer77",
+	}
+}
+
+func seedJarvisLite() *proto.LiteProfile {
+	j := seedJarvis()
+	return &proto.LiteProfile{
+		User:              j.User,
+		Rank:              j.Rank,
+		RealName:          j.RealName,
+		UniformUrl:        j.UniformUrl,
+		Roster:            j.Roster,
+		Primary:           j.Primary,
+		Secondaries:       j.Secondaries,
+		JoinDate:          j.JoinDate,
+		PromotionDate:     j.PromotionDate,
+		KeycloakId:        j.KeycloakId,
+		DiscordId:         j.DiscordId,
+		AwardDate:         "2021-03-01",
+		RecordDate:        "2020-10-17",
+		LastForumPostDate: j.LastForumPostDate,
+		Mos:               j.Mos,
+	}
+}
+
+func seedDoeLite() *proto.LiteProfile {
+	d := seedDoe()
+	return &proto.LiteProfile{
+		User:            d.User,
+		Rank:            d.Rank,
+		RealName:        d.RealName,
+		UniformUrl:      d.UniformUrl,
+		Roster:          d.Roster,
+		Secondaries:     []*proto.Position{},
+		JoinDate:        d.JoinDate,
+		ConsoleGamertag: d.ConsoleGamertag,
+	}
+}
+
+func (recordingDatastore) FindProfilesById(userIds ...uint64) ([]*proto.Profile, error) {
+	// Path value is the milpac relation key (see type comment). 777 is the
+	// injected-outage id for the 500 golden.
+	switch userIds[0] {
+	case 1:
+		return []*proto.Profile{seedJarvis()}, nil
+	case 2:
+		return []*proto.Profile{seedDoe()}, nil
+	case 777:
+		return nil, errOutage
+	default:
+		return nil, gorm.ErrRecordNotFound
+	}
+}
+
+func (recordingDatastore) FindProfilesByUsername(username string) ([]*proto.Profile, error) {
+	switch username {
+	case "Jarvis.A":
+		return []*proto.Profile{seedJarvis()}, nil
+	case "John.Doe":
+		return []*proto.Profile{seedDoe()}, nil
+	default:
+		return nil, gorm.ErrRecordNotFound
+	}
+}
+
+func (recordingDatastore) FindProfileByDiscordID(discordId string) (*proto.Profile, error) {
+	if discordId == "112233445566778899" {
+		return seedJarvis(), nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (recordingDatastore) FindProfileByGamertag(gamertag string) (*proto.Profile, error) {
+	if gamertag == "CavGamer77" {
+		return seedDoe(), nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (recordingDatastore) FindProfileByKeycloakID(string) (*proto.Profile, error) {
+	panic("contract: keycloak route is deliberately not recorded (#116)")
+}
+
+// --- Rosters ------------------------------------------------------------
+
+func (recordingDatastore) FindRosterByType(t proto.RosterType) (*proto.Roster, error) {
+	switch t {
+	case proto.RosterType_ROSTER_TYPE_COMBAT:
+		return &proto.Roster{Profiles: map[uint64]*proto.Profile{1: seedJarvis(), 2: seedDoe()}}, nil
+	case proto.RosterType_ROSTER_TYPE_ARLINGTON:
+		return nil, errOutage
+	default:
+		// Empty-but-present roster: {"profiles":{}}.
+		return &proto.Roster{Profiles: map[uint64]*proto.Profile{}}, nil
+	}
+}
+
+func (recordingDatastore) FindLiteRosterByType(t proto.RosterType) (*proto.LiteRoster, error) {
+	switch t {
+	case proto.RosterType_ROSTER_TYPE_COMBAT:
+		return &proto.LiteRoster{Profiles: map[uint64]*proto.LiteProfile{1: seedJarvisLite(), 2: seedDoeLite()}}, nil
+	default:
+		return &proto.LiteRoster{Profiles: map[uint64]*proto.LiteProfile{}}, nil
+	}
+}
+
+func (recordingDatastore) FindS1UniformsRosterByType(t proto.RosterType) (*proto.S1UniformsRoster, error) {
+	if t != proto.RosterType_ROSTER_TYPE_COMBAT {
+		return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{}}, nil
+	}
+	return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{
+		1: {
+			User:                     &proto.User{UserId: 3, Username: "Jarvis.A"},
+			Rank:                     &proto.S1UniformsRank{RankShort: "MG", RankFull: "Major General", RankImageUrl: "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618"},
+			RealName:                 "Adam Jarvis",
+			UniformUrl:               "https://7cav.us/data/roster_uniforms/0/1.jpg",
+			UniformDate:              "2025-11-02",
+			UniformUpdateTriggerDate: "2025-12-01",
+			Roster:                   proto.RosterType_ROSTER_TYPE_COMBAT,
+			PrimaryPositionTitle:     "Regimental Technical Aide",
+			Secondaries:              []*proto.S1UniformsPosition{{PositionTitle: "S6 Web Developer"}},
+			JoinDate:                 "2014-02-08",
+			PromotionDate:            "2020-10-17",
+			AreaOfResponsibility:     "S6",
+		},
+		2: {
+			User:                 &proto.User{UserId: 8, Username: "John.Doe"},
+			Rank:                 &proto.S1UniformsRank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "https://7cav.us/data/roster_ranks/0/22.jpg"},
+			RealName:             "John Doe",
+			UniformUrl:           "https://7cav.us/data/roster_uniforms/0/2.jpg",
+			Roster:               proto.RosterType_ROSTER_TYPE_COMBAT,
+			PrimaryPositionTitle: "Rifleman",
+			Secondaries:          []*proto.S1UniformsPosition{},
+			JoinDate:             "2026-01-15",
+		},
+	}}, nil
+}
+
+func (recordingDatastore) FindProfilesByPosition(positionQuery string) (*proto.LiteRoster, error) {
+	if positionQuery == "Regimental Technical Aide" {
+		return &proto.LiteRoster{Profiles: map[uint64]*proto.LiteProfile{1: seedJarvisLite()}}, nil
+	}
+	// Frozen #137 behavior: plausible queries come back empty, not 404.
+	return &proto.LiteRoster{Profiles: map[uint64]*proto.LiteProfile{}}, nil
+}
+
+// --- Reference lists ------------------------------------------------------
+
+func (recordingDatastore) FindAllRanks() ([]*proto.RankExpanded, error) {
+	return []*proto.RankExpanded{
+		{RankShort: "MG", RankFull: "Major General", RankImageUrl: "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618", RankId: 4, RankDisplayOrder: 4},
+		{RankShort: "PVT", RankFull: "Private", RankImageUrl: "https://7cav.us/data/roster_ranks/0/22.jpg", RankId: 22, RankDisplayOrder: 22},
+	}, nil
+}
+
+func (recordingDatastore) FindAllPositionGroups() ([]*proto.PositionGroup, error) {
+	return []*proto.PositionGroup{
+		{
+			GroupId:           9,
+			GroupTitle:        "Regimental HQ",
+			GroupDisplayOrder: 1,
+			Positions: []*proto.PositionExpanded{
+				{PositionTitle: "Regimental Technical Aide", PositionId: 773, PositionDisplayOrder: 3, PositionPossibleSecondary: false},
+				{PositionTitle: "S6 Web Developer", PositionId: 812, PositionDisplayOrder: 7, PositionPossibleSecondary: true},
+			},
+		},
+	}, nil
+}
+
+func (recordingDatastore) FindAwol() ([]*proto.Awol, error) {
+	return []*proto.Awol{
+		{
+			GroupName: "Alpha Company",
+			RankName:  "Private",
+			Username:  "John.Doe",
+			UserId:    8,
+			HumanDate: "2026-05-01",
+			Timestamp: 1777600000,
+			PostId:    445566,
+			MilpacId:  2,
+		},
+	}, nil
+}
+
+func (recordingDatastore) GetTableUpdates() ([]xenforo.TableInfo, error) {
+	panic("contract: GetTableUpdates is not a public route")
+}
+
+// --- Tickets --------------------------------------------------------------
+
+// seedTickets returns the ticket world sorted by last_modified_date DESC,
+// ticket_id DESC — the order the real datastore queries in.
+func seedTickets() []*proto.Ticket {
+	return []*proto.Ticket{
+		{
+			TicketId:            44,
+			TicketRef:           "ZZTOP44Q",
+			Title:               "Transfer request: Bravo to Alpha",
+			CategoryId:          5,
+			CategoryTitle:       "S1 Personnel",
+			CategoryAncestorIds: []uint32{1},
+			TicketState:         "open",
+			StatusId:            2,
+			StatusName:          "In Progress",
+			PriorityId:          2,
+			PriorityName:        "Normal",
+			PrefixId:            3,
+			PrefixName:          "Transfer",
+			DiscussionState:     "visible",
+			TicketLocked:        false,
+			StarterUserId:       8,
+			StarterUsername:     "John.Doe",
+			AssignedUserId:      3,
+			AssignedUsername:    "Jarvis.A",
+			Participants: []*proto.TicketParticipant{
+				{UserId: 8, LastReadDate: 1748690000},
+				{UserId: 3, LastReadDate: 1748695000},
+			},
+			StartDate:           1748600000,
+			LastMessageDate:     1748699000,
+			LastMessageUserId:   3,
+			LastMessageUsername: "Jarvis.A",
+			LastModifiedDate:    1748700000,
+			ReplyCount:          1,
+			TotalMessageCount:   2,
+			CustomFields:        map[string]string{"department": "S1", "billet": "Rifleman"},
+			ForumUrl:            "https://7cav.us/tickets/ZZTOP44Q/",
+		},
+		{
+			TicketId:            43,
+			TicketRef:           "QQWW43RR",
+			Title:               "TeamSpeak <connection> issues & errors",
+			CategoryId:          7,
+			CategoryTitle:       "S6 Technical Support",
+			CategoryAncestorIds: []uint32{},
+			TicketState:         "resolved",
+			StatusId:            5,
+			StatusName:          "Resolved",
+			PriorityId:          1,
+			PriorityName:        "Low",
+			DiscussionState:     "visible",
+			StarterUserId:       3,
+			StarterUsername:     "Jarvis.A",
+			Participants:        []*proto.TicketParticipant{},
+			StartDate:           1748500000,
+			LastMessageDate:     1748590000,
+			LastMessageUserId:   3,
+			LastMessageUsername: "Jarvis.A",
+			LastModifiedDate:    1748600000,
+			ReplyCount:          0,
+			TotalMessageCount:   1,
+			CustomFields:        map[string]string{},
+			ForumUrl:            "https://7cav.us/tickets/QQWW43RR/",
+		},
+		{
+			TicketId:            42,
+			TicketRef:           "MF1UI9HE",
+			Title:               "Enlistment — John.Doe",
+			CategoryId:          1,
+			CategoryTitle:       "Recruiting",
+			CategoryAncestorIds: []uint32{},
+			TicketState:         "open",
+			StatusId:            1,
+			StatusName:          "New",
+			PriorityId:          3,
+			PriorityName:        "High",
+			PrefixId:            1,
+			PrefixName:          "Enlistment",
+			DiscussionState:     "visible",
+			StarterUserId:       8,
+			StarterUsername:     "John.Doe",
+			Participants:        []*proto.TicketParticipant{{UserId: 8, LastReadDate: 1748450000}},
+			StartDate:           1748400000,
+			LastMessageDate:     1748480000,
+			LastMessageUserId:   8,
+			LastMessageUsername: "John.Doe",
+			LastModifiedDate:    1748500000,
+			ReplyCount:          2,
+			TotalMessageCount:   3,
+			CustomFields:        map[string]string{"recruiter": "Jarvis.A"},
+			ForumUrl:            "https://7cav.us/tickets/MF1UI9HE/",
+		},
+	}
+}
+
+// seedMessages42 is the message thread for ticket 42, position ascending.
+func seedMessages42() []*proto.Message {
+	return []*proto.Message{
+		{
+			MessageId:    9001,
+			TicketId:     42,
+			UserId:       8,
+			Username:     "John.Doe",
+			MessageDate:  1748400000,
+			Message:      "[B]Enlistment[/B] request — I'd like to join the 7th Cavalry & start ASAP <o7>",
+			MessageState: "visible",
+			Position:     0,
+			AttachCount:  0,
+		},
+		{
+			MessageId:    9002,
+			TicketId:     42,
+			UserId:       3,
+			Username:     "Jarvis.A",
+			MessageDate:  1748450000,
+			Message:      "Welcome aboard — processing now.",
+			MessageState: "visible",
+			Position:     1,
+			AttachCount:  1,
+			LastEditDate: 1748451000,
+			EditCount:    1,
+		},
+		{
+			MessageId:    9003,
+			TicketId:     42,
+			UserId:       8,
+			Username:     "John.Doe",
+			MessageDate:  1748480000,
+			Message:      "Thank you!",
+			MessageState: "visible",
+			Position:     2,
+		},
+	}
+}
+
+// Cursor helpers mirroring datastores/tickets.go exactly.
+func encodeTicketCursor(lastModified, ticketID uint32) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%d:%d", lastModified, ticketID)))
+}
+
+func decodeTicketCursor(c string) (uint32, uint32, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(c)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%w: %v", datastores.ErrInvalidCursor, err)
+	}
+	parts := strings.Split(string(raw), ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("%w: expected ts:id", datastores.ErrInvalidCursor)
+	}
+	ts, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%w: %v", datastores.ErrInvalidCursor, err)
+	}
+	id, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%w: %v", datastores.ErrInvalidCursor, err)
+	}
+	return uint32(ts), uint32(id), nil
+}
+
+func encodeMessageCursor(position uint32) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(strconv.FormatUint(uint64(position), 10)))
+}
+
+func decodeMessageCursor(c string) (uint32, error) {
+	if c == "" {
+		return 0, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(c)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", datastores.ErrInvalidCursor, err)
+	}
+	pos, err := strconv.ParseUint(string(raw), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", datastores.ErrInvalidCursor, err)
+	}
+	return uint32(pos), nil
+}
+
+func (recordingDatastore) ListTickets(_ context.Context, _ datastores.TicketReferenceCache, f *datastores.ListTicketsFilter) ([]*proto.Ticket, string, bool, error) {
+	perPage := f.PerPage
+	if perPage == 0 {
+		perPage = 50
+	} else if perPage > 100 {
+		perPage = 100
+	}
+
+	var afterTs, afterId uint32
+	hasCursor := f.AfterCursor != ""
+	if hasCursor {
+		var err error
+		afterTs, afterId, err = decodeTicketCursor(f.AfterCursor)
+		if err != nil {
+			return nil, "", false, err
+		}
+	}
+
+	var rows []*proto.Ticket
+	for _, t := range seedTickets() {
+		if hasCursor && !(t.LastModifiedDate < afterTs || (t.LastModifiedDate == afterTs && t.TicketId < afterId)) {
+			continue
+		}
+		if !matchTicket(t, f) {
+			continue
+		}
+		rows = append(rows, t)
+	}
+
+	hasMore := len(rows) > int(perPage)
+	if hasMore {
+		rows = rows[:perPage]
+	}
+	next := ""
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1]
+		next = encodeTicketCursor(last.LastModifiedDate, last.TicketId)
+	}
+	if rows == nil {
+		rows = []*proto.Ticket{}
+	}
+	return rows, next, hasMore, nil
+}
+
+func matchTicket(t *proto.Ticket, f *datastores.ListTicketsFilter) bool {
+	if len(f.CategoryIDs) > 0 {
+		match := containsU32(f.CategoryIDs, t.CategoryId)
+		if !match && !f.ExcludeSubcategories {
+			for _, anc := range t.CategoryAncestorIds {
+				if containsU32(f.CategoryIDs, anc) {
+					match = true
+					break
+				}
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	if len(f.TicketStates) > 0 && !containsStr(f.TicketStates, t.TicketState) {
+		return false
+	}
+	if len(f.StatusIDs) > 0 && !containsU32(f.StatusIDs, t.StatusId) {
+		return false
+	}
+	if len(f.PrefixIDs) > 0 && !containsU32(f.PrefixIDs, t.PrefixId) {
+		return false
+	}
+	if len(f.AssignedUserIDs) > 0 && !containsU32(f.AssignedUserIDs, t.AssignedUserId) {
+		return false
+	}
+	if len(f.StarterUserIDs) > 0 && !containsU32(f.StarterUserIDs, t.StarterUserId) {
+		return false
+	}
+	if f.ModifiedSince > 0 && t.LastModifiedDate < f.ModifiedSince {
+		return false
+	}
+	return true
+}
+
+func containsU32(haystack []uint32, needle uint32) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func (recordingDatastore) GetTicket(_ context.Context, _ datastores.TicketReferenceCache, ticketID uint32, _ string) (*proto.Ticket, error) {
+	for _, t := range seedTickets() {
+		if t.TicketId == ticketID {
+			return t, nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (recordingDatastore) GetTicketByRef(_ context.Context, _ datastores.TicketReferenceCache, ref string, _ string) (*proto.Ticket, error) {
+	for _, t := range seedTickets() {
+		if t.TicketRef == ref {
+			return t, nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (recordingDatastore) GetTicketFirstMessages(_ context.Context, ticketID uint32, n int, _ bool) ([]*proto.Message, uint32, error) {
+	if ticketID != 42 {
+		return []*proto.Message{}, 0, nil
+	}
+	msgs := seedMessages42()
+	total := uint32(len(msgs))
+	if n < len(msgs) {
+		msgs = msgs[:n]
+	}
+	return msgs, total, nil
+}
+
+func (recordingDatastore) ListTicketMessages(_ context.Context, ticketID uint32, afterCursor string, perPage uint32, _ bool) ([]*proto.Message, string, bool, error) {
+	from, err := decodeMessageCursor(afterCursor)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if perPage == 0 {
+		perPage = 50
+	} else if perPage > 100 {
+		perPage = 100
+	}
+	var rows []*proto.Message
+	if ticketID == 42 {
+		for _, m := range seedMessages42() {
+			if m.Position >= from {
+				rows = append(rows, m)
+			}
+		}
+	}
+	hasMore := len(rows) > int(perPage)
+	if hasMore {
+		rows = rows[:perPage]
+	}
+	next := ""
+	if hasMore && len(rows) > 0 {
+		next = encodeMessageCursor(rows[len(rows)-1].Position + 1)
+	}
+	if rows == nil {
+		rows = []*proto.Message{}
+	}
+	return rows, next, hasMore, nil
+}
+
+func (recordingDatastore) ListCategories(_ context.Context, _ datastores.TicketReferenceCache) ([]*proto.Category, error) {
+	return []*proto.Category{
+		{CategoryId: 1, Title: "Recruiting", Description: "Enlistment & recruiting questions", ParentCategoryId: 0, Depth: 0, DisplayOrder: 10, TicketCount: 120},
+		{CategoryId: 5, Title: "S1 Personnel", Description: "", ParentCategoryId: 1, Depth: 1, DisplayOrder: 20, TicketCount: 34},
+		{CategoryId: 7, Title: "S6 Technical Support", Description: "Teamspeak, forum & game-server help", ParentCategoryId: 0, Depth: 0, DisplayOrder: 30, TicketCount: 78},
+	}, nil
+}

--- a/contract/golden.go
+++ b/contract/golden.go
@@ -29,6 +29,15 @@ const (
 	AuthNoScopes Auth = "no-scopes"
 )
 
+// Valid reports whether a is one of the defined credential tiers.
+func (a Auth) Valid() bool {
+	switch a {
+	case AuthNone, AuthRawKey, AuthInvalidKey, AuthRead, AuthReadTickets, AuthNoScopes:
+		return true
+	}
+	return false
+}
+
 // authHeader maps an Auth tier to the Authorization header the harness sends.
 // The token strings are battery fixtures: the recording fake datastore (and
 // any future stack's test seed) must accept exactly these.
@@ -217,15 +226,26 @@ func CompareGolden(want, got *Golden) []string {
 	return diffs
 }
 
-// goldenPath maps a case name to its file under dir.
-func goldenPath(dir, name string) string {
-	return filepath.Join(dir, filepath.FromSlash(name)+".golden.json")
+// goldenPath maps a case name to its file under dir. Empty names and names
+// that resolve outside dir (path traversal, absolute paths) are rejected.
+func goldenPath(dir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("golden name must not be empty")
+	}
+	rel := filepath.FromSlash(name)
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("golden name %q escapes the goldens directory", name)
+	}
+	return filepath.Join(dir, rel+".golden.json"), nil
 }
 
 // SaveGolden writes g to its file under dir, creating directories as needed.
 // The file itself is deterministic: fixed field order, canonical body.
 func SaveGolden(dir string, g *Golden) error {
-	path := goldenPath(dir, g.Case)
+	path, err := goldenPath(dir, g.Case)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -243,15 +263,29 @@ func SaveGolden(dir string, g *Golden) error {
 	return os.WriteFile(path, append(marshalCanonical(pretty), '\n'), 0o644)
 }
 
-// LoadGolden reads the committed golden for a case name.
+// LoadGolden reads the committed golden for a case name and validates its
+// structural invariants: exactly one of body/bodyText set and a defined auth
+// tier — a hand-edited golden violating either is an error, not a silent
+// pass.
 func LoadGolden(dir, name string) (*Golden, error) {
-	raw, err := os.ReadFile(goldenPath(dir, name))
+	path, err := goldenPath(dir, name)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 	var g Golden
 	if err := json.Unmarshal(raw, &g); err != nil {
 		return nil, fmt.Errorf("golden %s: %w", name, err)
+	}
+	if (g.Body != nil) == (g.BodyText != nil) {
+		return nil, fmt.Errorf("golden %s: exactly one of body/bodyText must be set (json=%t text=%t)",
+			name, g.Body != nil, g.BodyText != nil)
+	}
+	if !g.Auth.Valid() {
+		return nil, fmt.Errorf("golden %s: invalid auth tier %q", name, g.Auth)
 	}
 	return &g, nil
 }

--- a/contract/golden.go
+++ b/contract/golden.go
@@ -122,11 +122,11 @@ func RunCase(h http.Handler, c Case) (*Golden, []byte, error) {
 
 	raw := rr.Body.Bytes()
 	if isJSONContentType(rr.Header().Get("Content-Type")) {
-		v, err := Canonicalize(raw)
+		v, err := canonicalize(raw)
 		if err != nil {
 			return nil, raw, fmt.Errorf("case %s: response declared JSON but does not parse: %w", c.Name, err)
 		}
-		g.Body = MarshalCanonical(StripKeycloakID(v))
+		g.Body = marshalCanonical(stripKeycloakID(v))
 	} else {
 		s := string(raw)
 		g.BodyText = &s
@@ -153,13 +153,13 @@ func CompareGolden(want, got *Golden) []string {
 	}
 	switch {
 	case want.Body != nil && got.Body != nil:
-		wv, werr := Canonicalize(want.Body)
-		gv, gerr := Canonicalize(got.Body)
+		wv, werr := canonicalize(want.Body)
+		gv, gerr := canonicalize(got.Body)
 		if werr != nil || gerr != nil {
 			diffs = append(diffs, fmt.Sprintf("body: unparseable golden (want err %v, got err %v)", werr, gerr))
 			break
 		}
-		diffs = append(diffs, Diff(wv, gv)...)
+		diffs = append(diffs, diff(wv, gv)...)
 	case want.BodyText != nil && got.BodyText != nil:
 		if *want.BodyText != *got.BodyText {
 			diffs = append(diffs, fmt.Sprintf("bodyText: want %q, got %q", *want.BodyText, *got.BodyText))
@@ -190,11 +190,11 @@ func SaveGolden(dir string, g *Golden) error {
 	// Indent the embedded canonical body consistently: re-render through the
 	// canonical encoder (number-literal preserving) so committed goldens are
 	// deterministic and pleasant to review.
-	pretty, err := Canonicalize(out)
+	pretty, err := canonicalize(out)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(MarshalCanonical(pretty), '\n'), 0o644)
+	return os.WriteFile(path, append(marshalCanonical(pretty), '\n'), 0o644)
 }
 
 // LoadGolden reads the committed golden for a case name.

--- a/contract/golden.go
+++ b/contract/golden.go
@@ -74,7 +74,11 @@ type Case struct {
 //     tier pinned by #106.
 //   - X-Content-Type-Options rides along on the plain-text error responses
 //     (http.Error sets it) and clients may rely on it.
-var contractHeaders = []string{"Content-Type", "X-Content-Type-Options"}
+//   - WWW-Authenticate pins an ABSENCE: #106 froze the 401 tiers as having
+//     no challenge header. RunCase skips empty headers, so goldens carry no
+//     WWW-Authenticate key; a rewrite whose auth middleware adds one shows
+//     up in CompareGolden as ""-vs-set — a red diff.
+var contractHeaders = []string{"Content-Type", "X-Content-Type-Options", "WWW-Authenticate"}
 
 // Golden is the recorded contract for one case: status, allowlisted headers,
 // and the response body. JSON bodies are stored canonicalized (sorted keys,

--- a/contract/golden.go
+++ b/contract/golden.go
@@ -1,0 +1,211 @@
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Auth identifies which credential a battery case presents. The concrete
+// header values live in authHeader; goldens record the tier, not the token.
+type Auth string
+
+const (
+	// AuthNone sends no Authorization header.
+	AuthNone Auth = "none"
+	// AuthRawKey sends a bare key without the "Bearer " scheme.
+	AuthRawKey Auth = "raw-key"
+	// AuthInvalidKey sends a well-formed Bearer token that no key matches.
+	AuthInvalidKey Auth = "invalid-key"
+	// AuthRead is a valid key holding the "read" scope (milpacs surface).
+	AuthRead Auth = "read"
+	// AuthReadTickets is a valid key holding the "read:tickets" scope.
+	AuthReadTickets Auth = "read:tickets"
+	// AuthNoScopes is a valid key holding no scopes at all.
+	AuthNoScopes Auth = "no-scopes"
+)
+
+// authHeader maps an Auth tier to the Authorization header the harness sends.
+// The token strings are battery fixtures: the recording fake datastore (and
+// any future stack's test seed) must accept exactly these.
+func authHeader(a Auth) (value string, present bool) {
+	switch a {
+	case AuthNone:
+		return "", false
+	case AuthRawKey:
+		return "cav7_rawkeywithoutscheme", true
+	case AuthInvalidKey:
+		return "Bearer cav7_unknownkey", true
+	case AuthRead:
+		return "Bearer cav7_readkey", true
+	case AuthReadTickets:
+		return "Bearer cav7_ticketskey", true
+	case AuthNoScopes:
+		return "Bearer cav7_noscopekey", true
+	default:
+		panic(fmt.Sprintf("contract: unknown auth tier %q", a))
+	}
+}
+
+// Case is one recorded request in the battery. Name doubles as the golden
+// file path relative to the goldens dir (slashes create directories).
+type Case struct {
+	Name string
+	// Method is always GET today; kept explicit so the corpus stays honest
+	// if a non-GET route ever appears.
+	Method string
+	// Path is the request target including any query string, exactly as a
+	// client would send it (URL-encoded).
+	Path string
+	Auth Auth
+	// Notes documents why the case exists (shows up in the golden file).
+	Notes string
+}
+
+// contractHeaders is the allowlist of headers recorded in goldens. Everything
+// else (Date, Content-Length, X-Cache, Grpc-Metadata-*, transfer encodings)
+// is infrastructure of the current stack, not contract:
+//
+//   - Content-Type distinguishes the JSON surface from the plain-text 401
+//     tier pinned by #106.
+//   - X-Content-Type-Options rides along on the plain-text error responses
+//     (http.Error sets it) and clients may rely on it.
+var contractHeaders = []string{"Content-Type", "X-Content-Type-Options"}
+
+// Golden is the recorded contract for one case: status, allowlisted headers,
+// and the response body. JSON bodies are stored canonicalized (sorted keys,
+// stable whitespace, keycloakId stripped); non-JSON bodies (the plain-text
+// 401 tier) are stored verbatim in BodyText.
+type Golden struct {
+	Case   string            `json:"case"`
+	Method string            `json:"method"`
+	Path   string            `json:"path"`
+	Auth   Auth              `json:"auth"`
+	Notes  string            `json:"notes,omitempty"`
+	Status int               `json:"status"`
+	Header map[string]string `json:"header"`
+	// Body holds the canonical JSON body; null when the body is not JSON.
+	Body json.RawMessage `json:"body,omitempty"`
+	// BodyText holds the verbatim body when it is not JSON.
+	BodyText *string `json:"bodyText,omitempty"`
+}
+
+// RunCase drives one battery case through the mounted stack and returns the
+// observed Golden (canonicalized, with the single keycloakId transform
+// applied) plus the raw response bytes for informational byte-level output.
+func RunCase(h http.Handler, c Case) (*Golden, []byte, error) {
+	req := httptest.NewRequest(c.Method, c.Path, nil)
+	if v, ok := authHeader(c.Auth); ok {
+		req.Header.Set("Authorization", v)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	g := &Golden{
+		Case:   c.Name,
+		Method: c.Method,
+		Path:   c.Path,
+		Auth:   c.Auth,
+		Notes:  c.Notes,
+		Status: rr.Code,
+		Header: map[string]string{},
+	}
+	for _, name := range contractHeaders {
+		if v := rr.Header().Get(name); v != "" {
+			g.Header[name] = v
+		}
+	}
+
+	raw := rr.Body.Bytes()
+	if isJSONContentType(rr.Header().Get("Content-Type")) {
+		v, err := Canonicalize(raw)
+		if err != nil {
+			return nil, raw, fmt.Errorf("case %s: response declared JSON but does not parse: %w", c.Name, err)
+		}
+		g.Body = MarshalCanonical(StripKeycloakID(v))
+	} else {
+		s := string(raw)
+		g.BodyText = &s
+	}
+	return g, raw, nil
+}
+
+func isJSONContentType(ct string) bool {
+	return strings.HasPrefix(ct, "application/json")
+}
+
+// CompareGolden semantically compares a committed golden against an observed
+// one. Returned strings are human-readable mismatches; empty means equal.
+func CompareGolden(want, got *Golden) []string {
+	var diffs []string
+	if want.Status != got.Status {
+		diffs = append(diffs, fmt.Sprintf("status: want %d, got %d", want.Status, got.Status))
+	}
+	for _, name := range contractHeaders {
+		w, g := want.Header[name], got.Header[name]
+		if w != g {
+			diffs = append(diffs, fmt.Sprintf("header %s: want %q, got %q", name, w, g))
+		}
+	}
+	switch {
+	case want.Body != nil && got.Body != nil:
+		wv, werr := Canonicalize(want.Body)
+		gv, gerr := Canonicalize(got.Body)
+		if werr != nil || gerr != nil {
+			diffs = append(diffs, fmt.Sprintf("body: unparseable golden (want err %v, got err %v)", werr, gerr))
+			break
+		}
+		diffs = append(diffs, Diff(wv, gv)...)
+	case want.BodyText != nil && got.BodyText != nil:
+		if *want.BodyText != *got.BodyText {
+			diffs = append(diffs, fmt.Sprintf("bodyText: want %q, got %q", *want.BodyText, *got.BodyText))
+		}
+	default:
+		diffs = append(diffs, fmt.Sprintf("body kind: want json=%t text=%t, got json=%t text=%t",
+			want.Body != nil, want.BodyText != nil, got.Body != nil, got.BodyText != nil))
+	}
+	return diffs
+}
+
+// goldenPath maps a case name to its file under dir.
+func goldenPath(dir, name string) string {
+	return filepath.Join(dir, filepath.FromSlash(name)+".golden.json")
+}
+
+// SaveGolden writes g to its file under dir, creating directories as needed.
+// The file itself is deterministic: fixed field order, canonical body.
+func SaveGolden(dir string, g *Golden) error {
+	path := goldenPath(dir, g.Case)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(g, "", "  ")
+	if err != nil {
+		return err
+	}
+	// Indent the embedded canonical body consistently: re-render through the
+	// canonical encoder (number-literal preserving) so committed goldens are
+	// deterministic and pleasant to review.
+	pretty, err := Canonicalize(out)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(MarshalCanonical(pretty), '\n'), 0o644)
+}
+
+// LoadGolden reads the committed golden for a case name.
+func LoadGolden(dir, name string) (*Golden, error) {
+	raw, err := os.ReadFile(goldenPath(dir, name))
+	if err != nil {
+		return nil, err
+	}
+	var g Golden
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return nil, fmt.Errorf("golden %s: %w", name, err)
+	}
+	return &g, nil
+}

--- a/contract/golden.go
+++ b/contract/golden.go
@@ -138,10 +138,38 @@ func isJSONContentType(ct string) bool {
 	return strings.HasPrefix(ct, "application/json")
 }
 
+// isContractHeader reports whether name is in the contractHeaders allowlist.
+func isContractHeader(name string) bool {
+	for _, h := range contractHeaders {
+		if h == name {
+			return true
+		}
+	}
+	return false
+}
+
 // CompareGolden semantically compares a committed golden against an observed
 // one. Returned strings are human-readable mismatches; empty means equal.
+//
+// Besides status/headers/body it self-checks the recorded request metadata
+// (case, method, path, auth) so a golden replayed under the wrong request is
+// a diff rather than silently write-only, flags recorded header keys outside
+// the contractHeaders allowlist, and rejects malformed goldens that carry
+// both or neither of body/bodyText.
 func CompareGolden(want, got *Golden) []string {
 	var diffs []string
+	if want.Case != got.Case {
+		diffs = append(diffs, fmt.Sprintf("case: want %q, got %q", want.Case, got.Case))
+	}
+	if want.Method != got.Method {
+		diffs = append(diffs, fmt.Sprintf("method: want %q, got %q", want.Method, got.Method))
+	}
+	if want.Path != got.Path {
+		diffs = append(diffs, fmt.Sprintf("path: want %q, got %q", want.Path, got.Path))
+	}
+	if want.Auth != got.Auth {
+		diffs = append(diffs, fmt.Sprintf("auth: want %q, got %q", want.Auth, got.Auth))
+	}
 	if want.Status != got.Status {
 		diffs = append(diffs, fmt.Sprintf("status: want %d, got %d", want.Status, got.Status))
 	}
@@ -149,6 +177,20 @@ func CompareGolden(want, got *Golden) []string {
 		w, g := want.Header[name], got.Header[name]
 		if w != g {
 			diffs = append(diffs, fmt.Sprintf("header %s: want %q, got %q", name, w, g))
+		}
+	}
+	for name := range want.Header {
+		if !isContractHeader(name) {
+			diffs = append(diffs, fmt.Sprintf("header %s: recorded but not contract-compared (not in allowlist)", name))
+		}
+	}
+	for _, side := range []struct {
+		label string
+		g     *Golden
+	}{{"want", want}, {"got", got}} {
+		if (side.g.Body != nil) == (side.g.BodyText != nil) {
+			diffs = append(diffs, fmt.Sprintf("%s: malformed golden: exactly one of body/bodyText must be set (json=%t text=%t)",
+				side.label, side.g.Body != nil, side.g.BodyText != nil))
 		}
 	}
 	switch {

--- a/contract/golden_test.go
+++ b/contract/golden_test.go
@@ -28,6 +28,76 @@ func jsonGolden(status int, body string) *Golden {
 	}
 }
 
+// fullGolden builds a golden with all request metadata populated, as RunCase
+// and the committed corpus produce them.
+func fullGolden() *Golden {
+	g := jsonGolden(200, `{"a":1}`)
+	g.Method = "GET"
+	g.Path = "/api/v1/milpacs/ranks"
+	g.Auth = AuthRead
+	return g
+}
+
+func TestCompareGolden_RequestMetadataMismatch(t *testing.T) {
+	tampers := []struct {
+		field  string
+		mutate func(g *Golden)
+	}{
+		{"case", func(g *Golden) { g.Case = "tampered" }},
+		{"method", func(g *Golden) { g.Method = "POST" }},
+		{"path", func(g *Golden) { g.Path = "/api/v1/tampered" }},
+		{"auth", func(g *Golden) { g.Auth = AuthNoScopes }},
+	}
+	for _, tc := range tampers {
+		t.Run(tc.field, func(t *testing.T) {
+			want, got := fullGolden(), fullGolden()
+			tc.mutate(got)
+			diffs := CompareGolden(want, got)
+			require.NotEmpty(t, diffs, "recorded request metadata must be compared, not write-only")
+			assert.Contains(t, strings.Join(diffs, "\n"), tc.field)
+		})
+	}
+}
+
+func TestCompareGolden_NonAllowlistedRecordedHeaderIsADiff(t *testing.T) {
+	want, got := fullGolden(), fullGolden()
+	want.Header["X-Made-Up"] = "1"
+	diffs := CompareGolden(want, got)
+	require.NotEmpty(t, diffs)
+	assert.Contains(t, strings.Join(diffs, "\n"), "recorded but not contract-compared")
+	assert.Contains(t, strings.Join(diffs, "\n"), "X-Made-Up")
+}
+
+func TestCompareGolden_BodyAndBodyTextBothSetIsADiff(t *testing.T) {
+	for _, side := range []string{"want", "got"} {
+		t.Run(side, func(t *testing.T) {
+			want, got := fullGolden(), fullGolden()
+			text := "also text"
+			if side == "want" {
+				want.BodyText = &text
+			} else {
+				got.BodyText = &text
+			}
+			diffs := CompareGolden(want, got)
+			require.NotEmpty(t, diffs, "a golden with both body and bodyText is malformed")
+			joined := strings.Join(diffs, "\n")
+			assert.Contains(t, joined, "exactly one of")
+			assert.Contains(t, joined, side)
+		})
+	}
+}
+
+func TestCompareGolden_NeitherBodyNorBodyTextIsADiff(t *testing.T) {
+	want, got := fullGolden(), fullGolden()
+	want.Body, got.Body = nil, nil
+	diffs := CompareGolden(want, got)
+	require.NotEmpty(t, diffs, "a golden with neither body nor bodyText is malformed")
+	joined := strings.Join(diffs, "\n")
+	assert.Contains(t, joined, "exactly one of")
+	assert.Contains(t, joined, "want")
+	assert.Contains(t, joined, "got")
+}
+
 func TestCompareGolden_Equal(t *testing.T) {
 	assert.Empty(t, CompareGolden(jsonGolden(200, `{"a":1}`), jsonGolden(200, `{"a": 1}`)),
 		"whitespace must not matter")

--- a/contract/golden_test.go
+++ b/contract/golden_test.go
@@ -1,0 +1,115 @@
+package contract
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func textGolden(status int, body string) *Golden {
+	return &Golden{
+		Case: "t", Status: status,
+		Header:   map[string]string{"Content-Type": "text/plain; charset=utf-8"},
+		BodyText: &body,
+	}
+}
+
+func jsonGolden(status int, body string) *Golden {
+	return &Golden{
+		Case: "t", Status: status,
+		Header: map[string]string{"Content-Type": "application/json"},
+		Body:   json.RawMessage(body),
+	}
+}
+
+func TestCompareGolden_Equal(t *testing.T) {
+	assert.Empty(t, CompareGolden(jsonGolden(200, `{"a":1}`), jsonGolden(200, `{"a": 1}`)),
+		"whitespace must not matter")
+}
+
+func TestCompareGolden_StatusMismatch(t *testing.T) {
+	diffs := CompareGolden(jsonGolden(200, `{"a":1}`), jsonGolden(404, `{"a":1}`))
+	require.Len(t, diffs, 1)
+	assert.Contains(t, diffs[0], "status")
+}
+
+func TestCompareGolden_HeaderMismatch(t *testing.T) {
+	a := jsonGolden(200, `{"a":1}`)
+	b := jsonGolden(200, `{"a":1}`)
+	b.Header["Content-Type"] = "text/plain; charset=utf-8"
+	diffs := CompareGolden(a, b)
+	require.Len(t, diffs, 1)
+	assert.Contains(t, diffs[0], "Content-Type")
+}
+
+func TestCompareGolden_BodyKindMismatch(t *testing.T) {
+	diffs := CompareGolden(jsonGolden(401, `{}`), textGolden(401, "Unauthorized\n"))
+	require.NotEmpty(t, diffs)
+	// The Content-Type header also differs; the kind mismatch must be
+	// reported in addition.
+	assert.Contains(t, strings.Join(diffs, "\n"), "body kind")
+}
+
+func TestCompareGolden_BodyTextMismatch(t *testing.T) {
+	// The plain-text 401 tier compares verbatim, trailing newline included.
+	diffs := CompareGolden(textGolden(401, "Unauthorized\n"), textGolden(401, "Unauthorized"))
+	require.Len(t, diffs, 1)
+	assert.Contains(t, diffs[0], "bodyText")
+}
+
+func TestRunCase_AppliesTransformAndAllowlist(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Cache", "MISS") // infrastructure header — must not be recorded
+		_, _ = w.Write([]byte(`{"keycloakId":"secret","userId":"3"}`))
+	})
+	g, raw, err := RunCase(h, Case{Name: "x", Method: "GET", Path: "/api/v1/x", Auth: AuthRead})
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(g.Body), "keycloakId", "single documented transform")
+	assert.Contains(t, string(g.Body), `"userId": "3"`)
+	assert.Contains(t, string(raw), "keycloakId", "raw bytes stay untransformed wire truth")
+	_, recorded := g.Header["X-Cache"]
+	assert.False(t, recorded, "only allowlisted headers are contract")
+}
+
+func TestRunCase_NonJSONContentTypeRecordsVerbatimText(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	})
+	g, _, err := RunCase(h, Case{Name: "x", Method: "GET", Path: "/api/v1/x", Auth: AuthNone})
+	require.NoError(t, err)
+	require.NotNil(t, g.BodyText)
+	assert.Equal(t, "Unauthorized\n", *g.BodyText)
+	assert.Nil(t, g.Body)
+}
+
+func TestRunCase_DeclaredJSONThatDoesNotParseIsAnError(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	})
+	_, _, err := RunCase(h, Case{Name: "x", Method: "GET", Path: "/api/v1/x", Auth: AuthRead})
+	require.Error(t, err)
+}
+
+func TestSaveLoadGolden_RoundTripsBigNumbersExactly(t *testing.T) {
+	dir := t.TempDir()
+	g := jsonGolden(200, `{"big":9007199254740993,"id":"42"}`)
+	g.Case = "sub/dir/case"
+	require.NoError(t, SaveGolden(dir, g))
+
+	loaded, err := LoadGolden(dir, "sub/dir/case")
+	require.NoError(t, err)
+	assert.Empty(t, CompareGolden(g, loaded))
+
+	raw, err := os.ReadFile(filepath.Join(dir, "sub", "dir", "case.golden.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "9007199254740993", "float64 round-tripping would corrupt this literal")
+}

--- a/contract/golden_test.go
+++ b/contract/golden_test.go
@@ -149,6 +149,33 @@ func TestRunCase_AppliesTransformAndAllowlist(t *testing.T) {
 	assert.False(t, recorded, "only allowlisted headers are contract")
 }
 
+func TestWWWAuthenticateAbsenceIsPinned(t *testing.T) {
+	// #106 pinned the 401 tiers as having NO WWW-Authenticate. A standard
+	// auth middleware in the rewrite would add one; that must be a red diff.
+	// Mechanism under test: RunCase skips empty headers (the recorded golden
+	// has no WWW-Authenticate key), so CompareGolden sees ""-vs-set.
+	c := Case{Name: "x", Method: "GET", Path: "/api/v1/x", Auth: AuthNone}
+
+	current := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	})
+	want, _, err := RunCase(current, c)
+	require.NoError(t, err)
+	_, recorded := want.Header["WWW-Authenticate"]
+	require.False(t, recorded, "absent header must not be recorded as an empty value")
+
+	rewrite := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="api"`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	})
+	got, _, err := RunCase(rewrite, c)
+	require.NoError(t, err)
+
+	diffs := CompareGolden(want, got)
+	require.NotEmpty(t, diffs, "rewrite adding WWW-Authenticate must produce a red diff")
+	assert.Contains(t, strings.Join(diffs, "\n"), "WWW-Authenticate")
+}
+
 func TestRunCase_NonJSONContentTypeRecordsVerbatimText(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)

--- a/contract/golden_test.go
+++ b/contract/golden_test.go
@@ -196,10 +196,59 @@ func TestRunCase_DeclaredJSONThatDoesNotParseIsAnError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLoadGolden_RejectsBodyBodyTextXORViolation(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name+".golden.json"), []byte(content), 0o644))
+	}
+
+	write("both", `{"case":"both","method":"GET","path":"/x","auth":"read","status":200,"header":{},"body":{"a":1},"bodyText":"t"}`)
+	_, err := LoadGolden(dir, "both")
+	require.Error(t, err, "a golden with both body and bodyText is malformed")
+
+	write("neither", `{"case":"neither","method":"GET","path":"/x","auth":"read","status":200,"header":{}}`)
+	_, err = LoadGolden(dir, "neither")
+	require.Error(t, err, "a golden with neither body nor bodyText is malformed")
+}
+
+func TestLoadGolden_RejectsInvalidAuthTier(t *testing.T) {
+	dir := t.TempDir()
+	raw := `{"case":"bad","method":"GET","path":"/x","auth":"superadmin","status":200,"header":{},"body":{"a":1}}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.golden.json"), []byte(raw), 0o644))
+	_, err := LoadGolden(dir, "bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth")
+}
+
+func TestAuthValid(t *testing.T) {
+	for _, a := range []Auth{AuthNone, AuthRawKey, AuthInvalidKey, AuthRead, AuthReadTickets, AuthNoScopes} {
+		assert.True(t, a.Valid(), "%s is a defined tier", a)
+	}
+	assert.False(t, Auth("").Valid())
+	assert.False(t, Auth("superadmin").Valid())
+}
+
+func TestGoldenPathRejectsTraversalAndEmptyNames(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"", "../escape", "sub/../../escape", "/abs/path"} {
+		t.Run("load_"+name, func(t *testing.T) {
+			_, err := LoadGolden(dir, name)
+			require.Error(t, err, "name %q must not resolve outside the goldens dir", name)
+		})
+		t.Run("save_"+name, func(t *testing.T) {
+			g := jsonGolden(200, `{"a":1}`)
+			g.Case = name
+			g.Auth = AuthRead
+			require.Error(t, SaveGolden(dir, g), "name %q must not resolve outside the goldens dir", name)
+		})
+	}
+}
+
 func TestSaveLoadGolden_RoundTripsBigNumbersExactly(t *testing.T) {
 	dir := t.TempDir()
 	g := jsonGolden(200, `{"big":9007199254740993,"id":"42"}`)
 	g.Case = "sub/dir/case"
+	g.Auth = AuthRead
 	require.NoError(t, SaveGolden(dir, g))
 
 	loaded, err := LoadGolden(dir, "sub/dir/case")

--- a/contract/goldens/auth/milpacs_invalid_key.golden.json
+++ b/contract/goldens/auth/milpacs_invalid_key.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "invalid-key",
+  "bodyText": "Unauthorized\n",
+  "case": "auth/milpacs_invalid_key",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "Well-formed Bearer token, unknown key: generic 'Unauthorized', leaks nothing.",
+  "path": "/api/v1/milpacs/profile/id/1",
+  "status": 401
+}

--- a/contract/goldens/auth/milpacs_missing_header.golden.json
+++ b/contract/goldens/auth/milpacs_missing_header.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "none",
+  "bodyText": "Unauthorized: expected 'Authorization: Bearer <key>' header\n",
+  "case": "auth/milpacs_missing_header",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "No Authorization header: plain-text 401 naming the Bearer scheme.",
+  "path": "/api/v1/milpacs/profile/id/1",
+  "status": 401
+}

--- a/contract/goldens/auth/milpacs_no_scopes.golden.json
+++ b/contract/goldens/auth/milpacs_no_scopes.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "no-scopes",
+  "body": {
+    "code": 7,
+    "details": [],
+    "message": "scope required: read"
+  },
+  "case": "auth/milpacs_no_scopes",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Valid key with empty scope set: same PermissionDenied surface.",
+  "path": "/api/v1/milpacs/profile/id/1",
+  "status": 403
+}

--- a/contract/goldens/auth/milpacs_raw_key.golden.json
+++ b/contract/goldens/auth/milpacs_raw_key.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "raw-key",
+  "bodyText": "Unauthorized: expected 'Authorization: Bearer <key>' header\n",
+  "case": "auth/milpacs_raw_key",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "Raw key without 'Bearer ' prefix: same scheme-error 401 tier.",
+  "path": "/api/v1/milpacs/profile/id/1",
+  "status": 401
+}

--- a/contract/goldens/auth/milpacs_wrong_scope.golden.json
+++ b/contract/goldens/auth/milpacs_wrong_scope.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 7,
+    "details": [],
+    "message": "scope required: read"
+  },
+  "case": "auth/milpacs_wrong_scope",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Valid key lacking 'read': PermissionDenied JSON via gRPC status mapping.",
+  "path": "/api/v1/milpacs/profile/id/1",
+  "status": 403
+}

--- a/contract/goldens/auth/tickets_invalid_key.golden.json
+++ b/contract/goldens/auth/tickets_invalid_key.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "invalid-key",
+  "bodyText": "Unauthorized\n",
+  "case": "auth/tickets_invalid_key",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "Tickets surface, unknown key: generic 'Unauthorized'.",
+  "path": "/api/v1/tickets",
+  "status": 401
+}

--- a/contract/goldens/auth/tickets_missing_header.golden.json
+++ b/contract/goldens/auth/tickets_missing_header.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "none",
+  "bodyText": "Unauthorized: expected 'Authorization: Bearer <key>' header\n",
+  "case": "auth/tickets_missing_header",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "Tickets surface, no Authorization header: plain-text scheme-error 401.",
+  "path": "/api/v1/tickets",
+  "status": 401
+}

--- a/contract/goldens/auth/tickets_raw_key.golden.json
+++ b/contract/goldens/auth/tickets_raw_key.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "raw-key",
+  "bodyText": "Unauthorized: expected 'Authorization: Bearer <key>' header\n",
+  "case": "auth/tickets_raw_key",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "Tickets surface, raw key: scheme-error 401.",
+  "path": "/api/v1/tickets",
+  "status": 401
+}

--- a/contract/goldens/auth/tickets_wrong_scope.golden.json
+++ b/contract/goldens/auth/tickets_wrong_scope.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 7,
+    "details": [],
+    "message": "scope required: read:tickets"
+  },
+  "case": "auth/tickets_wrong_scope",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "'read' does not imply 'read:tickets': PermissionDenied JSON.",
+  "path": "/api/v1/tickets",
+  "status": 403
+}

--- a/contract/goldens/auth/unknown_path_authenticated.golden.json
+++ b/contract/goldens/auth/unknown_path_authenticated.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "Not Found"
+  },
+  "case": "auth/unknown_path_authenticated",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Unknown path under the API prefix with valid auth: JSON 404 body from the gateway mux.",
+  "path": "/api/v1/does/not/exist",
+  "status": 404
+}

--- a/contract/goldens/auth/unknown_path_unauthenticated.golden.json
+++ b/contract/goldens/auth/unknown_path_unauthenticated.golden.json
@@ -1,0 +1,13 @@
+{
+  "auth": "none",
+  "bodyText": "Unauthorized: expected 'Authorization: Bearer <key>' header\n",
+  "case": "auth/unknown_path_unauthenticated",
+  "header": {
+    "Content-Type": "text/plain; charset=utf-8",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "method": "GET",
+  "notes": "Auth runs before routing: unknown path without auth is the 401 tier, not 404.",
+  "path": "/api/v1/does/not/exist",
+  "status": 401
+}

--- a/contract/goldens/milpacs/awol.golden.json
+++ b/contract/goldens/milpacs/awol.golden.json
@@ -1,0 +1,25 @@
+{
+  "auth": "read",
+  "body": {
+    "awols": [
+      {
+        "groupName": "Alpha Company",
+        "humanDate": "2026-05-01",
+        "milpacId": "2",
+        "postId": "445566",
+        "rankName": "Private",
+        "timestamp": "1777600000",
+        "userId": "8",
+        "username": "John.Doe"
+      }
+    ]
+  },
+  "case": "milpacs/awol",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "AWOL list; uint64 timestamp/postId/milpacId emitted as strings.",
+  "path": "/api/v1/milpacs/awol",
+  "status": 200
+}

--- a/contract/goldens/milpacs/discord_happy.golden.json
+++ b/contract/goldens/milpacs/discord_happy.golden.json
@@ -1,0 +1,65 @@
+{
+  "auth": "read",
+  "body": {
+    "awards": [
+      {
+        "awardDate": "2021-03-01",
+        "awardDetails": "For technical excellence & dedication <est. 2014>",
+        "awardImageUrl": "https://7cav.us/data/awards/ccm.jpg",
+        "awardName": "Commendation Medal",
+        "awardUid": "901"
+      }
+    ],
+    "consoleGamertag": "",
+    "discordId": "112233445566778899",
+    "joinDate": "2014-02-08",
+    "lastForumPostDate": "2026-05-30",
+    "mos": "11B",
+    "primary": {
+      "positionId": "773",
+      "positionTitle": "Regimental Technical Aide"
+    },
+    "promotionDate": "2020-10-17",
+    "rank": {
+      "rankFull": "Major General",
+      "rankId": "4",
+      "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+      "rankShort": "MG"
+    },
+    "realName": "Adam Jarvis",
+    "records": [
+      {
+        "recordDate": "2020-10-17",
+        "recordDetails": "Promoted to Major General (O-8)",
+        "recordType": "RECORD_TYPE_PROMOTION",
+        "recordUid": "46"
+      },
+      {
+        "recordDate": "2020-09-27",
+        "recordDetails": "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+        "recordType": "RECORD_TYPE_OPERATION",
+        "recordUid": "13863"
+      }
+    ],
+    "roster": "ROSTER_TYPE_COMBAT",
+    "secondaries": [
+      {
+        "positionId": "812",
+        "positionTitle": "S6 Web Developer"
+      }
+    ],
+    "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+    "user": {
+      "userId": "3",
+      "username": "Jarvis.A"
+    }
+  },
+  "case": "milpacs/discord_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Full profile via Discord snowflake.",
+  "path": "/api/v1/milpac/discord/112233445566778899",
+  "status": 200
+}

--- a/contract/goldens/milpacs/discord_not_found.golden.json
+++ b/contract/goldens/milpacs/discord_not_found.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "no user found for discordid: 999000999"
+  },
+  "case": "milpacs/discord_not_found",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "NotFound message names the discord id.",
+  "path": "/api/v1/milpac/discord/999000999",
+  "status": 404
+}

--- a/contract/goldens/milpacs/gamertag_happy.golden.json
+++ b/contract/goldens/milpacs/gamertag_happy.golden.json
@@ -1,0 +1,36 @@
+{
+  "auth": "read",
+  "body": {
+    "awards": [],
+    "consoleGamertag": "CavGamer77",
+    "discordId": "",
+    "joinDate": "2026-01-15",
+    "lastForumPostDate": "",
+    "mos": "",
+    "primary": null,
+    "promotionDate": "",
+    "rank": {
+      "rankFull": "Private",
+      "rankId": "22",
+      "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+      "rankShort": "PVT"
+    },
+    "realName": "John Doe",
+    "records": [],
+    "roster": "ROSTER_TYPE_COMBAT",
+    "secondaries": [],
+    "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+    "user": {
+      "userId": "8",
+      "username": "John.Doe"
+    }
+  },
+  "case": "milpacs/gamertag_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Full profile via console gamertag.",
+  "path": "/api/v1/milpac/gamertag/CavGamer77",
+  "status": 200
+}

--- a/contract/goldens/milpacs/gamertag_not_found.golden.json
+++ b/contract/goldens/milpacs/gamertag_not_found.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "no user found for gamertag: GhostTag"
+  },
+  "case": "milpacs/gamertag_not_found",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "NotFound message names the gamertag.",
+  "path": "/api/v1/milpac/gamertag/GhostTag",
+  "status": 404
+}

--- a/contract/goldens/milpacs/position_groups.golden.json
+++ b/contract/goldens/milpacs/position_groups.golden.json
@@ -1,0 +1,34 @@
+{
+  "auth": "read",
+  "body": {
+    "groups": [
+      {
+        "groupDisplayOrder": 1,
+        "groupId": "9",
+        "groupTitle": "Regimental HQ",
+        "positions": [
+          {
+            "positionDisplayOrder": 3,
+            "positionId": "773",
+            "positionPossibleSecondary": false,
+            "positionTitle": "Regimental Technical Aide"
+          },
+          {
+            "positionDisplayOrder": 7,
+            "positionId": "812",
+            "positionPossibleSecondary": true,
+            "positionTitle": "S6 Web Developer"
+          }
+        ]
+      }
+    ]
+  },
+  "case": "milpacs/position_groups",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Nested groups → positions, including false booleans emitted.",
+  "path": "/api/v1/milpacs/position/groups",
+  "status": 200
+}

--- a/contract/goldens/milpacs/profile_by_id_happy.golden.json
+++ b/contract/goldens/milpacs/profile_by_id_happy.golden.json
@@ -1,0 +1,65 @@
+{
+  "auth": "read",
+  "body": {
+    "awards": [
+      {
+        "awardDate": "2021-03-01",
+        "awardDetails": "For technical excellence & dedication <est. 2014>",
+        "awardImageUrl": "https://7cav.us/data/awards/ccm.jpg",
+        "awardName": "Commendation Medal",
+        "awardUid": "901"
+      }
+    ],
+    "consoleGamertag": "",
+    "discordId": "112233445566778899",
+    "joinDate": "2014-02-08",
+    "lastForumPostDate": "2026-05-30",
+    "mos": "11B",
+    "primary": {
+      "positionId": "773",
+      "positionTitle": "Regimental Technical Aide"
+    },
+    "promotionDate": "2020-10-17",
+    "rank": {
+      "rankFull": "Major General",
+      "rankId": "4",
+      "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+      "rankShort": "MG"
+    },
+    "realName": "Adam Jarvis",
+    "records": [
+      {
+        "recordDate": "2020-10-17",
+        "recordDetails": "Promoted to Major General (O-8)",
+        "recordType": "RECORD_TYPE_PROMOTION",
+        "recordUid": "46"
+      },
+      {
+        "recordDate": "2020-09-27",
+        "recordDetails": "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+        "recordType": "RECORD_TYPE_OPERATION",
+        "recordUid": "13863"
+      }
+    ],
+    "roster": "ROSTER_TYPE_COMBAT",
+    "secondaries": [
+      {
+        "positionId": "812",
+        "positionTitle": "S6 Web Developer"
+      }
+    ],
+    "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+    "user": {
+      "userId": "3",
+      "username": "Jarvis.A"
+    }
+  },
+  "case": "milpacs/profile_by_id_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Path value is the MILPAC RELATION key, not the forum user id: seed diverges (relation 1 ↔ user 3) and this golden proves relation wins (user.userId is \"3\"). keycloakId stripped by the corpus transform.",
+  "path": "/api/v1/milpacs/profile/id/1",
+  "status": 200
+}

--- a/contract/goldens/milpacs/profile_by_id_internal_error.golden.json
+++ b/contract/goldens/milpacs/profile_by_id_internal_error.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 13,
+    "details": [],
+    "message": "fetch profile by user id: simulated datastore outage"
+  },
+  "case": "milpacs/profile_by_id_internal_error",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Datastore failure: Internal JSON with the wrapped error message leaked. Frozen.",
+  "path": "/api/v1/milpacs/profile/id/777",
+  "status": 500
+}

--- a/contract/goldens/milpacs/profile_by_id_not_found.golden.json
+++ b/contract/goldens/milpacs/profile_by_id_not_found.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "no profile found for user ID: 999"
+  },
+  "case": "milpacs/profile_by_id_not_found",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "NotFound: handler-specific message string, verbatim.",
+  "path": "/api/v1/milpacs/profile/id/999",
+  "status": 404
+}

--- a/contract/goldens/milpacs/profile_by_id_parse_error.golden.json
+++ b/contract/goldens/milpacs/profile_by_id_parse_error.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "type mismatch, parameter: user_id, error: strconv.ParseUint: parsing \"abc\": invalid syntax"
+  },
+  "case": "milpacs/profile_by_id_parse_error",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Non-numeric id: gateway type-mismatch error leaks parse-error text. Frozen.",
+  "path": "/api/v1/milpacs/profile/id/abc",
+  "status": 400
+}

--- a/contract/goldens/milpacs/profile_by_id_sparse.golden.json
+++ b/contract/goldens/milpacs/profile_by_id_sparse.golden.json
@@ -1,0 +1,36 @@
+{
+  "auth": "read",
+  "body": {
+    "awards": [],
+    "consoleGamertag": "CavGamer77",
+    "discordId": "",
+    "joinDate": "2026-01-15",
+    "lastForumPostDate": "",
+    "mos": "",
+    "primary": null,
+    "promotionDate": "",
+    "rank": {
+      "rankFull": "Private",
+      "rankId": "22",
+      "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+      "rankShort": "PVT"
+    },
+    "realName": "John Doe",
+    "records": [],
+    "roster": "ROSTER_TYPE_COMBAT",
+    "secondaries": [],
+    "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+    "user": {
+      "userId": "8",
+      "username": "John.Doe"
+    }
+  },
+  "case": "milpacs/profile_by_id_sparse",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Emit-everything semantics: unset nested message is null (primary), empty collections are [], unset strings are \"\", 64-bit ints are strings.",
+  "path": "/api/v1/milpacs/profile/id/2",
+  "status": 200
+}

--- a/contract/goldens/milpacs/profile_by_id_zero.golden.json
+++ b/contract/goldens/milpacs/profile_by_id_zero.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "no username or user ID provided"
+  },
+  "case": "milpacs/profile_by_id_zero",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "id 0 parses but is the proto zero value: 'no username or user ID provided'.",
+  "path": "/api/v1/milpacs/profile/id/0",
+  "status": 400
+}

--- a/contract/goldens/milpacs/profile_by_username_happy.golden.json
+++ b/contract/goldens/milpacs/profile_by_username_happy.golden.json
@@ -1,0 +1,65 @@
+{
+  "auth": "read",
+  "body": {
+    "awards": [
+      {
+        "awardDate": "2021-03-01",
+        "awardDetails": "For technical excellence & dedication <est. 2014>",
+        "awardImageUrl": "https://7cav.us/data/awards/ccm.jpg",
+        "awardName": "Commendation Medal",
+        "awardUid": "901"
+      }
+    ],
+    "consoleGamertag": "",
+    "discordId": "112233445566778899",
+    "joinDate": "2014-02-08",
+    "lastForumPostDate": "2026-05-30",
+    "mos": "11B",
+    "primary": {
+      "positionId": "773",
+      "positionTitle": "Regimental Technical Aide"
+    },
+    "promotionDate": "2020-10-17",
+    "rank": {
+      "rankFull": "Major General",
+      "rankId": "4",
+      "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+      "rankShort": "MG"
+    },
+    "realName": "Adam Jarvis",
+    "records": [
+      {
+        "recordDate": "2020-10-17",
+        "recordDetails": "Promoted to Major General (O-8)",
+        "recordType": "RECORD_TYPE_PROMOTION",
+        "recordUid": "46"
+      },
+      {
+        "recordDate": "2020-09-27",
+        "recordDetails": "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+        "recordType": "RECORD_TYPE_OPERATION",
+        "recordUid": "13863"
+      }
+    ],
+    "roster": "ROSTER_TYPE_COMBAT",
+    "secondaries": [
+      {
+        "positionId": "812",
+        "positionTitle": "S6 Web Developer"
+      }
+    ],
+    "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+    "user": {
+      "userId": "3",
+      "username": "Jarvis.A"
+    }
+  },
+  "case": "milpacs/profile_by_username_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Username binding of the same RPC.",
+  "path": "/api/v1/milpacs/profile/username/Jarvis.A",
+  "status": 200
+}

--- a/contract/goldens/milpacs/profile_by_username_not_found.golden.json
+++ b/contract/goldens/milpacs/profile_by_username_not_found.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "no profile found for username: Ghost.User"
+  },
+  "case": "milpacs/profile_by_username_not_found",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "NotFound message names the username.",
+  "path": "/api/v1/milpacs/profile/username/Ghost.User",
+  "status": 404
+}

--- a/contract/goldens/milpacs/ranks.golden.json
+++ b/contract/goldens/milpacs/ranks.golden.json
@@ -1,0 +1,29 @@
+{
+  "auth": "read",
+  "body": {
+    "ranks": [
+      {
+        "rankDisplayOrder": 4,
+        "rankFull": "Major General",
+        "rankId": "4",
+        "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+        "rankShort": "MG"
+      },
+      {
+        "rankDisplayOrder": 22,
+        "rankFull": "Private",
+        "rankId": "22",
+        "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+        "rankShort": "PVT"
+      }
+    ]
+  },
+  "case": "milpacs/ranks",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Rank reference list; 64-bit rankId as string, 32-bit displayOrder as number.",
+  "path": "/api/v1/milpacs/ranks",
+  "status": 200
+}

--- a/contract/goldens/position/search_empty_result.golden.json
+++ b/contract/goldens/position/search_empty_result.golden.json
@@ -1,0 +1,14 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {}
+  },
+  "case": "position/search_empty_result",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Plausible query, no rows: {\"profiles\":{}} with 200 — frozen as-is, see #137.",
+  "path": "/api/v1/milpacs/position/search/squad%20leader",
+  "status": 200
+}

--- a/contract/goldens/position/search_happy.golden.json
+++ b/contract/goldens/position/search_happy.golden.json
@@ -1,0 +1,48 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "awardDate": "2021-03-01",
+        "consoleGamertag": "",
+        "discordId": "112233445566778899",
+        "joinDate": "2014-02-08",
+        "lastForumPostDate": "2026-05-30",
+        "mos": "11B",
+        "primary": {
+          "positionId": "773",
+          "positionTitle": "Regimental Technical Aide"
+        },
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankId": "4",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "recordDate": "2020-10-17",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionId": "812",
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      }
+    }
+  },
+  "case": "position/search_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "URL-encoded spaces decode before reaching the handler; exact title hits.",
+  "path": "/api/v1/milpacs/position/search/Regimental%20Technical%20Aide",
+  "status": 200
+}

--- a/contract/goldens/position/search_multi_segment.golden.json
+++ b/contract/goldens/position/search_multi_segment.golden.json
@@ -1,0 +1,14 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {}
+  },
+  "case": "position/search_multi_segment",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "{position_query=**} swallows slashes: multi-segment query routes, returns empty.",
+  "path": "/api/v1/milpacs/position/search/Platoon/Leader",
+  "status": 200
+}

--- a/contract/goldens/position/search_trailing_slash.golden.json
+++ b/contract/goldens/position/search_trailing_slash.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "position query cannot be empty"
+  },
+  "case": "position/search_trailing_slash",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Bare search path: the ** glob matches the empty segment and the handler rejects it — 'position query cannot be empty'.",
+  "path": "/api/v1/milpacs/position/search/",
+  "status": 400
+}

--- a/contract/goldens/roster/bogus_enum.golden.json
+++ b/contract/goldens/roster/bogus_enum.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "type mismatch, parameter: roster, error: IMAGINARY_ROSTER is not valid"
+  },
+  "case": "roster/bogus_enum",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Unknown enum literal: gateway parse error leaks enum-parse text. Frozen.",
+  "path": "/api/v1/roster/IMAGINARY_ROSTER",
+  "status": 400
+}

--- a/contract/goldens/roster/combat_by_name.golden.json
+++ b/contract/goldens/roster/combat_by_name.golden.json
@@ -1,0 +1,94 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "awards": [
+          {
+            "awardDate": "2021-03-01",
+            "awardDetails": "For technical excellence & dedication <est. 2014>",
+            "awardImageUrl": "https://7cav.us/data/awards/ccm.jpg",
+            "awardName": "Commendation Medal",
+            "awardUid": "901"
+          }
+        ],
+        "consoleGamertag": "",
+        "discordId": "112233445566778899",
+        "joinDate": "2014-02-08",
+        "lastForumPostDate": "2026-05-30",
+        "mos": "11B",
+        "primary": {
+          "positionId": "773",
+          "positionTitle": "Regimental Technical Aide"
+        },
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankId": "4",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "records": [
+          {
+            "recordDate": "2020-10-17",
+            "recordDetails": "Promoted to Major General (O-8)",
+            "recordType": "RECORD_TYPE_PROMOTION",
+            "recordUid": "46"
+          },
+          {
+            "recordDate": "2020-09-27",
+            "recordDetails": "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+            "recordType": "RECORD_TYPE_OPERATION",
+            "recordUid": "13863"
+          }
+        ],
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionId": "812",
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "awards": [],
+        "consoleGamertag": "CavGamer77",
+        "discordId": "",
+        "joinDate": "2026-01-15",
+        "lastForumPostDate": "",
+        "mos": "",
+        "primary": null,
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankId": "22",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "records": [],
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "roster/combat_by_name",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Enum NAME path form. Map keyed by relation id (string keys in JSON).",
+  "path": "/api/v1/roster/ROSTER_TYPE_COMBAT",
+  "status": 200
+}

--- a/contract/goldens/roster/combat_by_number.golden.json
+++ b/contract/goldens/roster/combat_by_number.golden.json
@@ -1,0 +1,94 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "awards": [
+          {
+            "awardDate": "2021-03-01",
+            "awardDetails": "For technical excellence & dedication <est. 2014>",
+            "awardImageUrl": "https://7cav.us/data/awards/ccm.jpg",
+            "awardName": "Commendation Medal",
+            "awardUid": "901"
+          }
+        ],
+        "consoleGamertag": "",
+        "discordId": "112233445566778899",
+        "joinDate": "2014-02-08",
+        "lastForumPostDate": "2026-05-30",
+        "mos": "11B",
+        "primary": {
+          "positionId": "773",
+          "positionTitle": "Regimental Technical Aide"
+        },
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankId": "4",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "records": [
+          {
+            "recordDate": "2020-10-17",
+            "recordDetails": "Promoted to Major General (O-8)",
+            "recordType": "RECORD_TYPE_PROMOTION",
+            "recordUid": "46"
+          },
+          {
+            "recordDate": "2020-09-27",
+            "recordDetails": "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+            "recordType": "RECORD_TYPE_OPERATION",
+            "recordUid": "13863"
+          }
+        ],
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionId": "812",
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "awards": [],
+        "consoleGamertag": "CavGamer77",
+        "discordId": "",
+        "joinDate": "2026-01-15",
+        "lastForumPostDate": "",
+        "mos": "",
+        "primary": null,
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankId": "22",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "records": [],
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "roster/combat_by_number",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Enum NUMBER path form: same payload as combat_by_name.",
+  "path": "/api/v1/roster/1",
+  "status": 200
+}

--- a/contract/goldens/roster/internal_error.golden.json
+++ b/contract/goldens/roster/internal_error.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 13,
+    "details": [],
+    "message": "fetch roster ROSTER_TYPE_ARLINGTON: simulated datastore outage"
+  },
+  "case": "roster/internal_error",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Datastore failure: Internal JSON; message embeds the enum name and wrapped error.",
+  "path": "/api/v1/roster/ROSTER_TYPE_ARLINGTON",
+  "status": 500
+}

--- a/contract/goldens/roster/lite_combat_by_name.golden.json
+++ b/contract/goldens/roster/lite_combat_by_name.golden.json
@@ -1,0 +1,73 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "awardDate": "2021-03-01",
+        "consoleGamertag": "",
+        "discordId": "112233445566778899",
+        "joinDate": "2014-02-08",
+        "lastForumPostDate": "2026-05-30",
+        "mos": "11B",
+        "primary": {
+          "positionId": "773",
+          "positionTitle": "Regimental Technical Aide"
+        },
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankId": "4",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "recordDate": "2020-10-17",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionId": "812",
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "awardDate": "",
+        "consoleGamertag": "CavGamer77",
+        "discordId": "",
+        "joinDate": "2026-01-15",
+        "lastForumPostDate": "",
+        "mos": "",
+        "primary": null,
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankId": "22",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "recordDate": "",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "roster/lite_combat_by_name",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Lite profile shape (no records/awards arrays).",
+  "path": "/api/v1/roster/ROSTER_TYPE_COMBAT/lite",
+  "status": 200
+}

--- a/contract/goldens/roster/lite_combat_by_number.golden.json
+++ b/contract/goldens/roster/lite_combat_by_number.golden.json
@@ -1,0 +1,73 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "awardDate": "2021-03-01",
+        "consoleGamertag": "",
+        "discordId": "112233445566778899",
+        "joinDate": "2014-02-08",
+        "lastForumPostDate": "2026-05-30",
+        "mos": "11B",
+        "primary": {
+          "positionId": "773",
+          "positionTitle": "Regimental Technical Aide"
+        },
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankId": "4",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "recordDate": "2020-10-17",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionId": "812",
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "awardDate": "",
+        "consoleGamertag": "CavGamer77",
+        "discordId": "",
+        "joinDate": "2026-01-15",
+        "lastForumPostDate": "",
+        "mos": "",
+        "primary": null,
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankId": "22",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "recordDate": "",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "roster/lite_combat_by_number",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Number form of the lite roster.",
+  "path": "/api/v1/roster/1/lite",
+  "status": 200
+}

--- a/contract/goldens/roster/lite_reserve_empty.golden.json
+++ b/contract/goldens/roster/lite_reserve_empty.golden.json
@@ -1,0 +1,14 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {}
+  },
+  "case": "roster/lite_reserve_empty",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Empty lite roster: {\"profiles\":{}}.",
+  "path": "/api/v1/roster/2/lite",
+  "status": 200
+}

--- a/contract/goldens/roster/lite_unspecified.golden.json
+++ b/contract/goldens/roster/lite_unspecified.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "cannot request null roster type"
+  },
+  "case": "roster/lite_unspecified",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Zero enum on the lite binding.",
+  "path": "/api/v1/roster/ROSTER_TYPE_UNSPECIFIED/lite",
+  "status": 400
+}

--- a/contract/goldens/roster/reserve_empty.golden.json
+++ b/contract/goldens/roster/reserve_empty.golden.json
@@ -1,0 +1,14 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {}
+  },
+  "case": "roster/reserve_empty",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Roster with no members: {\"profiles\":{}}.",
+  "path": "/api/v1/roster/ROSTER_TYPE_RESERVE",
+  "status": 200
+}

--- a/contract/goldens/roster/unknown_query_param_ignored.golden.json
+++ b/contract/goldens/roster/unknown_query_param_ignored.golden.json
@@ -1,0 +1,94 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "awards": [
+          {
+            "awardDate": "2021-03-01",
+            "awardDetails": "For technical excellence & dedication <est. 2014>",
+            "awardImageUrl": "https://7cav.us/data/awards/ccm.jpg",
+            "awardName": "Commendation Medal",
+            "awardUid": "901"
+          }
+        ],
+        "consoleGamertag": "",
+        "discordId": "112233445566778899",
+        "joinDate": "2014-02-08",
+        "lastForumPostDate": "2026-05-30",
+        "mos": "11B",
+        "primary": {
+          "positionId": "773",
+          "positionTitle": "Regimental Technical Aide"
+        },
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankId": "4",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "records": [
+          {
+            "recordDate": "2020-10-17",
+            "recordDetails": "Promoted to Major General (O-8)",
+            "recordType": "RECORD_TYPE_PROMOTION",
+            "recordUid": "46"
+          },
+          {
+            "recordDate": "2020-09-27",
+            "recordDetails": "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+            "recordType": "RECORD_TYPE_OPERATION",
+            "recordUid": "13863"
+          }
+        ],
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionId": "812",
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "awards": [],
+        "consoleGamertag": "CavGamer77",
+        "discordId": "",
+        "joinDate": "2026-01-15",
+        "lastForumPostDate": "",
+        "mos": "",
+        "primary": null,
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankId": "22",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "records": [],
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "roster/unknown_query_param_ignored",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Unknown query parameters are ignored: identical payload to combat_by_name.",
+  "path": "/api/v1/roster/ROSTER_TYPE_COMBAT?totally_unknown=1&alsoUnknown=x",
+  "status": 200
+}

--- a/contract/goldens/roster/unspecified_by_name.golden.json
+++ b/contract/goldens/roster/unspecified_by_name.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "cannot request null roster type"
+  },
+  "case": "roster/unspecified_by_name",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Explicit zero enum: 'cannot request null roster type'.",
+  "path": "/api/v1/roster/ROSTER_TYPE_UNSPECIFIED",
+  "status": 400
+}

--- a/contract/goldens/roster/unspecified_by_number.golden.json
+++ b/contract/goldens/roster/unspecified_by_number.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "cannot request null roster type"
+  },
+  "case": "roster/unspecified_by_number",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Numeric zero: same InvalidArgument.",
+  "path": "/api/v1/roster/0",
+  "status": 400
+}

--- a/contract/goldens/s1/uniforms_combat_by_name.golden.json
+++ b/contract/goldens/s1/uniforms_combat_by_name.golden.json
@@ -1,0 +1,61 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "areaOfResponsibility": "S6",
+        "joinDate": "2014-02-08",
+        "primaryPositionTitle": "Regimental Technical Aide",
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformDate": "2025-11-02",
+        "uniformUpdateTriggerDate": "2025-12-01",
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "areaOfResponsibility": "",
+        "joinDate": "2026-01-15",
+        "primaryPositionTitle": "Rifleman",
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformDate": "",
+        "uniformUpdateTriggerDate": "",
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "s1/uniforms_combat_by_name",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "S1 uniforms shape, enum name form.",
+  "path": "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT",
+  "status": 200
+}

--- a/contract/goldens/s1/uniforms_combat_by_number.golden.json
+++ b/contract/goldens/s1/uniforms_combat_by_number.golden.json
@@ -1,0 +1,61 @@
+{
+  "auth": "read",
+  "body": {
+    "profiles": {
+      "1": {
+        "areaOfResponsibility": "S6",
+        "joinDate": "2014-02-08",
+        "primaryPositionTitle": "Regimental Technical Aide",
+        "promotionDate": "2020-10-17",
+        "rank": {
+          "rankFull": "Major General",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+          "rankShort": "MG"
+        },
+        "realName": "Adam Jarvis",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [
+          {
+            "positionTitle": "S6 Web Developer"
+          }
+        ],
+        "uniformDate": "2025-11-02",
+        "uniformUpdateTriggerDate": "2025-12-01",
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/1.jpg",
+        "user": {
+          "userId": "3",
+          "username": "Jarvis.A"
+        }
+      },
+      "2": {
+        "areaOfResponsibility": "",
+        "joinDate": "2026-01-15",
+        "primaryPositionTitle": "Rifleman",
+        "promotionDate": "",
+        "rank": {
+          "rankFull": "Private",
+          "rankImageUrl": "https://7cav.us/data/roster_ranks/0/22.jpg",
+          "rankShort": "PVT"
+        },
+        "realName": "John Doe",
+        "roster": "ROSTER_TYPE_COMBAT",
+        "secondaries": [],
+        "uniformDate": "",
+        "uniformUpdateTriggerDate": "",
+        "uniformUrl": "https://7cav.us/data/roster_uniforms/0/2.jpg",
+        "user": {
+          "userId": "8",
+          "username": "John.Doe"
+        }
+      }
+    }
+  },
+  "case": "s1/uniforms_combat_by_number",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "S1 uniforms, enum number form: same payload.",
+  "path": "/api/v1/s1/uniforms/1",
+  "status": 200
+}

--- a/contract/goldens/s1/uniforms_unspecified.golden.json
+++ b/contract/goldens/s1/uniforms_unspecified.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "cannot request null roster type"
+  },
+  "case": "s1/uniforms_unspecified",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Zero enum on the uniforms binding.",
+  "path": "/api/v1/s1/uniforms/0",
+  "status": 400
+}

--- a/contract/goldens/tickets/categories.golden.json
+++ b/contract/goldens/tickets/categories.golden.json
@@ -1,0 +1,42 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "categories": [
+      {
+        "categoryId": 1,
+        "depth": 0,
+        "description": "Enlistment & recruiting questions",
+        "displayOrder": 10,
+        "parentCategoryId": 0,
+        "ticketCount": 120,
+        "title": "Recruiting"
+      },
+      {
+        "categoryId": 5,
+        "depth": 1,
+        "description": "",
+        "displayOrder": 20,
+        "parentCategoryId": 1,
+        "ticketCount": 34,
+        "title": "S1 Personnel"
+      },
+      {
+        "categoryId": 7,
+        "depth": 0,
+        "description": "Teamspeak, forum & game-server help",
+        "displayOrder": 30,
+        "parentCategoryId": 0,
+        "ticketCount": 78,
+        "title": "S6 Technical Support"
+      }
+    ]
+  },
+  "case": "tickets/categories",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Category reference tree; literal 'categories' segment wins over {ticket_id}.",
+  "path": "/api/v1/tickets/categories",
+  "status": 200
+}

--- a/contract/goldens/tickets/get_by_id_happy.golden.json
+++ b/contract/goldens/tickets/get_by_id_happy.golden.json
@@ -1,0 +1,93 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "firstMessages": [
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "[B]Enlistment[/B] request — I'd like to join the 7th Cavalry & start ASAP <o7>",
+        "messageDate": 1748400000,
+        "messageId": 9001,
+        "messageState": "visible",
+        "position": 0,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      },
+      {
+        "attachCount": 1,
+        "editCount": 1,
+        "lastEditDate": 1748451000,
+        "message": "Welcome aboard — processing now.",
+        "messageDate": 1748450000,
+        "messageId": 9002,
+        "messageState": "visible",
+        "position": 1,
+        "ticketId": 42,
+        "userId": 3,
+        "username": "Jarvis.A"
+      },
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "Thank you!",
+        "messageDate": 1748480000,
+        "messageId": 9003,
+        "messageState": "visible",
+        "position": 2,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      }
+    ],
+    "ticket": {
+      "assignedUserId": 0,
+      "assignedUsername": "",
+      "categoryAncestorIds": [],
+      "categoryId": 1,
+      "categoryTitle": "Recruiting",
+      "customFields": {
+        "recruiter": "Jarvis.A"
+      },
+      "discussionState": "visible",
+      "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+      "lastMessageDate": 1748480000,
+      "lastMessageUserId": 8,
+      "lastMessageUsername": "John.Doe",
+      "lastModifiedDate": 1748500000,
+      "participants": [
+        {
+          "lastReadDate": 1748450000,
+          "userId": 8
+        }
+      ],
+      "prefixId": 1,
+      "prefixName": "Enlistment",
+      "priorityId": 3,
+      "priorityName": "High",
+      "replyCount": 2,
+      "startDate": 1748400000,
+      "starterUserId": 8,
+      "starterUsername": "John.Doe",
+      "statusId": 1,
+      "statusName": "New",
+      "ticketId": 42,
+      "ticketLocked": false,
+      "ticketRef": "MF1UI9HE",
+      "ticketState": "open",
+      "title": "Enlistment — John.Doe",
+      "totalMessageCount": 3
+    },
+    "totalMessageCount": 3
+  },
+  "case": "tickets/get_by_id_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Ticket + firstMessages + deprecated top-level totalMessageCount duplicating ticket.totalMessageCount.",
+  "path": "/api/v1/tickets/42",
+  "status": 200
+}

--- a/contract/goldens/tickets/get_by_id_not_found.golden.json
+++ b/contract/goldens/tickets/get_by_id_not_found.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "ticket 9999 not found"
+  },
+  "case": "tickets/get_by_id_not_found",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "NotFound names the numeric id.",
+  "path": "/api/v1/tickets/9999",
+  "status": 404
+}

--- a/contract/goldens/tickets/get_by_id_parse_error.golden.json
+++ b/contract/goldens/tickets/get_by_id_parse_error.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "type mismatch, parameter: ticket_id, error: strconv.ParseUint: parsing \"abc\": invalid syntax"
+  },
+  "case": "tickets/get_by_id_parse_error",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Non-numeric id under {ticket_id}: leaked parse-error text. Frozen.",
+  "path": "/api/v1/tickets/abc",
+  "status": 400
+}

--- a/contract/goldens/tickets/get_by_ref_happy.golden.json
+++ b/contract/goldens/tickets/get_by_ref_happy.golden.json
@@ -1,0 +1,93 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "firstMessages": [
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "[B]Enlistment[/B] request — I'd like to join the 7th Cavalry & start ASAP <o7>",
+        "messageDate": 1748400000,
+        "messageId": 9001,
+        "messageState": "visible",
+        "position": 0,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      },
+      {
+        "attachCount": 1,
+        "editCount": 1,
+        "lastEditDate": 1748451000,
+        "message": "Welcome aboard — processing now.",
+        "messageDate": 1748450000,
+        "messageId": 9002,
+        "messageState": "visible",
+        "position": 1,
+        "ticketId": 42,
+        "userId": 3,
+        "username": "Jarvis.A"
+      },
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "Thank you!",
+        "messageDate": 1748480000,
+        "messageId": 9003,
+        "messageState": "visible",
+        "position": 2,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      }
+    ],
+    "ticket": {
+      "assignedUserId": 0,
+      "assignedUsername": "",
+      "categoryAncestorIds": [],
+      "categoryId": 1,
+      "categoryTitle": "Recruiting",
+      "customFields": {
+        "recruiter": "Jarvis.A"
+      },
+      "discussionState": "visible",
+      "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+      "lastMessageDate": 1748480000,
+      "lastMessageUserId": 8,
+      "lastMessageUsername": "John.Doe",
+      "lastModifiedDate": 1748500000,
+      "participants": [
+        {
+          "lastReadDate": 1748450000,
+          "userId": 8
+        }
+      ],
+      "prefixId": 1,
+      "prefixName": "Enlistment",
+      "priorityId": 3,
+      "priorityName": "High",
+      "replyCount": 2,
+      "startDate": 1748400000,
+      "starterUserId": 8,
+      "starterUsername": "John.Doe",
+      "statusId": 1,
+      "statusName": "New",
+      "ticketId": 42,
+      "ticketLocked": false,
+      "ticketRef": "MF1UI9HE",
+      "ticketState": "open",
+      "title": "Enlistment — John.Doe",
+      "totalMessageCount": 3
+    },
+    "totalMessageCount": 3
+  },
+  "case": "tickets/get_by_ref_happy",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Ref binding returns the same GetTicketResponse shape.",
+  "path": "/api/v1/tickets/ref/MF1UI9HE",
+  "status": 200
+}

--- a/contract/goldens/tickets/get_by_ref_not_found.golden.json
+++ b/contract/goldens/tickets/get_by_ref_not_found.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 5,
+    "details": [],
+    "message": "ticket \"NOPE9999\" not found"
+  },
+  "case": "tickets/get_by_ref_not_found",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "NotFound quotes the ref.",
+  "path": "/api/v1/tickets/ref/NOPE9999",
+  "status": 404
+}

--- a/contract/goldens/tickets/list_category_exclude_subcategories.golden.json
+++ b/contract/goldens/tickets/list_category_exclude_subcategories.golden.json
@@ -1,0 +1,55 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 1,
+        "categoryTitle": "Recruiting",
+        "customFields": {
+          "recruiter": "Jarvis.A"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+        "lastMessageDate": 1748480000,
+        "lastMessageUserId": 8,
+        "lastMessageUsername": "John.Doe",
+        "lastModifiedDate": 1748500000,
+        "participants": [
+          {
+            "lastReadDate": 1748450000,
+            "userId": 8
+          }
+        ],
+        "prefixId": 1,
+        "prefixName": "Enlistment",
+        "priorityId": 3,
+        "priorityName": "High",
+        "replyCount": 2,
+        "startDate": 1748400000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 1,
+        "statusName": "New",
+        "ticketId": 42,
+        "ticketLocked": false,
+        "ticketRef": "MF1UI9HE",
+        "ticketState": "open",
+        "title": "Enlistment — John.Doe",
+        "totalMessageCount": 3
+      }
+    ]
+  },
+  "case": "tickets/list_category_exclude_subcategories",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "exclude_subcategories=true matches the exact category only.",
+  "path": "/api/v1/tickets?category_id=1&exclude_subcategories=true",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_category_includes_subcategories.golden.json
+++ b/contract/goldens/tickets/list_category_includes_subcategories.golden.json
@@ -1,0 +1,100 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 3,
+        "assignedUsername": "Jarvis.A",
+        "categoryAncestorIds": [
+          1
+        ],
+        "categoryId": 5,
+        "categoryTitle": "S1 Personnel",
+        "customFields": {
+          "billet": "Rifleman",
+          "department": "S1"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/ZZTOP44Q/",
+        "lastMessageDate": 1748699000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748700000,
+        "participants": [
+          {
+            "lastReadDate": 1748690000,
+            "userId": 8
+          },
+          {
+            "lastReadDate": 1748695000,
+            "userId": 3
+          }
+        ],
+        "prefixId": 3,
+        "prefixName": "Transfer",
+        "priorityId": 2,
+        "priorityName": "Normal",
+        "replyCount": 1,
+        "startDate": 1748600000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 2,
+        "statusName": "In Progress",
+        "ticketId": 44,
+        "ticketLocked": false,
+        "ticketRef": "ZZTOP44Q",
+        "ticketState": "open",
+        "title": "Transfer request: Bravo to Alpha",
+        "totalMessageCount": 2
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 1,
+        "categoryTitle": "Recruiting",
+        "customFields": {
+          "recruiter": "Jarvis.A"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+        "lastMessageDate": 1748480000,
+        "lastMessageUserId": 8,
+        "lastMessageUsername": "John.Doe",
+        "lastModifiedDate": 1748500000,
+        "participants": [
+          {
+            "lastReadDate": 1748450000,
+            "userId": 8
+          }
+        ],
+        "prefixId": 1,
+        "prefixName": "Enlistment",
+        "priorityId": 3,
+        "priorityName": "High",
+        "replyCount": 2,
+        "startDate": 1748400000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 1,
+        "statusName": "New",
+        "ticketId": 42,
+        "ticketLocked": false,
+        "ticketRef": "MF1UI9HE",
+        "ticketState": "open",
+        "title": "Enlistment — John.Doe",
+        "totalMessageCount": 3
+      }
+    ]
+  },
+  "case": "tickets/list_category_includes_subcategories",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Category filter expands the subtree by default: parent 1 pulls in child category 5.",
+  "path": "/api/v1/tickets?category_id=1",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_default.golden.json
+++ b/contract/goldens/tickets/list_default.golden.json
@@ -1,0 +1,131 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 3,
+        "assignedUsername": "Jarvis.A",
+        "categoryAncestorIds": [
+          1
+        ],
+        "categoryId": 5,
+        "categoryTitle": "S1 Personnel",
+        "customFields": {
+          "billet": "Rifleman",
+          "department": "S1"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/ZZTOP44Q/",
+        "lastMessageDate": 1748699000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748700000,
+        "participants": [
+          {
+            "lastReadDate": 1748690000,
+            "userId": 8
+          },
+          {
+            "lastReadDate": 1748695000,
+            "userId": 3
+          }
+        ],
+        "prefixId": 3,
+        "prefixName": "Transfer",
+        "priorityId": 2,
+        "priorityName": "Normal",
+        "replyCount": 1,
+        "startDate": 1748600000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 2,
+        "statusName": "In Progress",
+        "ticketId": 44,
+        "ticketLocked": false,
+        "ticketRef": "ZZTOP44Q",
+        "ticketState": "open",
+        "title": "Transfer request: Bravo to Alpha",
+        "totalMessageCount": 2
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 7,
+        "categoryTitle": "S6 Technical Support",
+        "customFields": {},
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/QQWW43RR/",
+        "lastMessageDate": 1748590000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748600000,
+        "participants": [],
+        "prefixId": 0,
+        "prefixName": "",
+        "priorityId": 1,
+        "priorityName": "Low",
+        "replyCount": 0,
+        "startDate": 1748500000,
+        "starterUserId": 3,
+        "starterUsername": "Jarvis.A",
+        "statusId": 5,
+        "statusName": "Resolved",
+        "ticketId": 43,
+        "ticketLocked": false,
+        "ticketRef": "QQWW43RR",
+        "ticketState": "resolved",
+        "title": "TeamSpeak <connection> issues & errors",
+        "totalMessageCount": 1
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 1,
+        "categoryTitle": "Recruiting",
+        "customFields": {
+          "recruiter": "Jarvis.A"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+        "lastMessageDate": 1748480000,
+        "lastMessageUserId": 8,
+        "lastMessageUsername": "John.Doe",
+        "lastModifiedDate": 1748500000,
+        "participants": [
+          {
+            "lastReadDate": 1748450000,
+            "userId": 8
+          }
+        ],
+        "prefixId": 1,
+        "prefixName": "Enlistment",
+        "priorityId": 3,
+        "priorityName": "High",
+        "replyCount": 2,
+        "startDate": 1748400000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 1,
+        "statusName": "New",
+        "ticketId": 42,
+        "ticketLocked": false,
+        "ticketRef": "MF1UI9HE",
+        "ticketState": "open",
+        "title": "Enlistment — John.Doe",
+        "totalMessageCount": 3
+      }
+    ]
+  },
+  "case": "tickets/list_default",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "All seeded tickets, last_modified DESC; empty next_cursor, has_more false.",
+  "path": "/api/v1/tickets",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_invalid_cursor_camel.golden.json
+++ b/contract/goldens/tickets/list_invalid_cursor_camel.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "invalid after_cursor"
+  },
+  "case": "tickets/list_invalid_cursor_camel",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Malformed cursor (camelCase key): InvalidArgument 'invalid after_cursor'.",
+  "path": "/api/v1/tickets?afterCursor=bogus",
+  "status": 400
+}

--- a/contract/goldens/tickets/list_page_two.golden.json
+++ b/contract/goldens/tickets/list_page_two.golden.json
@@ -1,0 +1,48 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": true,
+    "nextCursor": "MTc0ODYwMDAwMDo0Mw",
+    "tickets": [
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 7,
+        "categoryTitle": "S6 Technical Support",
+        "customFields": {},
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/QQWW43RR/",
+        "lastMessageDate": 1748590000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748600000,
+        "participants": [],
+        "prefixId": 0,
+        "prefixName": "",
+        "priorityId": 1,
+        "priorityName": "Low",
+        "replyCount": 0,
+        "startDate": 1748500000,
+        "starterUserId": 3,
+        "starterUsername": "Jarvis.A",
+        "statusId": 5,
+        "statusName": "Resolved",
+        "ticketId": 43,
+        "ticketLocked": false,
+        "ticketRef": "QQWW43RR",
+        "ticketState": "resolved",
+        "title": "TeamSpeak <connection> issues & errors",
+        "totalMessageCount": 1
+      }
+    ]
+  },
+  "case": "tickets/list_page_two",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Round-tripped cursor: page 2 holds ticket 43 and a further cursor.",
+  "path": "/api/v1/tickets?per_page=1&after_cursor=MTc0ODcwMDAwMDo0NA",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_per_page_camel.golden.json
+++ b/contract/goldens/tickets/list_per_page_camel.golden.json
@@ -1,0 +1,62 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": true,
+    "nextCursor": "MTc0ODcwMDAwMDo0NA",
+    "tickets": [
+      {
+        "assignedUserId": 3,
+        "assignedUsername": "Jarvis.A",
+        "categoryAncestorIds": [
+          1
+        ],
+        "categoryId": 5,
+        "categoryTitle": "S1 Personnel",
+        "customFields": {
+          "billet": "Rifleman",
+          "department": "S1"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/ZZTOP44Q/",
+        "lastMessageDate": 1748699000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748700000,
+        "participants": [
+          {
+            "lastReadDate": 1748690000,
+            "userId": 8
+          },
+          {
+            "lastReadDate": 1748695000,
+            "userId": 3
+          }
+        ],
+        "prefixId": 3,
+        "prefixName": "Transfer",
+        "priorityId": 2,
+        "priorityName": "Normal",
+        "replyCount": 1,
+        "startDate": 1748600000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 2,
+        "statusName": "In Progress",
+        "ticketId": 44,
+        "ticketLocked": false,
+        "ticketRef": "ZZTOP44Q",
+        "ticketState": "open",
+        "title": "Transfer request: Bravo to Alpha",
+        "totalMessageCount": 2
+      }
+    ]
+  },
+  "case": "tickets/list_per_page_camel",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "camelCase spelling of the same key: identical payload to list_per_page_snake.",
+  "path": "/api/v1/tickets?perPage=1",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_per_page_snake.golden.json
+++ b/contract/goldens/tickets/list_per_page_snake.golden.json
@@ -1,0 +1,62 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": true,
+    "nextCursor": "MTc0ODcwMDAwMDo0NA",
+    "tickets": [
+      {
+        "assignedUserId": 3,
+        "assignedUsername": "Jarvis.A",
+        "categoryAncestorIds": [
+          1
+        ],
+        "categoryId": 5,
+        "categoryTitle": "S1 Personnel",
+        "customFields": {
+          "billet": "Rifleman",
+          "department": "S1"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/ZZTOP44Q/",
+        "lastMessageDate": 1748699000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748700000,
+        "participants": [
+          {
+            "lastReadDate": 1748690000,
+            "userId": 8
+          },
+          {
+            "lastReadDate": 1748695000,
+            "userId": 3
+          }
+        ],
+        "prefixId": 3,
+        "prefixName": "Transfer",
+        "priorityId": 2,
+        "priorityName": "Normal",
+        "replyCount": 1,
+        "startDate": 1748600000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 2,
+        "statusName": "In Progress",
+        "ticketId": 44,
+        "ticketLocked": false,
+        "ticketRef": "ZZTOP44Q",
+        "ticketState": "open",
+        "title": "Transfer request: Bravo to Alpha",
+        "totalMessageCount": 2
+      }
+    ]
+  },
+  "case": "tickets/list_per_page_snake",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "snake_case query key; page 1 with next_cursor and has_more true.",
+  "path": "/api/v1/tickets?per_page=1",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_repeated_status_filter.golden.json
+++ b/contract/goldens/tickets/list_repeated_status_filter.golden.json
@@ -1,0 +1,86 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 7,
+        "categoryTitle": "S6 Technical Support",
+        "customFields": {},
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/QQWW43RR/",
+        "lastMessageDate": 1748590000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748600000,
+        "participants": [],
+        "prefixId": 0,
+        "prefixName": "",
+        "priorityId": 1,
+        "priorityName": "Low",
+        "replyCount": 0,
+        "startDate": 1748500000,
+        "starterUserId": 3,
+        "starterUsername": "Jarvis.A",
+        "statusId": 5,
+        "statusName": "Resolved",
+        "ticketId": 43,
+        "ticketLocked": false,
+        "ticketRef": "QQWW43RR",
+        "ticketState": "resolved",
+        "title": "TeamSpeak <connection> issues & errors",
+        "totalMessageCount": 1
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 1,
+        "categoryTitle": "Recruiting",
+        "customFields": {
+          "recruiter": "Jarvis.A"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+        "lastMessageDate": 1748480000,
+        "lastMessageUserId": 8,
+        "lastMessageUsername": "John.Doe",
+        "lastModifiedDate": 1748500000,
+        "participants": [
+          {
+            "lastReadDate": 1748450000,
+            "userId": 8
+          }
+        ],
+        "prefixId": 1,
+        "prefixName": "Enlistment",
+        "priorityId": 3,
+        "priorityName": "High",
+        "replyCount": 2,
+        "startDate": 1748400000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 1,
+        "statusName": "New",
+        "ticketId": 42,
+        "ticketLocked": false,
+        "ticketRef": "MF1UI9HE",
+        "ticketState": "open",
+        "title": "Enlistment — John.Doe",
+        "totalMessageCount": 3
+      }
+    ]
+  },
+  "case": "tickets/list_repeated_status_filter",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Repeated query params build a repeated field: tickets 43 and 42 only.",
+  "path": "/api/v1/tickets?status_id=1&status_id=5",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_starter_filter.golden.json
+++ b/contract/goldens/tickets/list_starter_filter.golden.json
@@ -1,0 +1,100 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 3,
+        "assignedUsername": "Jarvis.A",
+        "categoryAncestorIds": [
+          1
+        ],
+        "categoryId": 5,
+        "categoryTitle": "S1 Personnel",
+        "customFields": {
+          "billet": "Rifleman",
+          "department": "S1"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/ZZTOP44Q/",
+        "lastMessageDate": 1748699000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748700000,
+        "participants": [
+          {
+            "lastReadDate": 1748690000,
+            "userId": 8
+          },
+          {
+            "lastReadDate": 1748695000,
+            "userId": 3
+          }
+        ],
+        "prefixId": 3,
+        "prefixName": "Transfer",
+        "priorityId": 2,
+        "priorityName": "Normal",
+        "replyCount": 1,
+        "startDate": 1748600000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 2,
+        "statusName": "In Progress",
+        "ticketId": 44,
+        "ticketLocked": false,
+        "ticketRef": "ZZTOP44Q",
+        "ticketState": "open",
+        "title": "Transfer request: Bravo to Alpha",
+        "totalMessageCount": 2
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 1,
+        "categoryTitle": "Recruiting",
+        "customFields": {
+          "recruiter": "Jarvis.A"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+        "lastMessageDate": 1748480000,
+        "lastMessageUserId": 8,
+        "lastMessageUsername": "John.Doe",
+        "lastModifiedDate": 1748500000,
+        "participants": [
+          {
+            "lastReadDate": 1748450000,
+            "userId": 8
+          }
+        ],
+        "prefixId": 1,
+        "prefixName": "Enlistment",
+        "priorityId": 3,
+        "priorityName": "High",
+        "replyCount": 2,
+        "startDate": 1748400000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 1,
+        "statusName": "New",
+        "ticketId": 42,
+        "ticketLocked": false,
+        "ticketRef": "MF1UI9HE",
+        "ticketState": "open",
+        "title": "Enlistment — John.Doe",
+        "totalMessageCount": 3
+      }
+    ]
+  },
+  "case": "tickets/list_starter_filter",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Starter filter; forum user id (8), not relation key.",
+  "path": "/api/v1/tickets?starter_user_id=8",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_state_filter.golden.json
+++ b/contract/goldens/tickets/list_state_filter.golden.json
@@ -1,0 +1,48 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 7,
+        "categoryTitle": "S6 Technical Support",
+        "customFields": {},
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/QQWW43RR/",
+        "lastMessageDate": 1748590000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748600000,
+        "participants": [],
+        "prefixId": 0,
+        "prefixName": "",
+        "priorityId": 1,
+        "priorityName": "Low",
+        "replyCount": 0,
+        "startDate": 1748500000,
+        "starterUserId": 3,
+        "starterUsername": "Jarvis.A",
+        "statusId": 5,
+        "statusName": "Resolved",
+        "ticketId": 43,
+        "ticketLocked": false,
+        "ticketRef": "QQWW43RR",
+        "ticketState": "resolved",
+        "title": "TeamSpeak <connection> issues & errors",
+        "totalMessageCount": 1
+      }
+    ]
+  },
+  "case": "tickets/list_state_filter",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "String filter: resolved only.",
+  "path": "/api/v1/tickets?ticket_state=resolved",
+  "status": 200
+}

--- a/contract/goldens/tickets/list_unknown_param_ignored.golden.json
+++ b/contract/goldens/tickets/list_unknown_param_ignored.golden.json
@@ -1,0 +1,131 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "nextCursor": "",
+    "tickets": [
+      {
+        "assignedUserId": 3,
+        "assignedUsername": "Jarvis.A",
+        "categoryAncestorIds": [
+          1
+        ],
+        "categoryId": 5,
+        "categoryTitle": "S1 Personnel",
+        "customFields": {
+          "billet": "Rifleman",
+          "department": "S1"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/ZZTOP44Q/",
+        "lastMessageDate": 1748699000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748700000,
+        "participants": [
+          {
+            "lastReadDate": 1748690000,
+            "userId": 8
+          },
+          {
+            "lastReadDate": 1748695000,
+            "userId": 3
+          }
+        ],
+        "prefixId": 3,
+        "prefixName": "Transfer",
+        "priorityId": 2,
+        "priorityName": "Normal",
+        "replyCount": 1,
+        "startDate": 1748600000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 2,
+        "statusName": "In Progress",
+        "ticketId": 44,
+        "ticketLocked": false,
+        "ticketRef": "ZZTOP44Q",
+        "ticketState": "open",
+        "title": "Transfer request: Bravo to Alpha",
+        "totalMessageCount": 2
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 7,
+        "categoryTitle": "S6 Technical Support",
+        "customFields": {},
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/QQWW43RR/",
+        "lastMessageDate": 1748590000,
+        "lastMessageUserId": 3,
+        "lastMessageUsername": "Jarvis.A",
+        "lastModifiedDate": 1748600000,
+        "participants": [],
+        "prefixId": 0,
+        "prefixName": "",
+        "priorityId": 1,
+        "priorityName": "Low",
+        "replyCount": 0,
+        "startDate": 1748500000,
+        "starterUserId": 3,
+        "starterUsername": "Jarvis.A",
+        "statusId": 5,
+        "statusName": "Resolved",
+        "ticketId": 43,
+        "ticketLocked": false,
+        "ticketRef": "QQWW43RR",
+        "ticketState": "resolved",
+        "title": "TeamSpeak <connection> issues & errors",
+        "totalMessageCount": 1
+      },
+      {
+        "assignedUserId": 0,
+        "assignedUsername": "",
+        "categoryAncestorIds": [],
+        "categoryId": 1,
+        "categoryTitle": "Recruiting",
+        "customFields": {
+          "recruiter": "Jarvis.A"
+        },
+        "discussionState": "visible",
+        "forumUrl": "https://7cav.us/tickets/MF1UI9HE/",
+        "lastMessageDate": 1748480000,
+        "lastMessageUserId": 8,
+        "lastMessageUsername": "John.Doe",
+        "lastModifiedDate": 1748500000,
+        "participants": [
+          {
+            "lastReadDate": 1748450000,
+            "userId": 8
+          }
+        ],
+        "prefixId": 1,
+        "prefixName": "Enlistment",
+        "priorityId": 3,
+        "priorityName": "High",
+        "replyCount": 2,
+        "startDate": 1748400000,
+        "starterUserId": 8,
+        "starterUsername": "John.Doe",
+        "statusId": 1,
+        "statusName": "New",
+        "ticketId": 42,
+        "ticketLocked": false,
+        "ticketRef": "MF1UI9HE",
+        "ticketState": "open",
+        "title": "Enlistment — John.Doe",
+        "totalMessageCount": 3
+      }
+    ]
+  },
+  "case": "tickets/list_unknown_param_ignored",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Unknown query parameter ignored: identical payload to list_default.",
+  "path": "/api/v1/tickets?utterly_unknown=42",
+  "status": 200
+}

--- a/contract/goldens/tickets/messages_default.golden.json
+++ b/contract/goldens/tickets/messages_default.golden.json
@@ -1,0 +1,56 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "messages": [
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "[B]Enlistment[/B] request — I'd like to join the 7th Cavalry & start ASAP <o7>",
+        "messageDate": 1748400000,
+        "messageId": 9001,
+        "messageState": "visible",
+        "position": 0,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      },
+      {
+        "attachCount": 1,
+        "editCount": 1,
+        "lastEditDate": 1748451000,
+        "message": "Welcome aboard — processing now.",
+        "messageDate": 1748450000,
+        "messageId": 9002,
+        "messageState": "visible",
+        "position": 1,
+        "ticketId": 42,
+        "userId": 3,
+        "username": "Jarvis.A"
+      },
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "Thank you!",
+        "messageDate": 1748480000,
+        "messageId": 9003,
+        "messageState": "visible",
+        "position": 2,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      }
+    ],
+    "nextCursor": ""
+  },
+  "case": "tickets/messages_default",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Full thread, position ascending; BBCode and &/<> characters unescaped in JSON strings.",
+  "path": "/api/v1/tickets/42/messages",
+  "status": 200
+}

--- a/contract/goldens/tickets/messages_invalid_cursor_snake.golden.json
+++ b/contract/goldens/tickets/messages_invalid_cursor_snake.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "invalid after_cursor"
+  },
+  "case": "tickets/messages_invalid_cursor_snake",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Malformed message cursor: InvalidArgument 'invalid after_cursor'.",
+  "path": "/api/v1/tickets/42/messages?after_cursor=bogus",
+  "status": 400
+}

--- a/contract/goldens/tickets/messages_page_two.golden.json
+++ b/contract/goldens/tickets/messages_page_two.golden.json
@@ -1,0 +1,30 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": true,
+    "messages": [
+      {
+        "attachCount": 1,
+        "editCount": 1,
+        "lastEditDate": 1748451000,
+        "message": "Welcome aboard — processing now.",
+        "messageDate": 1748450000,
+        "messageId": 9002,
+        "messageState": "visible",
+        "position": 1,
+        "ticketId": 42,
+        "userId": 3,
+        "username": "Jarvis.A"
+      }
+    ],
+    "nextCursor": "Mg"
+  },
+  "case": "tickets/messages_page_two",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Round-tripped message cursor: second message only.",
+  "path": "/api/v1/tickets/42/messages?per_page=1&after_cursor=MQ",
+  "status": 200
+}

--- a/contract/goldens/tickets/messages_parse_error.golden.json
+++ b/contract/goldens/tickets/messages_parse_error.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "code": 3,
+    "details": [],
+    "message": "type mismatch, parameter: ticket_id, error: strconv.ParseUint: parsing \"abc\": invalid syntax"
+  },
+  "case": "tickets/messages_parse_error",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Non-numeric id on the messages binding: leaked parse-error text.",
+  "path": "/api/v1/tickets/abc/messages",
+  "status": 400
+}

--- a/contract/goldens/tickets/messages_per_page_camel.golden.json
+++ b/contract/goldens/tickets/messages_per_page_camel.golden.json
@@ -1,0 +1,30 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": true,
+    "messages": [
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "[B]Enlistment[/B] request — I'd like to join the 7th Cavalry & start ASAP <o7>",
+        "messageDate": 1748400000,
+        "messageId": 9001,
+        "messageState": "visible",
+        "position": 0,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      }
+    ],
+    "nextCursor": "MQ"
+  },
+  "case": "tickets/messages_per_page_camel",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "camelCase spelling: identical payload to messages_per_page_snake.",
+  "path": "/api/v1/tickets/42/messages?perPage=1",
+  "status": 200
+}

--- a/contract/goldens/tickets/messages_per_page_snake.golden.json
+++ b/contract/goldens/tickets/messages_per_page_snake.golden.json
@@ -1,0 +1,30 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": true,
+    "messages": [
+      {
+        "attachCount": 0,
+        "editCount": 0,
+        "lastEditDate": 0,
+        "message": "[B]Enlistment[/B] request — I'd like to join the 7th Cavalry & start ASAP <o7>",
+        "messageDate": 1748400000,
+        "messageId": 9001,
+        "messageState": "visible",
+        "position": 0,
+        "ticketId": 42,
+        "userId": 8,
+        "username": "John.Doe"
+      }
+    ],
+    "nextCursor": "MQ"
+  },
+  "case": "tickets/messages_per_page_snake",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Message pagination: 1 row, position-based next_cursor, has_more true.",
+  "path": "/api/v1/tickets/42/messages?per_page=1",
+  "status": 200
+}

--- a/contract/goldens/tickets/messages_unknown_ticket.golden.json
+++ b/contract/goldens/tickets/messages_unknown_ticket.golden.json
@@ -1,0 +1,16 @@
+{
+  "auth": "read:tickets",
+  "body": {
+    "hasMore": false,
+    "messages": [],
+    "nextCursor": ""
+  },
+  "case": "tickets/messages_unknown_ticket",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Unknown ticket id: empty page, not 404. Frozen.",
+  "path": "/api/v1/tickets/555/messages",
+  "status": 200
+}

--- a/contract/harness_test.go
+++ b/contract/harness_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/7cav/api/cache"
 	"github.com/7cav/api/datastores"
@@ -25,6 +26,10 @@ var _ datastores.Datastore = recordingDatastore{}
 var (
 	stackHandler http.Handler
 	stackErr     error
+	// grpcServeErr receives the srv.Serve result if Serve ever returns
+	// (buffered 1, written exactly once). Peeked via pendingServeErr so a
+	// startup or mid-run server death is reported instead of discarded.
+	grpcServeErr chan error
 )
 
 // TestMain mounts the CURRENT production stack in-process exactly once:
@@ -50,10 +55,27 @@ func TestMain(m *testing.M) {
 
 func currentStack(t *testing.T) http.Handler {
 	t.Helper()
+	if stackErr == nil {
+		if err := pendingServeErr(); err != nil {
+			stackErr = fmt.Errorf("grpc server exited mid-run: %w", err)
+		}
+	}
 	if stackErr != nil {
 		t.Fatalf("mounting current stack: %v", stackErr)
 	}
 	return stackHandler
+}
+
+// pendingServeErr non-blockingly peeks at grpcServeErr and puts any value
+// back, so the one Serve result stays observable by every later caller.
+func pendingServeErr() error {
+	select {
+	case err := <-grpcServeErr:
+		grpcServeErr <- err
+		return err
+	default:
+		return nil
+	}
 }
 
 func mountCurrentStack() (http.Handler, error) {
@@ -72,8 +94,9 @@ func mountCurrentStack() (http.Handler, error) {
 	))
 	proto.RegisterMilpacServiceServer(srv, &grpcServices.MilpacsService{Datastore: ds})
 	proto.RegisterTicketsServiceServer(srv, &grpcServices.TicketsService{Datastore: ds})
+	grpcServeErr = make(chan error, 1)
 	go func() {
-		_ = srv.Serve(lis)
+		grpcServeErr <- srv.Serve(lis)
 	}()
 
 	redisHost, redisPort, err := startMissingRedis()
@@ -87,7 +110,25 @@ func mountCurrentStack() (http.Handler, error) {
 		Cache:     deadRedis,
 		Datastore: ds,
 	}
-	httpSrv := svc.Server()
+	// gateway.Service.Server() dials with grpc.WithBlock() on
+	// context.Background() — an unbounded blocking dial. If the gRPC server
+	// never came up, that dial would hang TestMain forever with zero output,
+	// so run the mount in a goroutine and watchdog it: finish, see the Serve
+	// error, or time out — never hang silently.
+	const mountTimeout = 10 * time.Second
+	mounted := make(chan *http.Server, 1)
+	go func() {
+		mounted <- svc.Server()
+	}()
+	var httpSrv *http.Server
+	select {
+	case httpSrv = <-mounted:
+	case err := <-grpcServeErr:
+		grpcServeErr <- err // keep it observable for pendingServeErr
+		return nil, fmt.Errorf("grpc server exited before gateway mount; serve error: %v", err)
+	case <-time.After(mountTimeout):
+		return nil, fmt.Errorf("grpc dial did not become ready in %s; serve error: %v", mountTimeout, pendingServeErr())
+	}
 	if httpSrv == nil {
 		return nil, fmt.Errorf("gateway.Service.Server() returned nil (dial or registration failure)")
 	}
@@ -133,6 +174,11 @@ func startMissingRedis() (host, port string, err error) {
 
 // quietProductionLoggers silences the chatty Info/Warn loggers of the stack
 // under test so corpus runs stay readable. Errors stay visible.
+//
+// Do NOT silence gateway.Error (or the grpc Error loggers): gateway.Service.
+// Server() reports dial/registration failure only via its Error log plus a
+// nil return, so muting Error would reduce a mount failure to a bare
+// "returned nil" with no cause.
 func quietProductionLoggers() {
 	for _, l := range []interface{ SetOutput(io.Writer) }{
 		gateway.Info, gateway.Warn,

--- a/contract/harness_test.go
+++ b/contract/harness_test.go
@@ -1,0 +1,146 @@
+package contract
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/7cav/api/cache"
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/middleware"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/servers/gateway"
+	grpcServices "github.com/7cav/api/servers/grpc"
+	"google.golang.org/grpc"
+)
+
+// Compile-time guarantee the recording fake implements the full interface.
+var _ datastores.Datastore = recordingDatastore{}
+
+var (
+	stackHandler http.Handler
+	stackErr     error
+)
+
+// TestMain mounts the CURRENT production stack in-process exactly once:
+//
+//	httptest request → gateway.Service.Server().Handler (real /api routing,
+//	real auth middleware, real sentry/cache/compression chain) → real gRPC
+//	client conn over TCP → real grpc.Server with the production interceptor
+//	chain (auth outer, sentry inner; mirrors servers.apiUnaryInterceptors)
+//	→ MilpacsService + TicketsService handlers → recordingDatastore.
+//
+// Differences from production, all behavior-neutral by construction:
+//   - the datastore is the seeded fake (no MySQL),
+//   - Redis is the always-erroring RESP stub (startMissingRedis), so the
+//     middleware treats every request as a miss (the post-#123 stack has no
+//     cache at all; X-Cache is not a contract header),
+//   - SENTRY_DSN is unset, so both sentry layers are pass-throughs,
+//   - the TicketsService reference cache is nil — the fake never touches it.
+func TestMain(m *testing.M) {
+	quietProductionLoggers()
+	stackHandler, stackErr = mountCurrentStack()
+	os.Exit(m.Run())
+}
+
+func currentStack(t *testing.T) http.Handler {
+	t.Helper()
+	if stackErr != nil {
+		t.Fatalf("mounting current stack: %v", stackErr)
+	}
+	return stackHandler
+}
+
+func mountCurrentStack() (http.Handler, error) {
+	ds := recordingDatastore{}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("grpc listen: %w", err)
+	}
+
+	// Production interceptor chain order (servers.apiUnaryInterceptors):
+	// auth outer, sentry inner.
+	srv := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		grpcServices.NewAuthInterceptor(ds),
+		grpcServices.NewSentryInterceptor(),
+	))
+	proto.RegisterMilpacServiceServer(srv, &grpcServices.MilpacsService{Datastore: ds})
+	proto.RegisterTicketsServiceServer(srv, &grpcServices.TicketsService{Datastore: ds})
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+
+	redisHost, redisPort, err := startMissingRedis()
+	if err != nil {
+		return nil, fmt.Errorf("redis stub: %w", err)
+	}
+	deadRedis := cache.NewRedisCache(redisHost, redisPort, "")
+
+	svc := gateway.Service{
+		Address:   lis.Addr().String(),
+		Cache:     deadRedis,
+		Datastore: ds,
+	}
+	httpSrv := svc.Server()
+	if httpSrv == nil {
+		return nil, fmt.Errorf("gateway.Service.Server() returned nil (dial or registration failure)")
+	}
+	return httpSrv.Handler, nil
+}
+
+// startMissingRedis serves a minimal RESP endpoint that answers every command
+// with -ERR. The cache middleware treats any Get error as a miss and ignores
+// Set errors, so every request deterministically exercises the cache-miss
+// path — same observable behavior as an unreachable Redis, but without
+// go-redis's network-error retry backoff (command errors are not retried),
+// keeping corpus runs fast. The cache layer leaves the stack at Phase 2
+// (#123); X-Cache is not a contract header.
+func startMissingRedis() (host, port string, err error) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", "", err
+	}
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				sc := bufio.NewScanner(c)
+				for sc.Scan() {
+					// Each RESP command from a client is an array; the
+					// header line starts with '*'. One error per command.
+					if strings.HasPrefix(sc.Text(), "*") {
+						if _, err := c.Write([]byte("-ERR contract harness: cache always misses\r\n")); err != nil {
+							return
+						}
+					}
+				}
+			}(conn)
+		}
+	}()
+	addr := lis.Addr().(*net.TCPAddr)
+	return addr.IP.String(), fmt.Sprint(addr.Port), nil
+}
+
+// quietProductionLoggers silences the chatty Info/Warn loggers of the stack
+// under test so corpus runs stay readable. Errors stay visible.
+func quietProductionLoggers() {
+	for _, l := range []interface{ SetOutput(io.Writer) }{
+		gateway.Info, gateway.Warn,
+		grpcServices.Info, grpcServices.Warn,
+		middleware.Info, middleware.Warn,
+		cache.Info, cache.Warn,
+		datastores.Info, datastores.Warn,
+	} {
+		l.SetOutput(io.Discard)
+	}
+}


### PR DESCRIPTION
Closes #116. Part of #112 (PRD: Goodbye gRPC) — **the red suite for the whole rewrite**.

## What

`contract/` — 69 committed goldens across all 16 surviving public routes, plus the replay harness that makes them executable against any `http.Handler`:

- **Harness**: the *production* chain in-process — real `gateway.Service.Server()` (auth → sentry → cache → compression, incl. the tickets bypass) over a real loopback gRPC server with the production interceptor order, seeded deterministic fake datastore, always-erroring RESP stub for deterministic cache misses. No docker; full corpus replays in ~0.1s.
- **Comparison is semantic JSON equality**: number *form* (64-bit-as-string vs 32-bit-as-number), array order, and null vs `{}` vs absent are contractual; bytes informational only (protojson isn't byte-stable). Status + allowlisted headers (`Content-Type`, `X-Content-Type-Options`, and `WWW-Authenticate` — whose *absence* on the 401 tiers is pinned per #106) are part of every golden.
- **Exactly one transform, documented**: `keycloakId` stripped symmetrically at record and replay (the field dies at cutover; goldens record truth, the transform documents the break). The keycloak lookup route is deliberately unrecorded and its absence test-enforced.
- **Frozen behavior recorded verbatim**: relation-key ≠ user-id on by-id profiles (relation 1 ↔ user 3 divergence proven in the golden), two-tier plain-text 401s, gRPC-status error JSON incl. leaked `strconv.ParseUint` text, JSON 404, enum name+number path forms (bodies verified identical pairwise), snake/camel dual spellings, repeated filters, unknown-params-ignored, `{"profiles":{}}` empty search (#137), read vs read:tickets scopes.
- **Public surface frozen at five entries** for the Phase 3 slices (#125–#129): `Cases`, `RunCase`, `CompareGolden`, `SaveGolden`, `LoadGolden` (+ `Case`/`Auth`/`Golden`). Canon machinery is internal — deep module, small replay-facing interface.
- Re-record procedure documented and deterministic (re-recording produces a zero-byte diff).

## Review hardening (multi-agent review applied, each fix red-proven)

- `CompareGolden` self-checks: request metadata (case/method/path/auth), non-allowlisted recorded headers, body/bodyText XOR — golden↔battery de-sync now diffs loudly
- Route-coverage guard uses anchored patterns (prefix version demonstrably missed deleted routes)
- `LoadGolden` validation + `goldenPath` traversal guard
- gRPC serve errors surfaced + 10s mount watchdog (startup failure: 1.1s descriptive fail vs 10-min silent hang)

## Test plan

- [x] Corpus green against the current stack, `-count=2`/`-count=3` stable
- [x] Mutation-verified: tampered goldens fail with pinpoint `$.path` diffs (6 tamper classes)
- [x] Zero writes outside `contract/`; `go.mod` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)