### PR TITLE
Phase 3 tracer: GET /api/v1/milpacs/ranks end-to-end on the new net/http stack

### DIFF
--- a/contract/harness_test.go
+++ b/contract/harness_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/proto"
+	"github.com/7cav/api/rest"
 	"github.com/7cav/api/servers/gateway"
 	grpcServices "github.com/7cav/api/servers/grpc"
 	"google.golang.org/grpc"
@@ -139,6 +140,7 @@ func quietProductionLoggers() {
 		gateway.Info, gateway.Warn,
 		grpcServices.Info, grpcServices.Warn,
 		datastores.Info, datastores.Warn,
+		rest.Info, rest.Warn, // the gateway delegates auth/gzip to rest (#125)
 	} {
 		l.SetOutput(io.Discard)
 	}

--- a/rest/auth.go
+++ b/rest/auth.go
@@ -44,16 +44,34 @@ func AuthMiddleware(ds datastores.Datastore, next http.Handler) http.Handler {
 		}
 
 		key, err := ds.ValidateApiKey(token)
-		if err != nil || key == nil {
+		if err != nil {
+			// Datastore failure is a server fault, not a credential
+			// rejection: a 401 here would tell a legitimate client its key
+			// went bad in the middle of an outage. Unavailable (503) signals
+			// retryable, through the JSON choke point like every non-401
+			// error. Log the cause with request context — the goldens cannot
+			// witness this branch — but NEVER the token.
+			Error.Printf("validating API key for %s %s: %v", r.Method, r.URL.Path, err)
+			writeError(w, r, codeUnavailable, "service unavailable")
+			return
+		}
+		if key == nil {
+			// Zero rows: an unknown/expired key. The generic 401 tier —
+			// leaks nothing about whether a key exists, is expired, or
+			// lacks scopes (golden-pinned, #106).
 			Warn.Printf("Unauthorized HTTP access attempt from %s", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		// Attach the validated key to the request ctx so downstream
-		// consumers — per-route scope checks, Sentry key-id tagging (#132),
-		// the metrics key-id label (#130) — can identify the caller without
-		// ever seeing the bearer token.
+		// Attach the validated key to the request ctx so INNER consumers can
+		// identify the caller without ever seeing the bearer token: the
+		// per-route scope checks (requireScope) and, until cutover deletes
+		// it, the legacy gateway's Sentry key-id tagging (its sentry layer
+		// sits inside auth). The new stack's sentry/metrics middlewares are
+		// UPSTREAM (outer) of auth — r.WithContext clones the request, so
+		// their request never carries this value; key-id reaches them via
+		// the context label-holder mechanism (#130), not this key.
 		next.ServeHTTP(w, r.WithContext(ContextWithKey(r.Context(), key)))
 	})
 }

--- a/rest/auth.go
+++ b/rest/auth.go
@@ -65,7 +65,7 @@ func AuthMiddleware(ds datastores.Datastore, next http.Handler) http.Handler {
 func requireScope(scope string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !KeyFromContext(r.Context()).HasScope(scope) {
-			writeError(w, codePermissionDenied, "scope required: %s", scope)
+			writeError(w, r, codePermissionDenied, "scope required: %s", scope)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/rest/auth.go
+++ b/rest/auth.go
@@ -1,0 +1,88 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/7cav/api/datastores"
+)
+
+// The HTTP auth middleware below moved here verbatim from servers/gateway
+// (its original seam) for the Phase 3 rewrite: the gateway delegates to this
+// implementation until it is deleted, so the two stacks can never diverge.
+// The two-tier 401 behavior is golden-pinned (#106): scheme errors name the
+// expected header form, unknown keys get the generic line, both plain text,
+// no WWW-Authenticate challenge.
+
+// maxTokenLen is the maximum length of a raw API key we'll accept.
+// cav7_ prefix (5) + 64 hex chars = 69; 128 gives generous headroom.
+const maxTokenLen = 128
+
+// errBearerScheme is the 401 body returned when the Authorization header is
+// missing or doesn't carry a usable Bearer token (no/empty/oversized token).
+// It names the expected format so callers who paste a raw key without the
+// "Bearer " prefix get a self-explanatory error. The key-validation-failure
+// branch stays the generic "Unauthorized" so it leaks nothing about whether a
+// key exists, is expired, or lacks scopes.
+const errBearerScheme = "Unauthorized: expected 'Authorization: Bearer <key>' header"
+
+// AuthMiddleware authenticates every request against the upstream key tables
+// (ADR 0004) and attaches the validated key to the request context. It runs
+// BEFORE routing — an unknown path without credentials is a 401, not a 404
+// (golden-pinned). Authorization (scope membership) is per-route: see
+// requireScope.
+//
+// Exported because the legacy gateway chain reuses it until cutover deletes
+// that stack.
+func AuthMiddleware(ds datastores.Datastore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := datastores.ParseBearerToken(r.Header.Get("Authorization"), maxTokenLen)
+		if token == "" {
+			Warn.Printf("Unauthorized HTTP access attempt (bad bearer scheme) from %s", r.RemoteAddr)
+			http.Error(w, errBearerScheme, http.StatusUnauthorized)
+			return
+		}
+
+		key, err := ds.ValidateApiKey(token)
+		if err != nil || key == nil {
+			Warn.Printf("Unauthorized HTTP access attempt from %s", r.RemoteAddr)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Attach the validated key to the request ctx so downstream
+		// consumers — per-route scope checks, Sentry key-id tagging (#132),
+		// the metrics key-id label (#130) — can identify the caller without
+		// ever seeing the bearer token.
+		next.ServeHTTP(w, r.WithContext(ContextWithKey(r.Context(), key)))
+	})
+}
+
+// requireScope gates a route on scope membership (ADR 0004: scope checks are
+// per-handler; "read" does not imply "read:tickets" and vice versa). A key
+// lacking the scope gets the PermissionDenied JSON via the error-writer
+// choke point — message string frozen by the goldens.
+func requireScope(scope string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !KeyFromContext(r.Context()).HasScope(scope) {
+			writeError(w, codePermissionDenied, "scope required: %s", scope)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// keyContextKey is the private type used to attach *ApiKeyResult to a request
+// ctx. Private so external packages can't accidentally clobber it.
+type keyContextKey struct{}
+
+// ContextWithKey returns a new context carrying the given API key result.
+func ContextWithKey(ctx context.Context, key *datastores.ApiKeyResult) context.Context {
+	return context.WithValue(ctx, keyContextKey{}, key)
+}
+
+// KeyFromContext returns the *ApiKeyResult attached to ctx, or nil if none.
+func KeyFromContext(ctx context.Context) *datastores.ApiKeyResult {
+	v, _ := ctx.Value(keyContextKey{}).(*datastores.ApiKeyResult)
+	return v
+}

--- a/rest/auth_test.go
+++ b/rest/auth_test.go
@@ -1,4 +1,9 @@
-package gateway
+package rest
+
+// The auth middleware tests moved here with the middleware itself (from
+// servers/gateway): same two-tier 401 behavior, now pinned at its single
+// source. The golden corpus pins the same behavior end-to-end on both
+// stacks.
 
 import (
 	"io"
@@ -14,7 +19,7 @@ import (
 
 // fakeAuthDatastore embeds the Datastore interface so it satisfies the type
 // without implementing every method; only ValidateApiKey is exercised by
-// authMiddleware. Any other call panics (nil method) — a loud failure if a
+// AuthMiddleware. Any other call panics (nil method) — a loud failure if a
 // test accidentally reaches further into the datastore.
 type fakeAuthDatastore struct {
 	datastores.Datastore
@@ -25,16 +30,19 @@ func (f *fakeAuthDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyRes
 	return f.validateApiKey(rawKey)
 }
 
-// callMiddleware runs authMiddleware in front of a handler that records whether
-// it was reached, and returns the recorded response plus the next-called flag.
-func callMiddleware(t *testing.T, ds datastores.Datastore, authHeader string) (*httptest.ResponseRecorder, bool) {
+// callMiddleware runs AuthMiddleware in front of a handler that records
+// whether it was reached, and returns the recorded response plus the
+// next-called flag and the key the handler saw on its context.
+func callMiddleware(t *testing.T, ds datastores.Datastore, authHeader string) (*httptest.ResponseRecorder, bool, *datastores.ApiKeyResult) {
 	t.Helper()
 	nextCalled := false
+	var seenKey *datastores.ApiKeyResult
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
+		seenKey = KeyFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	})
-	h := authMiddleware(ds, next)
+	h := AuthMiddleware(ds, next)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/whatever", nil)
 	if authHeader != "" {
@@ -42,7 +50,7 @@ func callMiddleware(t *testing.T, ds datastores.Datastore, authHeader string) (*
 	}
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
-	return rr, nextCalled
+	return rr, nextCalled, seenKey
 }
 
 func TestAuthMiddleware_NoAuthHeader_NamesBearerScheme(t *testing.T) {
@@ -50,7 +58,7 @@ func TestAuthMiddleware_NoAuthHeader_NamesBearerScheme(t *testing.T) {
 		t.Fatal("ValidateApiKey must not be called when no bearer token is present")
 		return nil, nil
 	}}
-	rr, nextCalled := callMiddleware(t, ds, "")
+	rr, nextCalled, _ := callMiddleware(t, ds, "")
 
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	assert.False(t, nextCalled)
@@ -64,7 +72,7 @@ func TestAuthMiddleware_RawKeyNoBearerPrefix_NamesBearerScheme(t *testing.T) {
 		t.Fatal("ValidateApiKey must not be called when the Bearer scheme is absent")
 		return nil, nil
 	}}
-	rr, nextCalled := callMiddleware(t, ds, "cav7_rawkeywithoutprefix")
+	rr, nextCalled, _ := callMiddleware(t, ds, "cav7_rawkeywithoutprefix")
 
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	assert.False(t, nextCalled)
@@ -78,7 +86,7 @@ func TestAuthMiddleware_BadKey_GenericUnauthorizedNoLeak(t *testing.T) {
 		assert.Equal(t, "cav7_badkey", token)
 		return nil, nil // zero rows → nil result, no error
 	}}
-	rr, nextCalled := callMiddleware(t, ds, "Bearer cav7_badkey")
+	rr, nextCalled, _ := callMiddleware(t, ds, "Bearer cav7_badkey")
 
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	assert.False(t, nextCalled)
@@ -89,23 +97,60 @@ func TestAuthMiddleware_BadKey_GenericUnauthorizedNoLeak(t *testing.T) {
 	assert.NotContains(t, body, "Bearer")
 }
 
-func TestAuthMiddleware_ValidKey_CallsNext(t *testing.T) {
+func TestAuthMiddleware_ValidKey_CallsNextWithKeyOnContext(t *testing.T) {
+	key := &datastores.ApiKeyResult{KeyId: 1, UserId: 2}
 	ds := &fakeAuthDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
-		return &datastores.ApiKeyResult{KeyId: 1, UserId: 2}, nil
+		return key, nil
 	}}
-	rr, nextCalled := callMiddleware(t, ds, "Bearer cav7_goodkey")
+	rr, nextCalled, seenKey := callMiddleware(t, ds, "Bearer cav7_goodkey")
 
 	require.True(t, nextCalled)
 	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Same(t, key, seenKey,
+		"the validated key must reach the handler via the request context")
 }
 
 func TestAuthMiddleware_ValidateError_GenericUnauthorized(t *testing.T) {
 	ds := &fakeAuthDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
 		return nil, io.ErrUnexpectedEOF
 	}}
-	rr, nextCalled := callMiddleware(t, ds, "Bearer cav7_anykey")
+	rr, nextCalled, _ := callMiddleware(t, ds, "Bearer cav7_anykey")
 
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	assert.False(t, nextCalled)
 	assert.Equal(t, "Unauthorized", strings.TrimSpace(rr.Body.String()))
+}
+
+// requireScope is the per-route authorization gate (ADR 0004: scope checks
+// are per-handler; one scope never implies another).
+func TestRequireScope(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := requireScope("read", next)
+
+	t.Run("key with the scope passes", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
+		req = req.WithContext(ContextWithKey(req.Context(),
+			&datastores.ApiKeyResult{Scopes: map[string]struct{}{"read": {}}}))
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("key with a different scope is denied", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/x", nil)
+		req = req.WithContext(ContextWithKey(req.Context(),
+			&datastores.ApiKeyResult{Scopes: map[string]struct{}{"read:tickets": {}}}))
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, rr.Body.String())
+	})
+
+	t.Run("no key on context is denied, not a panic", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/x", nil))
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
 }

--- a/rest/auth_test.go
+++ b/rest/auth_test.go
@@ -110,15 +110,30 @@ func TestAuthMiddleware_ValidKey_CallsNextWithKeyOnContext(t *testing.T) {
 		"the validated key must reach the handler via the request context")
 }
 
-func TestAuthMiddleware_ValidateError_GenericUnauthorized(t *testing.T) {
+// A datastore failure during key validation is a server fault, not a
+// credential rejection: it must NOT masquerade as the 401 tier (telling a
+// legitimate client its key went bad mid-outage), and it must be Error-logged
+// with request context — the goldens structurally cannot witness this branch,
+// so this test is the only thing keeping the outage visible. The bearer token
+// must never reach the log.
+func TestAuthMiddleware_DatastoreError_Is503AndLogged(t *testing.T) {
+	buf := captureErrorLog(t)
 	ds := &fakeAuthDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
 		return nil, io.ErrUnexpectedEOF
 	}}
-	rr, nextCalled, _ := callMiddleware(t, ds, "Bearer cav7_anykey")
+	rr, nextCalled, _ := callMiddleware(t, ds, "Bearer cav7_secrettoken")
 
-	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	assert.False(t, nextCalled)
-	assert.Equal(t, "Unauthorized", strings.TrimSpace(rr.Body.String()))
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"code":14,"message":"service unavailable","details":[]}`, rr.Body.String(),
+		"Unavailable JSON via the choke point, leaking nothing about the key")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "unexpected EOF")
+	assert.Contains(t, logged, "GET")
+	assert.Contains(t, logged, "/api/v1/whatever")
+	assert.NotContains(t, logged, "cav7_secrettoken", "the bearer token must NEVER be logged")
 }
 
 // requireScope is the per-route authorization gate (ADR 0004: scope checks

--- a/rest/gzip.go
+++ b/rest/gzip.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"compress/gzip"
+	"net/http"
+	"strings"
+)
+
+// GzipMiddleware moved here verbatim from servers/gateway (compression
+// middleware) for the Phase 3 rewrite; the gateway delegates to it until
+// cutover deletes that stack. It sits inside auth (401s are never gzipped)
+// and outside the mux, so every routed response — including the JSON 404 —
+// compresses when the client asks.
+//
+// Exported because the legacy gateway chain reuses it until cutover deletes
+// that stack.
+func GzipMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			defer func() {
+				if err := gz.Close(); err != nil {
+					// A Close failure means the gzip trailer never reached the
+					// client — a corrupt body behind an already-written status,
+					// invisible to the sentry layer outside this one.
+					Error.Printf("gzip close failed for %s %s (response likely truncated): %v", r.Method, r.URL.Path, err)
+				}
+			}()
+			gzw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
+			next.ServeHTTP(gzw, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	Writer *gzip.Writer
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	w.Header().Del("Content-Length") // This is necessary as otherwise it will have the uncompressed length
+	return w.Writer.Write(b)
+}

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -1,0 +1,42 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/types"
+)
+
+// getAllRanks serves GET /api/v1/milpacs/ranks: the rank reference list,
+// golden-pinned by milpacs/ranks. Error message string frozen from the old
+// handler (servers/grpc GetAllRanks).
+func getAllRanks(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ranks, err := ds.FindAllRanks()
+		if err != nil {
+			writeError(w, codeInternal, "error fetching ranks: %v", err)
+			return
+		}
+		writeJSON(w, types.RanksResponse{Ranks: ranksFromProto(ranks)})
+	})
+}
+
+// ranksFromProto maps the datastore's proto-typed rows to the wire types.
+// The mapping layer disappears at cutover (#134) when the Datastore
+// interface itself moves to the types package; until then each handler owns
+// its map — and the allocation discipline: empty collections are allocated
+// ([] on the wire), never nil.
+func ranksFromProto(in []*proto.RankExpanded) []*types.RankExpanded {
+	out := make([]*types.RankExpanded, 0, len(in))
+	for _, r := range in {
+		out = append(out, &types.RankExpanded{
+			RankShort:        r.GetRankShort(),
+			RankFull:         r.GetRankFull(),
+			RankImageUrl:     r.GetRankImageUrl(),
+			RankId:           r.GetRankId(),
+			RankDisplayOrder: r.GetRankDisplayOrder(),
+		})
+	}
+	return out
+}

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -15,10 +15,10 @@ func getAllRanks(ds datastores.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ranks, err := ds.FindAllRanks()
 		if err != nil {
-			writeError(w, codeInternal, "error fetching ranks: %v", err)
+			writeError(w, r, codeInternal, "error fetching ranks: %v", err)
 			return
 		}
-		writeJSON(w, types.RanksResponse{Ranks: ranksFromProto(ranks)})
+		writeJSON(w, r, types.RanksResponse{Ranks: ranksFromProto(ranks)})
 	})
 }
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -1,8 +1,11 @@
 // Package rest is the stdlib net/http stack that replaces the gRPC server +
-// grpc-gateway pair (PRD #112, Phase 3). It is test-mounted only until the
-// cutover slice (#134) — nothing routes production traffic here yet — but it
-// is the permanent home: at cutover the single public listener serves every
-// route through this package, and Phase 4 deletes the old stacks.
+// grpc-gateway pair (PRD #112, Phase 3). Two of its layers ALREADY serve
+// production: the legacy gateway delegates auth and gzip to
+// rest.AuthMiddleware/rest.GzipMiddleware (single source, so the stacks
+// cannot diverge while both are in-tree). The handler stack itself
+// (New/routes) is test-mounted only until the cutover slice (#134); this
+// package is the permanent home — at cutover the single public listener
+// serves every route through it, and Phase 4 deletes the old stacks.
 //
 // # Middleware chain (PRD order — assembled in New)
 //
@@ -13,9 +16,11 @@
 //   - sentryMiddleware (placeholder, #132): panic-recovery at the front of
 //     the chain; 5xx Sentry reports hook the writeError choke point.
 //   - metricsMiddleware (placeholder, #130): Prometheus request counter and
-//     latency histogram. Route label comes from r.Pattern (the mux's matched
-//     pattern); key-id reaches this OUTER layer via a context label-holder
-//     the auth middleware fills.
+//     latency histogram. BOTH labels must reach this OUTER layer via the
+//     context label-holder mechanism — route label included: AuthMiddleware's
+//     r.WithContext clones the request, so the mux sets Pattern on the inner
+//     copy only and this layer's request keeps Pattern == "". See
+//     metricsMiddleware below for the mechanism.
 //   - AuthMiddleware: bearer-key validation with the golden-pinned two-tier
 //     plain-text 401s. Runs BEFORE routing, so an unknown path without
 //     credentials is a 401, not a 404 (golden-pinned). Scope checks are
@@ -31,8 +36,10 @@
 //  2. Handler in this package: map the datastore result to the wire types
 //     (allocate empty collections!), writeJSON on success, writeError with
 //     the frozen message string on failure.
-//  3. Register in routes(): mux.Handle("GET /api/v1/...",
-//     requireScope("<scope>", handler)). Path parameters via r.PathValue.
+//  3. Register in routes(): handle(mux, "GET /api/v1/...", "<scope>",
+//     handler) — the scope gate is a required argument, not a wrapping
+//     convention. Path parameters via r.PathValue. Wrong-method and unknown
+//     paths are already covered by the mux fallback (405+Allow / JSON 404).
 //  4. Spec operation block in openapi/openapi.yaml (CI-enforced two-way
 //     coverage, contract/spec_test.go).
 //  5. Goldens green: add the route's battery case names to implementedCases
@@ -65,20 +72,57 @@ func New(ds datastores.Datastore) http.Handler {
 					routes(ds)))))
 }
 
-// routes builds the pattern-routing mux: one Handle call per public route,
-// each wrapped with its scope requirement. Unknown paths fall through to the
-// JSON 404.
+// routes builds the pattern-routing mux: one handle call per public route,
+// each gated on its scope. Everything no route pattern matches falls through
+// to fallback (the JSON 404, or the 405+Allow for a known path under an
+// unsupported method).
 func routes(ds datastores.Datastore) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// --- milpacs (scope: read) -------------------------------------------
-	mux.Handle("GET /api/v1/milpacs/ranks", requireScope("read", getAllRanks(ds)))
+	handle(mux, "GET /api/v1/milpacs/ranks", "read", getAllRanks(ds))
 
-	// Catch-all: unknown paths under the API prefix get the JSON 404 body
-	// (golden-pinned), not the stdlib text 404.
-	mux.HandleFunc("/", notFound)
+	mux.HandleFunc("/", fallback(mux))
 
 	return mux
+}
+
+// handle registers one public route: a method-qualified mux pattern, the
+// route's required scope, and its handler. The scope is a required positional
+// argument — gating by wrapping convention is how a scope check gets
+// forgotten, and a forgotten check is invisible to every test that uses a
+// fully-scoped key.
+func handle(mux *http.ServeMux, pattern, scope string, h http.Handler) {
+	mux.Handle(pattern, requireScope(scope, h))
+}
+
+// fallback serves every request no route pattern matched, splitting two
+// surfaces the catch-all would otherwise conflate:
+//
+//   - a KNOWN path under an unsupported method → 405 + Allow (enumerated
+//     break, ruled at #125: the old stack answered 501; 404 — the un-pinned
+//     behavior before this — would discard the "route exists" signal). The
+//     mux cannot produce this itself: its built-in 405 only fires when NO
+//     pattern matches, and the "/" catch-all always matches.
+//   - a genuinely unknown path → the JSON 404 body (golden-pinned).
+//
+// The split re-asks the mux whether the same path matches under GET (the
+// read surface is GET/HEAD-only; HEAD matches GET patterns and never lands
+// here). A probe pattern of "/" is the catch-all matching itself — an
+// unknown path. Pattern-based, so parameterized fan-out routes (#126–#129)
+// are covered with no per-route bookkeeping.
+func fallback(mux *http.ServeMux) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			probe := r.Clone(r.Context())
+			probe.Method = http.MethodGet
+			if _, pattern := mux.Handler(probe); pattern != "" && pattern != "/" {
+				methodNotAllowed(w, r)
+				return
+			}
+		}
+		notFound(w, r)
+	}
 }
 
 // sentryMiddleware is the documented extension point for #132 (full Sentry
@@ -91,9 +135,19 @@ func sentryMiddleware(next http.Handler) http.Handler {
 
 // metricsMiddleware is the documented extension point for #130 (Prometheus):
 // request counter labeled route/method/status/key-id and duration histogram
-// labeled route/method. Route label from r.Pattern after the mux matches;
-// key-id via a context label-holder filled by AuthMiddleware. Pass-through
-// until that slice lands.
+// labeled route/method. Pass-through until that slice lands.
+//
+// Label plumbing (#130, precise mechanism): NEITHER label can be read off
+// this layer's *http.Request after next.ServeHTTP returns. AuthMiddleware
+// calls r.WithContext, which CLONES the request — the mux then sets Pattern
+// on that inner clone, and the auth middleware attaches the key to the inner
+// context — so the request this layer holds keeps Pattern == "" and carries
+// no key. Both labels must instead travel through a context LABEL-HOLDER:
+// this middleware puts a pointer to a mutable holder struct into the context
+// before calling next (context values survive WithContext clones because the
+// clone wraps the same parent context); AuthMiddleware fills the key-id slot,
+// and the route slot is filled from r.Pattern inside the mux (e.g. by the
+// wrapper handle registers), where the matched pattern is actually set.
 func metricsMiddleware(next http.Handler) http.Handler {
 	return next
 }

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -1,0 +1,99 @@
+// Package rest is the stdlib net/http stack that replaces the gRPC server +
+// grpc-gateway pair (PRD #112, Phase 3). It is test-mounted only until the
+// cutover slice (#134) — nothing routes production traffic here yet — but it
+// is the permanent home: at cutover the single public listener serves every
+// route through this package, and Phase 4 deletes the old stacks.
+//
+// # Middleware chain (PRD order — assembled in New)
+//
+//	sentry → metrics → auth → gzip → mux
+//
+// Extension points, outermost first:
+//
+//   - sentryMiddleware (placeholder, #132): panic-recovery at the front of
+//     the chain; 5xx Sentry reports hook the writeError choke point.
+//   - metricsMiddleware (placeholder, #130): Prometheus request counter and
+//     latency histogram. Route label comes from r.Pattern (the mux's matched
+//     pattern); key-id reaches this OUTER layer via a context label-holder
+//     the auth middleware fills.
+//   - AuthMiddleware: bearer-key validation with the golden-pinned two-tier
+//     plain-text 401s. Runs BEFORE routing, so an unknown path without
+//     credentials is a 401, not a 404 (golden-pinned). Scope checks are
+//     per-route, not here — see requireScope.
+//   - GzipMiddleware: response compression. Inside auth (401s are never
+//     gzipped), outside the mux (every routed response, including the JSON
+//     404, compresses).
+//   - mux: the Go 1.22+ pattern-routing http.ServeMux.
+//
+// # Adding a route (the fan-out recipe, #126–#129)
+//
+//  1. Wire types in types/ (follow the conventions in the package doc).
+//  2. Handler in this package: map the datastore result to the wire types
+//     (allocate empty collections!), writeJSON on success, writeError with
+//     the frozen message string on failure.
+//  3. Register in routes(): mux.Handle("GET /api/v1/...",
+//     requireScope("<scope>", handler)). Path parameters via r.PathValue.
+//  4. Spec operation block in openapi/openapi.yaml (CI-enforced two-way
+//     coverage, contract/spec_test.go).
+//  5. Goldens green: add the route's battery case names to implementedCases
+//     in rest_test.go — the replay harness does the rest.
+package rest
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/7cav/api/datastores"
+)
+
+var (
+	Info  = log.New(os.Stdout, "INFO: ", log.LstdFlags)
+	Warn  = log.New(os.Stdout, "WARNING: ", log.LstdFlags)
+	Error = log.New(os.Stdout, "ERROR: ", log.LstdFlags)
+)
+
+// New assembles the new stack: the route mux wrapped in the PRD middleware
+// chain (sentry → metrics → auth → gzip → mux). The returned handler serves
+// the /api surface; non-API paths (the docs UI) are the cutover slice's
+// concern (#134) and 404 here until then.
+func New(ds datastores.Datastore) http.Handler {
+	return sentryMiddleware(
+		metricsMiddleware(
+			AuthMiddleware(ds,
+				GzipMiddleware(
+					routes(ds)))))
+}
+
+// routes builds the pattern-routing mux: one Handle call per public route,
+// each wrapped with its scope requirement. Unknown paths fall through to the
+// JSON 404.
+func routes(ds datastores.Datastore) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// --- milpacs (scope: read) -------------------------------------------
+	mux.Handle("GET /api/v1/milpacs/ranks", requireScope("read", getAllRanks(ds)))
+
+	// Catch-all: unknown paths under the API prefix get the JSON 404 body
+	// (golden-pinned), not the stdlib text 404.
+	mux.HandleFunc("/", notFound)
+
+	return mux
+}
+
+// sentryMiddleware is the documented extension point for #132 (full Sentry
+// wiring): panic-recovery middleware at the front of the chain, with 5xx
+// reports emitted from the writeError choke point. Pass-through until that
+// slice lands.
+func sentryMiddleware(next http.Handler) http.Handler {
+	return next
+}
+
+// metricsMiddleware is the documented extension point for #130 (Prometheus):
+// request counter labeled route/method/status/key-id and duration histogram
+// labeled route/method. Route label from r.Pattern after the mux matches;
+// key-id via a context label-holder filled by AuthMiddleware. Pass-through
+// until that slice lands.
+func metricsMiddleware(next http.Handler) http.Handler {
+	return next
+}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -44,6 +44,10 @@
 //     coverage, contract/spec_test.go).
 //  5. Goldens green: add the route's battery case names to implementedCases
 //     in rest_test.go — the replay harness does the rest.
+//  6. Classify every new case's request path in specRoutes
+//     (rest/spec_test.go) so the new-stack spec validation covers the
+//     route's observed responses — an unclassified path fails that suite,
+//     it never skips.
 package rest
 
 import (

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -315,6 +315,23 @@ func TestNewStack_WrongMethodOnUnknownRouteStays404(t *testing.T) {
 	assert.JSONEq(t, `{"code":5,"message":"Not Found","details":[]}`, rr.Body.String())
 }
 
+// Auth runs BEFORE routing (chain order), so a wrong-method request without
+// credentials is answered by the auth tier, not the method fallback: 401
+// scheme-tier plain text, no Allow header. The 405 only exists for callers
+// who already authenticated.
+func TestNewStack_WrongMethodWithoutCredsIs401NotAllow(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/milpacs/ranks", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code, "auth precedes method handling")
+	assert.Empty(t, rr.Header().Get("Allow"), "no method advertisement to unauthenticated callers")
+	assert.Equal(t, "Unauthorized: expected 'Authorization: Bearer <key>' header",
+		strings.TrimSpace(rr.Body.String()), "scheme-tier 401 body, frozen")
+}
+
 // HEAD is a supported read verb: Go's mux matches HEAD against GET patterns
 // (kept deliberately), and net/http suppresses the response body for HEAD at
 // the server. The body suppression lives in the real server's ResponseWriter

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -1,0 +1,248 @@
+package rest_test
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/7cav/api/contract"
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const goldensDir = "../contract/goldens"
+
+func init() {
+	// The auth middleware Warn-logs every rejected request; the battery
+	// replays many. Errors stay visible.
+	rest.Info.SetOutput(io.Discard)
+	rest.Warn.SetOutput(io.Discard)
+}
+
+// fakeDatastore seeds the new stack for golden replay. It must agree with
+// the recording seed (contract/fake_datastore_test.go) for everything the
+// implemented routes serve: the battery's bearer tokens and the two-rank
+// catalog. Unimplemented methods panic via the embedded nil interface — a
+// loud failure if a test reaches further than the routes it mounts.
+type fakeDatastore struct {
+	datastores.Datastore
+	findAllRanks func() ([]*proto.RankExpanded, error)
+}
+
+func (f *fakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
+	scopes := func(names ...string) map[string]struct{} {
+		m := map[string]struct{}{}
+		for _, n := range names {
+			m[n] = struct{}{}
+		}
+		return m
+	}
+	switch rawKey {
+	case "cav7_readkey":
+		return &datastores.ApiKeyResult{KeyId: 101, UserId: 3, Scopes: scopes("read")}, nil
+	case "cav7_ticketskey":
+		return &datastores.ApiKeyResult{KeyId: 102, UserId: 8, Scopes: scopes("read:tickets")}, nil
+	case "cav7_noscopekey":
+		return &datastores.ApiKeyResult{KeyId: 103, UserId: 9, Scopes: scopes()}, nil
+	default:
+		return nil, nil // zero rows — generic Unauthorized, leaks nothing
+	}
+}
+
+func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error) {
+	if f.findAllRanks != nil {
+		return f.findAllRanks()
+	}
+	return []*proto.RankExpanded{
+		{RankShort: "MG", RankFull: "Major General", RankImageUrl: "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618", RankId: 4, RankDisplayOrder: 4},
+		{RankShort: "PVT", RankFull: "Private", RankImageUrl: "https://7cav.us/data/roster_ranks/0/22.jpg", RankId: 22, RankDisplayOrder: 22},
+	}, nil
+}
+
+func newStack(t *testing.T) http.Handler {
+	t.Helper()
+	return rest.New(&fakeDatastore{})
+}
+
+// implementedCases names the battery cases the new stack serves today. Each
+// fan-out slice (#126–#129) appends its route's cases as it lands; at
+// cutover (#134) this list covers the whole battery.
+//
+// The auth 401-tier cases are here from the tracer on: the middleware
+// rejects them BEFORE routing, so they replay exactly against any path —
+// including ones whose routes don't exist yet.
+var implementedCases = []string{
+	"milpacs/ranks",
+	"auth/milpacs_missing_header",
+	"auth/milpacs_raw_key",
+	"auth/milpacs_invalid_key",
+	"auth/tickets_missing_header",
+	"auth/tickets_raw_key",
+	"auth/tickets_invalid_key",
+	"auth/unknown_path_authenticated",
+	"auth/unknown_path_unauthenticated",
+}
+
+// TestNewStack_GoldenReplay replays every implemented battery case against
+// the new stack mounted in-process and compares each response semantically
+// against the committed golden — the outer red→green loop of the rewrite.
+func TestNewStack_GoldenReplay(t *testing.T) {
+	h := newStack(t)
+
+	known := map[string]contract.Case{}
+	for _, c := range contract.Cases() {
+		known[c.Name] = c
+	}
+
+	for _, name := range implementedCases {
+		c, ok := known[name]
+		require.True(t, ok, "implementedCases entry %q names no battery case", name)
+		t.Run(name, func(t *testing.T) {
+			got, raw, err := contract.RunCase(h, c)
+			require.NoError(t, err)
+
+			want, err := contract.LoadGolden(goldensDir, c.Name)
+			require.NoError(t, err)
+
+			diffs := contract.CompareGolden(want, got)
+			for _, d := range diffs {
+				t.Error(d)
+			}
+			if len(diffs) > 0 {
+				t.Logf("raw response (%d bytes): %.2000s", len(raw), raw)
+			}
+		})
+	}
+}
+
+// scopeCases drives the auth tiers the battery only witnesses on
+// not-yet-implemented routes (the 403 scope tier needs a real route to
+// reach) against the ranks route instead. The committed auth goldens are the
+// expectation — identical body/status/headers, only the request path
+// differs, because both the scope-failure surface and the 401 tiers are
+// route-independent.
+func TestNewStack_AuthTiersOnRanksRoute(t *testing.T) {
+	h := newStack(t)
+
+	cases := []struct {
+		golden string        // committed golden carrying the expected response
+		auth   contract.Auth // tier to present to the ranks route
+	}{
+		{"auth/milpacs_wrong_scope", contract.AuthReadTickets},
+		{"auth/milpacs_no_scopes", contract.AuthNoScopes},
+		{"auth/milpacs_missing_header", contract.AuthNone},
+		{"auth/milpacs_raw_key", contract.AuthRawKey},
+		{"auth/milpacs_invalid_key", contract.AuthInvalidKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.golden, func(t *testing.T) {
+			want, err := contract.LoadGolden(goldensDir, tc.golden)
+			require.NoError(t, err)
+			require.Equal(t, tc.auth, want.Auth, "tier drifted from the recorded golden")
+
+			c := contract.Case{
+				Name:   tc.golden,
+				Method: http.MethodGet,
+				Path:   "/api/v1/milpacs/ranks",
+				Auth:   tc.auth,
+				Notes:  "synthesized: the recorded tier replayed against the ranks route",
+			}
+			got, raw, err := contract.RunCase(h, c)
+			require.NoError(t, err)
+
+			// Same response, different request path: rewrite the recorded
+			// request metadata to the synthesized case before comparing.
+			want.Path = c.Path
+
+			diffs := contract.CompareGolden(want, got)
+			for _, d := range diffs {
+				t.Error(d)
+			}
+			if len(diffs) > 0 {
+				t.Logf("raw response (%d bytes): %.2000s", len(raw), raw)
+			}
+		})
+	}
+}
+
+// TestNewStack_GzipRoundTrip pins the gzip layer's place in the chain with a
+// real round-trip: a 200 with Accept-Encoding: gzip must decompress back to
+// the ranks payload through an intact trailer.
+func TestNewStack_GzipRoundTrip(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "gzip", rr.Result().Header.Get("Content-Encoding"))
+	assert.Empty(t, rr.Result().Header.Get("Content-Length"),
+		"stale uncompressed Content-Length must be stripped")
+
+	zr, err := gzip.NewReader(rr.Body)
+	require.NoError(t, err, "body must be a valid gzip stream")
+	decoded, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close(), "gzip trailer (CRC + size) must be intact")
+	assert.Contains(t, string(decoded), `"rankFull":"Major General"`)
+}
+
+// Auth sits OUTSIDE gzip in the chain (PRD order): a 401 must come back
+// uncompressed even when the client advertises gzip — exactly as the old
+// stack behaves and as the plain-text golden tier implies.
+func TestNewStack_401IsNeverGzipped(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Empty(t, rr.Result().Header.Get("Content-Encoding"))
+	assert.True(t, strings.HasPrefix(rr.Body.String(), "Unauthorized"),
+		"401 body must be the plain-text tier, not a gzip stream")
+}
+
+// The datastore failing must surface as the frozen Internal error shape
+// through the choke point (message text mirrors the old handler verbatim).
+func TestNewStack_RanksDatastoreOutageIsInternalJSON(t *testing.T) {
+	h := rest.New(&fakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		return nil, io.ErrUnexpectedEOF
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"code":13,"message":"error fetching ranks: unexpected EOF","details":[]}`, rr.Body.String())
+}
+
+// An empty rank catalog must serialize as {"ranks":[]} — the allocation
+// discipline (empty collections are [], never null) the goldens can only
+// witness on populated routes.
+func TestNewStack_EmptyRanksIsEmptyArray(t *testing.T) {
+	h := rest.New(&fakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		return nil, nil
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, `{"ranks":[]}`, strings.TrimSpace(rr.Body.String()))
+}

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -230,6 +230,90 @@ func TestNewStack_RanksDatastoreOutageIsInternalJSON(t *testing.T) {
 	assert.JSONEq(t, `{"code":13,"message":"error fetching ranks: unexpected EOF","details":[]}`, rr.Body.String())
 }
 
+// --- Wrong-method contract (human ruling on review Critical 1, #125) -------
+//
+// Wrong-method on an existing route returns 405 Method Not Allowed with an
+// Allow: GET, HEAD header; HEAD stays a supported read verb (works on valid
+// routes, returns no body); 404 is reserved for genuinely unknown routes
+// only.
+//
+// Rationale (ruled, recorded in the PRD #112 enumerated-breaks list): this
+// API is read-only by published contract — no write endpoints exist and the
+// docs say so. Any POST/PATCH/etc. was never a supported call, so there is no
+// legitimate consumer whose error-handling the change can break; the
+// behavior-neutral cutover guarantee covers the GET/HEAD surface actually
+// published, which is untouched. That removes the only reason to shim the old
+// stack's 501 and frees the correct code: 405 (vs the un-pinned new code's
+// 404) preserves the useful "route exists, method doesn't" signal, and Allow
+// gives a mistaken-but-legitimate client the answer in one round trip. Public
+// docs mean 405 leaks nothing. When write endpoints arrive, those routes
+// advertise their own Allow and inherit this default — a forward-compatible
+// pattern, not a one-off.
+//
+// These pins are deliberately NEW-STACK-ONLY (plain tests here, not battery
+// cases): the golden corpus replays against the old stack too, and the old
+// stack answers 501 — a shared case would poison the old-stack suite. The 405
+// is net-new decided behavior, not recorded-from-old-stack behavior.
+
+func TestNewStack_WrongMethodOnKnownRouteIs405WithAllow(t *testing.T) {
+	h := newStack(t)
+
+	for _, method := range []string{http.MethodPost, http.MethodPatch, http.MethodDelete, http.MethodPut} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/v1/milpacs/ranks", nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+			assert.Equal(t, "GET, HEAD", rr.Header().Get("Allow"),
+				"Allow must answer the client in one round trip")
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			// Body verbatim from the old stack's wrong-method response (code
+			// 12 Unimplemented): only the HTTP status (501→405) and the Allow
+			// header change — consumers matching on the body see no
+			// difference.
+			assert.JSONEq(t, `{"code":12,"message":"Method Not Allowed","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+func TestNewStack_WrongMethodOnUnknownRouteStays404(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/does/not/exist", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code, "404 is reserved for genuinely unknown routes")
+	assert.Empty(t, rr.Header().Get("Allow"), "an unknown route has no methods to advertise")
+	assert.JSONEq(t, `{"code":5,"message":"Not Found","details":[]}`, rr.Body.String())
+}
+
+// HEAD is a supported read verb: Go's mux matches HEAD against GET patterns
+// (kept deliberately), and net/http suppresses the response body for HEAD at
+// the server. The body suppression lives in the real server's ResponseWriter
+// — a ResponseRecorder would show a body — so this test observes through a
+// live httptest.Server.
+func TestNewStack_HEADOnKnownRouteIs200WithNoBody(t *testing.T) {
+	srv := httptest.NewServer(rest.New(&fakeDatastore{}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL+"/api/v1/milpacs/ranks", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	res, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Empty(t, body, "net/http suppresses the body on HEAD responses")
+}
+
 // An empty rank catalog must serialize as {"ranks":[]} — the allocation
 // discipline (empty collections are [], never null) the goldens can only
 // witness on populated routes.

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -196,6 +196,30 @@ func TestNewStack_GzipRoundTrip(t *testing.T) {
 	assert.Contains(t, string(decoded), `"rankFull":"Major General"`)
 }
 
+// Gzip sits OUTSIDE the mux (PRD order): ERROR responses compress too, not
+// just handler 200s — the 403 scope tier is written inside the mux (per-route
+// requireScope → writeError), so a gzipped 403 that decompresses back to the
+// frozen JSON pins the gzip-outside-mux half of the chain-order criterion.
+func TestNewStack_GzipErrorResponseRoundTrip(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_ticketskey") // read:tickets ≠ read
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	require.Equal(t, "gzip", rr.Result().Header.Get("Content-Encoding"))
+
+	zr, err := gzip.NewReader(rr.Body)
+	require.NoError(t, err, "body must be a valid gzip stream")
+	decoded, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close(), "gzip trailer (CRC + size) must be intact")
+	assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, string(decoded))
+}
+
 // Auth sits OUTSIDE gzip in the chain (PRD order): a 401 must come back
 // uncompressed even when the client advertises gzip — exactly as the old
 // stack behaves and as the plain-text golden tier implies.

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -3,10 +3,14 @@ package rest_test
 // The hand-owned OpenAPI 3.1 spec (openapi/openapi.yaml) is executable
 // against the NEW stack too: every implemented battery case's OBSERVED
 // response (not the committed golden — contract/spec_test.go already covers
-// those) is validated against the document, with the same non-vacuousness
+// those) is validated against the document. Today that means the ranks
+// operation's full surface plus the 401 tiers observed on the profile-by-id
+// and tickets-list operations — the rest of the spec's operations are
+// witnessed only once their routes land (#126–#129). Same non-vacuousness
 // rules as the contract replay loop: the observed status must be EXPLICITLY
-// documented on the operation, and a JSON response requires an
-// application/json schema to validate against.
+// documented on the operation, a JSON response requires an application/json
+// schema to validate against, and every implemented case's path must be
+// classified in specRoutes — unclassified paths fail, never skip.
 
 import (
 	"bytes"
@@ -33,12 +37,19 @@ import (
 const specPath = "../openapi/openapi.yaml"
 
 // specRoutes maps an implemented battery case's request path (query string
-// stripped) to its spec path template. Fan-out slices extend it with their
-// routes; "" marks the deliberately off-spec unknown-path surface, asserted
+// stripped) to its spec path template. EVERY implemented case's path must be
+// classified here (recipe step 6 in the rest package doc) — validateObserved
+// fails on an unclassified path rather than skipping, so coverage cannot rot
+// silently. "" marks the deliberately off-spec unknown-path surface, asserted
 // to stay unmatched.
 var specRoutes = map[string]string{
-	"/api/v1/milpacs/ranks":  "/api/v1/milpacs/ranks",
-	"/api/v1/does/not/exist": "", // off-spec: unknown-path tier (mux behavior, not an operation)
+	"/api/v1/milpacs/ranks": "/api/v1/milpacs/ranks",
+	// The 401-tier battery cases replay against these two paths before their
+	// routes are implemented (auth runs before routing, so the observed 401s
+	// are route-independent); the operations document 401 explicitly.
+	"/api/v1/milpacs/profile/id/1": "/api/v1/milpacs/profile/id/{userId}",
+	"/api/v1/tickets":              "/api/v1/tickets",
+	"/api/v1/does/not/exist":       "", // off-spec: unknown-path tier (mux behavior, not an operation)
 }
 
 func loadSpecModel(t *testing.T) *v3.Document {
@@ -145,19 +156,15 @@ func TestNewStack_SpecValidation(t *testing.T) {
 		known[c.Name] = c
 	}
 
+	// EVERY implemented case is validated — no silent skips: an
+	// unclassified path fails inside validateObserved (the specRoutes
+	// require), so forgetting recipe step 6 is a red test, not a vacuous
+	// pass. The 401-tier cases replaying against not-yet-implemented routes
+	// still validate fine: their observed 401s are explicitly documented on
+	// the spec operations those paths classify to.
 	for _, name := range implementedCases {
 		c, ok := known[name]
 		require.True(t, ok, "implementedCases entry %q names no battery case", name)
-		// The 401-tier cases replay against routes the new stack does not
-		// serve yet; their paths classify to spec routes whose operations the
-		// fan-out slices own. Only validate cases whose path is classified.
-		basePath := c.Path
-		if i := strings.IndexByte(basePath, '?'); i >= 0 {
-			basePath = basePath[:i]
-		}
-		if _, classified := specRoutes[basePath]; !classified {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			g, _, err := contract.RunCase(h, c)
 			require.NoError(t, err)

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -1,0 +1,183 @@
+package rest_test
+
+// The hand-owned OpenAPI 3.1 spec (openapi/openapi.yaml) is executable
+// against the NEW stack too: every implemented battery case's OBSERVED
+// response (not the committed golden — contract/spec_test.go already covers
+// those) is validated against the document, with the same non-vacuousness
+// rules as the contract replay loop: the observed status must be EXPLICITLY
+// documented on the operation, and a JSON response requires an
+// application/json schema to validate against.
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/7cav/api/contract"
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi-validator/paths"
+	"github.com/pb33f/libopenapi-validator/responses"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const specPath = "../openapi/openapi.yaml"
+
+// specRoutes maps an implemented battery case's request path (query string
+// stripped) to its spec path template. Fan-out slices extend it with their
+// routes; "" marks the deliberately off-spec unknown-path surface, asserted
+// to stay unmatched.
+var specRoutes = map[string]string{
+	"/api/v1/milpacs/ranks":  "/api/v1/milpacs/ranks",
+	"/api/v1/does/not/exist": "", // off-spec: unknown-path tier (mux behavior, not an operation)
+}
+
+func loadSpecModel(t *testing.T) *v3.Document {
+	t.Helper()
+	raw, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+	doc, err := libopenapi.NewDocument(raw)
+	require.NoError(t, err)
+	model, errs := doc.BuildV3Model()
+	require.Empty(t, errs)
+	return &model.Model
+}
+
+// observedResponse reconstructs an http.Response from a replayed Golden so
+// the validator can check it.
+func observedResponse(g *contract.Golden) *http.Response {
+	h := http.Header{}
+	for k, v := range g.Header {
+		h.Set(k, v)
+	}
+	var body []byte
+	if g.Body != nil {
+		body = g.Body
+	} else if g.BodyText != nil {
+		body = []byte(*g.BodyText)
+	}
+	return &http.Response{
+		StatusCode: g.Status,
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+// validateObserved checks one observed response against the spec, refusing
+// to pass vacuously (mirrors contract/spec_test.go replayGoldenResponse).
+func validateObserved(t *testing.T, model *v3.Document, rv responses.ResponseBodyValidator, reqPath string, g *contract.Golden) {
+	t.Helper()
+
+	basePath := reqPath
+	if i := strings.IndexByte(basePath, '?'); i >= 0 {
+		basePath = basePath[:i]
+	}
+	tmpl, known := specRoutes[basePath]
+	require.True(t, known, "path %s missing from specRoutes — classify it (or mark it off-spec)", basePath)
+
+	req := httptest.NewRequest(http.MethodGet, reqPath, nil)
+
+	if tmpl == "" {
+		pathItem, _, matched := paths.FindPath(req, model, nil)
+		assert.Nil(t, pathItem,
+			"path %s must stay off-spec but matched spec path %q", reqPath, matched)
+		return
+	}
+
+	pathItem := model.Paths.PathItems.GetOrZero(tmpl)
+	require.NotNil(t, pathItem, "spec is missing path %s", tmpl)
+	op := pathItem.Get
+	require.NotNil(t, op, "spec path %s has no GET operation", tmpl)
+	require.NotNil(t, op.Responses, "operation %s declares no responses", op.OperationId)
+
+	statusCode := strconv.Itoa(g.Status)
+	docResp := op.Responses.Codes.GetOrZero(statusCode)
+	require.NotNil(t, docResp,
+		"operation %s: observed status %s is not explicitly documented (default resolution does not count)",
+		op.OperationId, statusCode)
+
+	if g.Body != nil {
+		var schema *base.SchemaProxy
+		if docResp.Content != nil {
+			if mt := docResp.Content.GetOrZero("application/json"); mt != nil {
+				schema = mt.Schema
+			}
+		}
+		require.NotNil(t, schema,
+			"operation %s: response %s declares no application/json schema — a JSON body would validate vacuously",
+			op.OperationId, statusCode)
+	} else {
+		require.Positive(t, orderedmap.Len(docResp.Content),
+			"operation %s: response %s declares no content but a body was observed", op.OperationId, statusCode)
+	}
+
+	valid, verrs := rv.ValidateResponseBodyWithPathItem(req, observedResponse(g), pathItem, tmpl)
+	if !valid {
+		var b strings.Builder
+		for _, e := range verrs {
+			fmt.Fprintf(&b, "[%s/%s] %s — %s\n", e.ValidationType, e.ValidationSubType, e.Message, e.Reason)
+			for _, s := range e.SchemaValidationErrors {
+				fmt.Fprintf(&b, "  field %s: %s\n", s.FieldPath, s.Reason)
+			}
+		}
+		t.Errorf("operation %s: observed response does not validate:\n%s", op.OperationId, b.String())
+	}
+}
+
+// TestNewStack_SpecValidation replays every implemented battery case against
+// the new stack and validates the OBSERVED response against the spec.
+func TestNewStack_SpecValidation(t *testing.T) {
+	model := loadSpecModel(t)
+	rv := responses.NewResponseBodyValidator(model)
+	h := newStack(t)
+
+	known := map[string]contract.Case{}
+	for _, c := range contract.Cases() {
+		known[c.Name] = c
+	}
+
+	for _, name := range implementedCases {
+		c, ok := known[name]
+		require.True(t, ok, "implementedCases entry %q names no battery case", name)
+		// The 401-tier cases replay against routes the new stack does not
+		// serve yet; their paths classify to spec routes whose operations the
+		// fan-out slices own. Only validate cases whose path is classified.
+		basePath := c.Path
+		if i := strings.IndexByte(basePath, '?'); i >= 0 {
+			basePath = basePath[:i]
+		}
+		if _, classified := specRoutes[basePath]; !classified {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			g, _, err := contract.RunCase(h, c)
+			require.NoError(t, err)
+			validateObserved(t, model, rv, c.Path, g)
+		})
+	}
+
+	// The ranks operation's 401 tier, observed live (explicitly documented
+	// on the operation as the shared Unauthorized response). The 403 scope
+	// tier resolves only via `default` — the corpus has no committed
+	// 403-on-ranks golden forcing an explicit declaration — so it is golden-
+	// compared in TestNewStack_AuthTiersOnRanksRoute but not spec-validated
+	// here (explicit-status rule).
+	t.Run("ranks_401_tier", func(t *testing.T) {
+		g, _, err := contract.RunCase(h, contract.Case{
+			Name: "ranks-401", Method: http.MethodGet, Path: "/api/v1/milpacs/ranks", Auth: contract.AuthNone,
+			Notes: "synthesized: 401 tier observed on the ranks operation",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnauthorized, g.Status)
+		validateObserved(t, model, rv, "/api/v1/milpacs/ranks", g)
+	})
+}

--- a/rest/write.go
+++ b/rest/write.go
@@ -1,0 +1,135 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// code is a gRPC status code number — the error contract of the public API
+// is the gRPC-status JSON shape with these numeric codes, frozen by the
+// golden corpus. Defined here (not imported from grpc-go) so the new stack
+// carries no gRPC dependency into Phase 4.
+type code int
+
+const (
+	codeOK                 code = 0
+	codeCanceled           code = 1
+	codeUnknown            code = 2
+	codeInvalidArgument    code = 3
+	codeDeadlineExceeded   code = 4
+	codeNotFound           code = 5
+	codeAlreadyExists      code = 6
+	codePermissionDenied   code = 7
+	codeResourceExhausted  code = 8
+	codeFailedPrecondition code = 9
+	codeAborted            code = 10
+	codeOutOfRange         code = 11
+	codeUnimplemented      code = 12
+	codeInternal           code = 13
+	codeUnavailable        code = 14
+	codeDataLoss           code = 15
+	codeUnauthenticated    code = 16
+)
+
+// httpStatus maps a gRPC code to its HTTP status — the table frozen from
+// grpc-gateway's runtime.HTTPStatusFromCode (the mapping the old stack
+// served). Unknown codes fail closed as 500.
+func (c code) httpStatus() int {
+	switch c {
+	case codeOK:
+		return http.StatusOK
+	case codeCanceled:
+		return 499 // client closed request (nginx convention, no stdlib name)
+	case codeUnknown:
+		return http.StatusInternalServerError
+	case codeInvalidArgument:
+		return http.StatusBadRequest
+	case codeDeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case codeNotFound:
+		return http.StatusNotFound
+	case codeAlreadyExists:
+		return http.StatusConflict
+	case codePermissionDenied:
+		return http.StatusForbidden
+	case codeResourceExhausted:
+		return http.StatusTooManyRequests
+	case codeFailedPrecondition:
+		return http.StatusBadRequest
+	case codeAborted:
+		return http.StatusConflict
+	case codeOutOfRange:
+		return http.StatusBadRequest
+	case codeUnimplemented:
+		return http.StatusNotImplemented
+	case codeInternal:
+		return http.StatusInternalServerError
+	case codeUnavailable:
+		return http.StatusServiceUnavailable
+	case codeDataLoss:
+		return http.StatusInternalServerError
+	case codeUnauthenticated:
+		return http.StatusUnauthorized
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// statusBody is the gRPC-status JSON error shape, frozen by the golden
+// corpus: {"code":N,"message":"...","details":[]}. Details has never been
+// observed populated; it stays an always-present empty array
+// (emit-everything).
+type statusBody struct {
+	Code    code   `json:"code"`
+	Message string `json:"message"`
+	Details []any  `json:"details"`
+}
+
+// writeError is the single error choke point of the new stack: every non-401
+// error response is written here — one place to keep the wire shape, the
+// code→HTTP mapping, and (extension point, #132) the 5xx Sentry reports.
+// The plain-text 401 tier deliberately bypasses it: the auth middleware
+// writes those itself (two-tier behavior golden-pinned by #106).
+//
+// Handler-specific message strings are frozen behavior (including the ones
+// that leak wrapped error text) — callers format them verbatim.
+func writeError(w http.ResponseWriter, c code, format string, args ...any) {
+	body, err := json.Marshal(statusBody{
+		Code:    c,
+		Message: fmt.Sprintf(format, args...),
+		Details: []any{},
+	})
+	if err != nil {
+		// statusBody cannot fail to marshal; guard against future edits.
+		http.Error(w, `{"code":13,"message":"failed to encode error","details":[]}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(c.httpStatus())
+	if _, err := w.Write(body); err != nil {
+		Error.Printf("writing error response: %v", err)
+	}
+}
+
+// notFound is the JSON 404 for unknown paths under the API prefix — the
+// gateway-mux body the corpus pinned, not the stdlib text 404.
+func notFound(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, codeNotFound, "Not Found")
+}
+
+// writeJSON writes a 200 application/json response. It marshals BEFORE
+// touching the ResponseWriter so an encoding failure can still surface as a
+// clean Internal error through the choke point instead of a truncated 200.
+func writeJSON(w http.ResponseWriter, v any) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		Error.Printf("encoding response: %v", err)
+		writeError(w, codeInternal, "failed to encode response")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(body); err != nil {
+		Error.Printf("writing response: %v", err)
+	}
+}

--- a/rest/write.go
+++ b/rest/write.go
@@ -148,6 +148,23 @@ func notFound(w http.ResponseWriter, r *http.Request) {
 	writeError(w, r, codeNotFound, "Not Found")
 }
 
+// methodNotAllowed answers a wrong-method request on an EXISTING route: 405
+// with Allow naming the supported verbs — today always "GET, HEAD", the whole
+// read surface (HEAD rides along on every GET pattern; when write endpoints
+// arrive their routes advertise their own Allow). Enumerated break (PRD #112,
+// ruled at #125): the old stack answered 501.
+//
+// Code mapping, decided deliberately: the frozen code→HTTP table has no code
+// that yields 405, so the body keeps the OLD stack's wrong-method body
+// verbatim — code 12 (Unimplemented), message "Method Not Allowed" — and only
+// the HTTP status (501→405) and the Allow header change. A consumer matching
+// on the JSON body sees no difference; writeStatusJSON carries the explicit
+// status override.
+func methodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Allow", "GET, HEAD")
+	writeStatusJSON(w, r, http.StatusMethodNotAllowed, codeUnimplemented, "Method Not Allowed")
+}
+
 // writeJSON writes a 200 application/json response. It marshals BEFORE
 // touching the ResponseWriter so an encoding failure can still surface as a
 // clean Internal error through the choke point instead of a truncated 200.

--- a/rest/write.go
+++ b/rest/write.go
@@ -86,50 +86,80 @@ type statusBody struct {
 	Details []any  `json:"details"`
 }
 
+// marshalJSON is json.Marshal behind a package seam so the marshal-failure
+// fallback below stays testable: statusBody itself cannot fail to marshal, so
+// the guard would otherwise be unreachable dead weight. Swapped only by tests.
+var marshalJSON = json.Marshal
+
 // writeError is the single error choke point of the new stack: every non-401
 // error response is written here — one place to keep the wire shape, the
-// code→HTTP mapping, and (extension point, #132) the 5xx Sentry reports.
-// The plain-text 401 tier deliberately bypasses it: the auth middleware
-// writes those itself (two-tier behavior golden-pinned by #106).
+// code→HTTP mapping, the ≥500 server-side logging, and (extension point,
+// #132) the 5xx Sentry reports. The plain-text 401 tier deliberately bypasses
+// it: the auth middleware writes those itself (two-tier behavior golden-pinned
+// by #106). r supplies the method/path request context for the log lines.
 //
 // Handler-specific message strings are frozen behavior (including the ones
 // that leak wrapped error text) — callers format them verbatim.
-func writeError(w http.ResponseWriter, c code, format string, args ...any) {
-	body, err := json.Marshal(statusBody{
+func writeError(w http.ResponseWriter, r *http.Request, c code, format string, args ...any) {
+	writeStatusJSON(w, r, c.httpStatus(), c, format, args...)
+}
+
+// writeStatusJSON is writeError with the HTTP status decoupled from the code:
+// for the rare response whose status the frozen code→HTTP table cannot
+// produce. Everything else must go through writeError so code and status can
+// never disagree by accident.
+func writeStatusJSON(w http.ResponseWriter, r *http.Request, status int, c code, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if status >= 500 {
+		// Cheap insurance: production 5xx outages stay visible server-side
+		// even if cutover (#134) lands before the Sentry slice (#132).
+		Error.Printf("%s %s: %d (code %d): %s", r.Method, r.URL.Path, status, c, msg)
+	}
+	body, err := marshalJSON(statusBody{
 		Code:    c,
-		Message: fmt.Sprintf(format, args...),
+		Message: msg,
 		Details: []any{},
 	})
 	if err != nil {
 		// statusBody cannot fail to marshal; guard against future edits.
-		http.Error(w, `{"code":13,"message":"failed to encode error","details":[]}`, http.StatusInternalServerError)
+		// Hand-written fallback, NOT http.Error: that would emit text/plain +
+		// X-Content-Type-Options: nosniff and append a newline — off-contract
+		// in three ways. Log the marshal failure WITH the original code and
+		// message, or the real error vanishes behind the generic body.
+		Error.Printf("%s %s: marshaling error body failed (original code %d, message %q): %v",
+			r.Method, r.URL.Path, c, msg, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, werr := w.Write([]byte(`{"code":13,"message":"failed to encode error","details":[]}`)); werr != nil {
+			Error.Printf("%s %s: writing fallback error response: %v", r.Method, r.URL.Path, werr)
+		}
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(c.httpStatus())
+	w.WriteHeader(status)
 	if _, err := w.Write(body); err != nil {
-		Error.Printf("writing error response: %v", err)
+		Error.Printf("%s %s: writing error response: %v", r.Method, r.URL.Path, err)
 	}
 }
 
 // notFound is the JSON 404 for unknown paths under the API prefix — the
 // gateway-mux body the corpus pinned, not the stdlib text 404.
-func notFound(w http.ResponseWriter, _ *http.Request) {
-	writeError(w, codeNotFound, "Not Found")
+func notFound(w http.ResponseWriter, r *http.Request) {
+	writeError(w, r, codeNotFound, "Not Found")
 }
 
 // writeJSON writes a 200 application/json response. It marshals BEFORE
 // touching the ResponseWriter so an encoding failure can still surface as a
 // clean Internal error through the choke point instead of a truncated 200.
-func writeJSON(w http.ResponseWriter, v any) {
+func writeJSON(w http.ResponseWriter, r *http.Request, v any) {
 	body, err := json.Marshal(v)
 	if err != nil {
-		Error.Printf("encoding response: %v", err)
-		writeError(w, codeInternal, "failed to encode response")
+		Error.Printf("%s %s: encoding response: %v", r.Method, r.URL.Path, err)
+		writeError(w, r, codeInternal, "failed to encode response")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(body); err != nil {
-		Error.Printf("writing response: %v", err)
+		Error.Printf("%s %s: writing response: %v", r.Method, r.URL.Path, err)
 	}
 }

--- a/rest/write_test.go
+++ b/rest/write_test.go
@@ -1,7 +1,10 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// captureErrorLog redirects the package Error logger into a buffer for one
+// test and restores the previous writer afterwards.
+func captureErrorLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := Error.Writer()
+	Error.SetOutput(&buf)
+	t.Cleanup(func() { Error.SetOutput(prev) })
+	return &buf
+}
+
 // The error writer is the single choke point for every non-401 error the new
 // stack emits: the gRPC-status JSON shape ({"code":N,"message":...,
 // "details":[]}) with the frozen code→HTTP mapping. The plain-text 401 tier
@@ -17,7 +31,7 @@ import (
 
 func TestWriteError_GRPCStatusJSONShape(t *testing.T) {
 	rr := httptest.NewRecorder()
-	writeError(rr, codePermissionDenied, "scope required: %s", "read")
+	writeError(rr, httptest.NewRequest(http.MethodGet, "/api/v1/x", nil), codePermissionDenied, "scope required: %s", "read")
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
@@ -79,7 +93,7 @@ func TestNotFoundHandler_JSON404(t *testing.T) {
 // the choke point instead of a half-written 200.
 func TestWriteJSON(t *testing.T) {
 	rr := httptest.NewRecorder()
-	writeJSON(rr, map[string]string{"hello": "world"})
+	writeJSON(rr, httptest.NewRequest(http.MethodGet, "/api/v1/x", nil), map[string]string{"hello": "world"})
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
@@ -87,11 +101,68 @@ func TestWriteJSON(t *testing.T) {
 }
 
 func TestWriteJSON_MarshalFailureBecomesInternalError(t *testing.T) {
+	captureErrorLog(t)
 	rr := httptest.NewRecorder()
-	writeJSON(rr, func() {}) // func values cannot marshal
+	writeJSON(rr, httptest.NewRequest(http.MethodGet, "/api/v1/x", nil), func() {}) // func values cannot marshal
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Equal(t, float64(13), body["code"])
+}
+
+// Every ≥500 response is Error-logged at the choke point with code, message,
+// method, and path — cheap insurance that a production outage is visible
+// server-side even if cutover (#134) lands before the Sentry slice (#132).
+func TestWriteError_500sAreLoggedWithRequestContext(t *testing.T) {
+	buf := captureErrorLog(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	writeError(rr, req, codeInternal, "error fetching ranks: %v", io.ErrUnexpectedEOF)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "GET")
+	assert.Contains(t, logged, "/api/v1/milpacs/ranks")
+	assert.Contains(t, logged, "code 13")
+	assert.Contains(t, logged, "error fetching ranks: unexpected EOF")
+}
+
+func TestWriteError_4xxIsNotErrorLogged(t *testing.T) {
+	buf := captureErrorLog(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	writeError(rr, req, codePermissionDenied, "scope required: read")
+
+	assert.Empty(t, buf.String(), "client errors must not spam the Error log")
+}
+
+// The marshal-failure fallback (statusBody cannot fail to marshal today; the
+// guard protects future edits) must stay on-contract: a hand-written constant
+// JSON body with application/json — NOT http.Error, which would emit
+// text/plain + X-Content-Type-Options: nosniff and append a newline — and the
+// failure must be logged with the original code/message and request context,
+// or the original error would vanish without a trace.
+func TestWriteError_MarshalFailureFallback(t *testing.T) {
+	buf := captureErrorLog(t)
+	prev := marshalJSON
+	marshalJSON = func(any) ([]byte, error) { return nil, errors.New("marshal exploded") }
+	t.Cleanup(func() { marshalJSON = prev })
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	writeError(rr, req, codePermissionDenied, "scope required: %s", "read")
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.Empty(t, rr.Header().Get("X-Content-Type-Options"),
+		"fallback must be hand-written, not http.Error (which adds nosniff)")
+	assert.Equal(t, `{"code":13,"message":"failed to encode error","details":[]}`, rr.Body.String(),
+		"constant fallback body, verbatim — no trailing newline")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "marshal exploded")
+	assert.Contains(t, logged, "code 7", "the original code must survive into the log")
+	assert.Contains(t, logged, "scope required: read", "the original message must survive into the log")
+	assert.Contains(t, logged, "GET")
+	assert.Contains(t, logged, "/api/v1/milpacs/ranks")
 }

--- a/rest/write_test.go
+++ b/rest/write_test.go
@@ -1,0 +1,97 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The error writer is the single choke point for every non-401 error the new
+// stack emits: the gRPC-status JSON shape ({"code":N,"message":...,
+// "details":[]}) with the frozen code→HTTP mapping. The plain-text 401 tier
+// never passes through it — the auth middleware writes those directly.
+
+func TestWriteError_GRPCStatusJSONShape(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeError(rr, codePermissionDenied, "scope required: %s", "read")
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, map[string]any{
+		"code":    float64(7),
+		"message": "scope required: read",
+		"details": []any{}, // always present, always an array — emit-everything
+	}, body)
+}
+
+// The complete code→HTTP table, frozen from grpc-gateway's
+// runtime.HTTPStatusFromCode so no fan-out slice ever re-decides a mapping.
+func TestCodeHTTPStatusMapping(t *testing.T) {
+	cases := []struct {
+		c    code
+		want int
+	}{
+		{codeOK, http.StatusOK},
+		{codeCanceled, 499}, // client closed request (nginx convention)
+		{codeUnknown, http.StatusInternalServerError},
+		{codeInvalidArgument, http.StatusBadRequest},
+		{codeDeadlineExceeded, http.StatusGatewayTimeout},
+		{codeNotFound, http.StatusNotFound},
+		{codeAlreadyExists, http.StatusConflict},
+		{codePermissionDenied, http.StatusForbidden},
+		{codeResourceExhausted, http.StatusTooManyRequests},
+		{codeFailedPrecondition, http.StatusBadRequest},
+		{codeAborted, http.StatusConflict},
+		{codeOutOfRange, http.StatusBadRequest},
+		{codeUnimplemented, http.StatusNotImplemented},
+		{codeInternal, http.StatusInternalServerError},
+		{codeUnavailable, http.StatusServiceUnavailable},
+		{codeDataLoss, http.StatusInternalServerError},
+		{codeUnauthenticated, http.StatusUnauthorized},
+		{code(42), http.StatusInternalServerError}, // unknown code: fail closed as a 500
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.c.httpStatus(), "code %d", c.c)
+	}
+}
+
+// Unknown paths under the API prefix return the gateway-mux-shaped JSON 404
+// — {"code":5,"message":"Not Found","details":[]} — not the stdlib text 404.
+// Golden-pinned by auth/unknown_path_authenticated.
+func TestNotFoundHandler_JSON404(t *testing.T) {
+	rr := httptest.NewRecorder()
+	notFound(rr, httptest.NewRequest(http.MethodGet, "/api/v1/does/not/exist", nil))
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"code":5,"message":"Not Found","details":[]}`, rr.Body.String())
+}
+
+// writeJSON is the success-path twin: application/json Content-Type and the
+// marshaled body. A marshal failure must surface as an Internal error through
+// the choke point instead of a half-written 200.
+func TestWriteJSON(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeJSON(rr, map[string]string{"hello": "world"})
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"hello":"world"}`, rr.Body.String())
+}
+
+func TestWriteJSON_MarshalFailureBecomesInternalError(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeJSON(rr, func() {}) // func values cannot marshal
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, float64(13), body["code"])
+}

--- a/servers/gateway/gateway.go
+++ b/servers/gateway/gateway.go
@@ -19,7 +19,6 @@
 package gateway
 
 import (
-	"compress/gzip"
 	"context"
 	"io/fs"
 	"log"
@@ -31,7 +30,7 @@ import (
 	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/openapi"
 	"github.com/7cav/api/proto"
-	grpcServices "github.com/7cav/api/servers/grpc"
+	"github.com/7cav/api/rest"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 )
@@ -59,77 +58,19 @@ func getOpenAPIHandler() http.Handler {
 	return http.FileServer(http.FS(sub))
 }
 
-// maxTokenLen is the maximum length of a raw API key we'll accept.
-// cav7_ prefix (5) + 64 hex chars = 69; 128 gives generous headroom.
-const maxTokenLen = 128
-
-// errBearerScheme is the 401 body returned when the Authorization header is
-// missing or doesn't carry a usable Bearer token (no/empty/oversized token).
-// It names the expected format so callers who paste a raw key without the
-// "Bearer " prefix get a self-explanatory error. The key-validation-failure
-// branch stays the generic "Unauthorized" so it leaks nothing about whether a
-// key exists, is expired, or lacks scopes.
-const errBearerScheme = "Unauthorized: expected 'Authorization: Bearer <key>' header"
-
-func authMiddleware(ds datastores.Datastore, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := datastores.ParseBearerToken(r.Header.Get("Authorization"), maxTokenLen)
-		if token == "" {
-			Warn.Printf("Unauthorized HTTP access attempt (bad bearer scheme) from %s", r.RemoteAddr)
-			http.Error(w, errBearerScheme, http.StatusUnauthorized)
-			return
-		}
-
-		key, err := ds.ValidateApiKey(token)
-		if err != nil || key == nil {
-			Warn.Printf("Unauthorized HTTP access attempt from %s", r.RemoteAddr)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		// Attach the validated key to the request ctx (mirrors the gRPC auth
-		// interceptor) so downstream consumers — e.g. Sentry key-id tagging —
-		// can identify the caller without ever seeing the bearer token.
-		next.ServeHTTP(w, r.WithContext(grpcServices.ContextWithKey(r.Context(), key)))
-	})
-}
-
-func compressionMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
-			w.Header().Set("Content-Encoding", "gzip")
-			gz := gzip.NewWriter(w)
-			defer func() {
-				if err := gz.Close(); err != nil {
-					// A Close failure means the gzip trailer never reached the
-					// client — a corrupt body behind an already-written status,
-					// invisible to the sentry layer outside this one.
-					Error.Printf("gzip close failed for %s %s (response likely truncated): %v", r.Method, r.URL.Path, err)
-				}
-			}()
-			gzw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
-			next.ServeHTTP(gzw, r)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-type gzipResponseWriter struct {
-	http.ResponseWriter
-	Writer *gzip.Writer
-}
-
-func (w *gzipResponseWriter) Write(b []byte) (int, error) {
-	w.Header().Del("Content-Length") // This is necessary as otherwise it will have the uncompressed length
-	return w.Writer.Write(b)
-}
-
 // buildAPIHandler assembles the /api middleware chain:
 // auth(sentry(compression(inner))). Sentry sits inside auth so it only
 // sees authenticated requests, with the API key already on ctx for key-id
 // tagging, and outside the compression layer so it observes the final
 // response status. No SENTRY_DSN → it is a pass-through.
+//
+// The auth and compression layers are the rest package's middleware (the
+// Phase 3 stack, #125): they moved there verbatim — single source, so the
+// two stacks cannot diverge while both are in-tree — and this gateway
+// delegates until cutover deletes it. rest.AuthMiddleware attaches the
+// validated key with rest.ContextWithKey; grpcServices.KeyFromContext
+// delegates to the same context key, so the Sentry key-id tagging below
+// keeps seeing it.
 //
 // Phase 2 de-cache (#123/#124): the response cache is gone — middleware out
 // of the chain at #123 (taking the X-Cache header with it — the PRD's
@@ -145,8 +86,8 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 // contract — see the buildAPIHandler tests — rather than an untestable
 // expression inside a dialing function.
 func buildAPIHandler(ds datastores.Datastore, inner http.Handler) http.Handler {
-	return authMiddleware(ds,
-		sentryMiddleware(compressionMiddleware(inner)))
+	return rest.AuthMiddleware(ds,
+		sentryMiddleware(rest.GzipMiddleware(inner)))
 }
 
 func (service *Service) Server() *http.Server {

--- a/servers/gateway/gateway_test.go
+++ b/servers/gateway/gateway_test.go
@@ -13,6 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fakeAuthDatastore embeds the Datastore interface so it satisfies the type
+// without implementing every method; only ValidateApiKey is exercised by the
+// auth layer (rest.AuthMiddleware — moved there at #125, tested there). Any
+// other call panics (nil method) — a loud failure if a test accidentally
+// reaches further into the datastore.
+type fakeAuthDatastore struct {
+	datastores.Datastore
+	validateApiKey func(string) (*datastores.ApiKeyResult, error)
+}
+
+func (f *fakeAuthDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
+	return f.validateApiKey(rawKey)
+}
+
 // TestBuildAPIHandler_ResponseCacheRemoved pins the Phase 2 de-cache
 // (#123/#124): the response cache is gone — middleware out of the /api chain
 // at #123, the cache package and Redis deleted outright at #124. Observable

--- a/servers/gateway/sentry_test.go
+++ b/servers/gateway/sentry_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/rest"
 	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -275,8 +276,8 @@ func TestBuildAPIHandler_BadAuth_401NoEvents(t *testing.T) {
 }
 
 // TestSentryMiddleware_BehindAuth_EventCarriesKeyID exercises the real chain
-// shape — authMiddleware outside, sentryMiddleware inside — and proves the
-// validated API key id reaches the event while the raw key never does.
+// shape — rest.AuthMiddleware outside, sentryMiddleware inside — and proves
+// the validated API key id reaches the event while the raw key never does.
 func TestSentryMiddleware_BehindAuth_EventCarriesKeyID(t *testing.T) {
 	transport := bindCaptureClient(t)
 	const secret = "cav7_topsecrettokenvalue"
@@ -285,7 +286,7 @@ func TestSentryMiddleware_BehindAuth_EventCarriesKeyID(t *testing.T) {
 		assert.Equal(t, secret, token)
 		return &datastores.ApiKeyResult{KeyId: 42, UserId: 7}, nil
 	}}
-	h := authMiddleware(ds, sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := rest.AuthMiddleware(ds, sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "upstream exploded", http.StatusInternalServerError)
 	})))
 

--- a/servers/grpc/auth.go
+++ b/servers/grpc/auth.go
@@ -4,23 +4,26 @@ import (
 	"context"
 
 	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/rest"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// keyContextKey is the private type used to attach *ApiKeyResult to a request
-// ctx. Private so external packages can't accidentally clobber it.
-type keyContextKey struct{}
+// The key-on-context helpers moved to the rest package (the Phase 3 stack,
+// #125) — their permanent home once this package is deleted at Phase 4. The
+// delegating aliases below keep this package's API stable and, more
+// importantly, keep BOTH stacks attaching/reading the same context key, so
+// the gateway's Sentry key-id tagging works regardless of which middleware
+// authenticated the request.
 
 // ContextWithKey returns a new context carrying the given API key result.
 func ContextWithKey(ctx context.Context, key *datastores.ApiKeyResult) context.Context {
-	return context.WithValue(ctx, keyContextKey{}, key)
+	return rest.ContextWithKey(ctx, key)
 }
 
 // KeyFromContext returns the *ApiKeyResult attached to ctx, or nil if none.
 func KeyFromContext(ctx context.Context) *datastores.ApiKeyResult {
-	v, _ := ctx.Value(keyContextKey{}).(*datastores.ApiKeyResult)
-	return v
+	return rest.KeyFromContext(ctx)
 }
 
 // RequireScope returns codes.PermissionDenied if the key on ctx lacks the named

--- a/types/ranks.go
+++ b/types/ranks.go
@@ -1,0 +1,18 @@
+package types
+
+// RankExpanded is one entry in the rank reference list — the catalog variant
+// that carries the display order (the plain Rank embedded in profiles omits
+// it). Served by GET /api/v1/milpacs/ranks.
+type RankExpanded struct {
+	RankShort        string `json:"rankShort"`
+	RankFull         string `json:"rankFull"`
+	RankImageUrl     string `json:"rankImageUrl"`
+	RankId           uint64 `json:"rankId,string"`
+	RankDisplayOrder uint32 `json:"rankDisplayOrder"`
+}
+
+// RanksResponse is the GET /api/v1/milpacs/ranks envelope. Ranks must be
+// allocated even when empty ([] on the wire, never null).
+type RanksResponse struct {
+	Ranks []*RankExpanded `json:"ranks"`
+}

--- a/types/ranks_test.go
+++ b/types/ranks_test.go
@@ -1,0 +1,67 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalToMap round-trips v through encoding/json into a generic map so the
+// assertions read the wire form a client would parse — names, presence and
+// JSON kinds — not Go struct internals.
+func marshalToMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m), "wire form must be a JSON object: %s", raw)
+	return m
+}
+
+// The populated form: lowerCamelCase names, 64-bit rankId as a JSON string,
+// 32-bit rankDisplayOrder as a JSON number — the protojson conventions the
+// golden corpus freezes (see contract/goldens/milpacs/ranks.golden.json).
+func TestRankExpanded_WireForm(t *testing.T) {
+	m := marshalToMap(t, types.RankExpanded{
+		RankShort:        "MG",
+		RankFull:         "Major General",
+		RankImageUrl:     "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+		RankId:           4,
+		RankDisplayOrder: 4,
+	})
+
+	assert.Equal(t, map[string]any{
+		"rankShort":        "MG",
+		"rankFull":         "Major General",
+		"rankImageUrl":     "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+		"rankId":           "4", // 64-bit int: decimal-string wire form
+		"rankDisplayOrder": float64(4),
+	}, m)
+}
+
+// Emit-everything: the zero value still serializes every field — no
+// omitempty anywhere. An absent key, "" and 0 are distinct wire states and
+// the contract requires presence.
+func TestRankExpanded_ZeroValueEmitsEveryField(t *testing.T) {
+	m := marshalToMap(t, types.RankExpanded{})
+
+	assert.Equal(t, map[string]any{
+		"rankShort":        "",
+		"rankFull":         "",
+		"rankImageUrl":     "",
+		"rankId":           "0",
+		"rankDisplayOrder": float64(0),
+	}, m)
+}
+
+// RanksResponse wraps the list under "ranks". The handler owns the
+// allocation discipline (an empty list must be [] not null — goldens enforce
+// it); the type's job is the envelope and field name.
+func TestRanksResponse_WireForm(t *testing.T) {
+	raw, err := json.Marshal(types.RanksResponse{Ranks: []*types.RankExpanded{}})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ranks":[]}`, string(raw))
+}

--- a/types/rostertype.go
+++ b/types/rostertype.go
@@ -1,0 +1,52 @@
+package types
+
+import "strconv"
+
+// RosterType identifies which roster is requested. The numeric values are
+// the upstream roster_id foreign key (xf_nf_rosters_* tables) and match the
+// retired proto enum exactly; the wire form is the NAME string.
+//
+// This is the worked example of the enum convention (see the package doc):
+// integer-backed named type, MarshalJSON emits the name, the zero value is
+// the _UNSPECIFIED name, and unnamed values fall back to the bare number.
+type RosterType int32
+
+const (
+	RosterTypeUnspecified RosterType = 0
+	RosterTypeCombat      RosterType = 1
+	RosterTypeReserve     RosterType = 2
+	RosterTypeEloa        RosterType = 3
+	RosterTypeWallOfHonor RosterType = 4
+	RosterTypeArlington   RosterType = 5
+	RosterTypePastMembers RosterType = 6
+)
+
+// rosterTypeNames is the wire-name catalog. Index == enum value.
+var rosterTypeNames = map[RosterType]string{
+	RosterTypeUnspecified: "ROSTER_TYPE_UNSPECIFIED",
+	RosterTypeCombat:      "ROSTER_TYPE_COMBAT",
+	RosterTypeReserve:     "ROSTER_TYPE_RESERVE",
+	RosterTypeEloa:        "ROSTER_TYPE_ELOA",
+	RosterTypeWallOfHonor: "ROSTER_TYPE_WALL_OF_HONOR",
+	RosterTypeArlington:   "ROSTER_TYPE_ARLINGTON",
+	RosterTypePastMembers: "ROSTER_TYPE_PAST_MEMBERS",
+}
+
+// String returns the wire name, or the bare decimal number for values the
+// catalog has no name for — mirroring the generated proto String(), so enum
+// values interpolate identically into the frozen error-message strings.
+func (rt RosterType) String() string {
+	if name, ok := rosterTypeNames[rt]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(rt), 10)
+}
+
+// MarshalJSON emits the enum name as a JSON string; values without a name
+// emit the bare number (protojson behavior for unknown enum values).
+func (rt RosterType) MarshalJSON() ([]byte, error) {
+	if name, ok := rosterTypeNames[rt]; ok {
+		return strconv.AppendQuote(nil, name), nil
+	}
+	return strconv.AppendInt(nil, int64(rt), 10), nil
+}

--- a/types/rostertype.go
+++ b/types/rostertype.go
@@ -4,7 +4,8 @@ import "strconv"
 
 // RosterType identifies which roster is requested. The numeric values are
 // the upstream roster_id foreign key (xf_nf_rosters_* tables) and match the
-// retired proto enum exactly; the wire form is the NAME string.
+// proto enum being retired at Phase 4 exactly; the wire form is the NAME
+// string.
 //
 // This is the worked example of the enum convention (see the package doc):
 // integer-backed named type, MarshalJSON emits the name, the zero value is
@@ -21,7 +22,7 @@ const (
 	RosterTypePastMembers RosterType = 6
 )
 
-// rosterTypeNames is the wire-name catalog. Index == enum value.
+// rosterTypeNames is the wire-name catalog, keyed by enum value.
 var rosterTypeNames = map[RosterType]string{
 	RosterTypeUnspecified: "ROSTER_TYPE_UNSPECIFIED",
 	RosterTypeCombat:      "ROSTER_TYPE_COMBAT",

--- a/types/rostertype_test.go
+++ b/types/rostertype_test.go
@@ -1,0 +1,52 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Enums serialize as their NAME string (protojson convention); the zero
+// value is zero-safe by construction — it emits the _UNSPECIFIED name, so a
+// forgotten assignment can never leak a bare 0 onto the wire.
+func TestRosterType_MarshalsAsNameString(t *testing.T) {
+	cases := []struct {
+		value types.RosterType
+		want  string
+	}{
+		{types.RosterTypeUnspecified, `"ROSTER_TYPE_UNSPECIFIED"`},
+		{types.RosterType(0), `"ROSTER_TYPE_UNSPECIFIED"`}, // zero value == unspecified
+		{types.RosterTypeCombat, `"ROSTER_TYPE_COMBAT"`},
+		{types.RosterTypeReserve, `"ROSTER_TYPE_RESERVE"`},
+		{types.RosterTypeEloa, `"ROSTER_TYPE_ELOA"`},
+		{types.RosterTypeWallOfHonor, `"ROSTER_TYPE_WALL_OF_HONOR"`},
+		{types.RosterTypeArlington, `"ROSTER_TYPE_ARLINGTON"`},
+		{types.RosterTypePastMembers, `"ROSTER_TYPE_PAST_MEMBERS"`},
+	}
+	for _, c := range cases {
+		raw, err := json.Marshal(c.value)
+		require.NoError(t, err)
+		assert.Equal(t, c.want, string(raw))
+	}
+}
+
+// A value with no registered name falls back to the bare number — exactly
+// what protojson emits for an unknown enum value, so upstream data the
+// catalog hasn't caught up with still round-trips instead of crashing.
+func TestRosterType_UnknownValueMarshalsAsNumber(t *testing.T) {
+	raw, err := json.Marshal(types.RosterType(99))
+	require.NoError(t, err)
+	assert.Equal(t, `99`, string(raw))
+}
+
+// String mirrors the wire name (and the number fallback) so enum values
+// format the same way in error messages as they do in JSON — the roster
+// handlers interpolate the enum into frozen message strings.
+func TestRosterType_StringMatchesWireName(t *testing.T) {
+	assert.Equal(t, "ROSTER_TYPE_COMBAT", types.RosterTypeCombat.String())
+	assert.Equal(t, "ROSTER_TYPE_UNSPECIFIED", types.RosterType(0).String())
+	assert.Equal(t, "99", types.RosterType(99).String())
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,29 @@
+// Package types holds the hand-written wire types of the public HTTP API —
+// the domain model that replaces the generated proto types in the stdlib
+// net/http rewrite (PRD #112, Phase 3). The golden contract corpus
+// (contract/) and the hand-owned OpenAPI spec (openapi/openapi.yaml) freeze
+// the wire form these types must reproduce.
+//
+// # Wire conventions (house style — every type in this package follows them)
+//
+//   - JSON names are lowerCamelCase.
+//   - Emit-everything: no `omitempty` anywhere. An absent key, "" and 0 are
+//     distinct wire states; the contract requires presence.
+//   - 64-bit integers serialize as JSON strings via the `,string` tag
+//     (protojson convention); 32-bit integers stay JSON numbers.
+//   - Unset nested messages are pointer fields and serialize as null.
+//   - Empty collections serialize as []/{} — never null. encoding/json
+//     renders a nil slice/map as null, so the ALLOCATION DISCIPLINE lives in
+//     the handlers/mappers: always allocate, even for zero elements. The
+//     goldens enforce it.
+//   - Enums are integer-backed named types with custom marshalers that emit
+//     the enum NAME as a JSON string; the zero value emits the _UNSPECIFIED
+//     name, and values without a name fall back to the bare number (protojson
+//     behavior). See RosterType for the worked example.
+//   - Go field names keep the generated proto spelling (RankId, not RankID)
+//     so the cutover datastore type-swap (#134) is import surgery, matching
+//     the existing house style (datastores.ApiKeyResult.KeyId).
+//
+// Adding a type: copy the conventions above, then let the route's goldens and
+// the spec replay loop (contract/spec_test.go) prove the wire form.
+package types


### PR DESCRIPTION
Closes #125. Part of #112 (Goodbye gRPC), Phase 3.

## What

The tracer-bullet slice: `GET /api/v1/milpacs/ranks` end-to-end on the new stdlib `net/http` stack, establishing every foundation the fan-out slices (#126–#129) reuse:

- **`rest/` package** — Go 1.22+ pattern-routing mux, middleware chain in PRD order (sentry → metrics → auth → gzip → mux) with documented extension points for #130/#132; `handle(mux, pattern, scope, handler)` registration helper so the scope gate is a required positional arg; `writeError`/`writeJSON` single choke point (gRPC-status JSON shape, frozen code→HTTP table, request-context logging, ≥500 server-side logging).
- **`types/` package** — hand-written wire-convention structs (lowerCamelCase, emit-everything, 64-bit ints as `,string`, enum name-string marshalers with `_UNSPECIFIED` zero); `RosterType` as the worked enum example.
- **Delegation refactor** — `servers/gateway` and `servers/grpc` now share auth/gzip/key-context with `rest/` (one context key across stacks; the auth + gzip middleware serve production through the gateway today; the handler stack stays test-mounted until #134).
- **Pins** — ranks goldens replay green against the new stack in-process (incl. all auth tiers); spec validation green for the ranks operation, and unclassified routes now go red instead of silently skipping.

## Ruled contract change (recorded in #112 "Deliberate breaks")

Wrong-method on an existing route is now **405 + `Allow: GET, HEAD`** (old stack: 501; un-pinned new code was 404). HEAD stays a supported read verb (200, no body); 404 is reserved for genuinely unknown routes. Read-only published API → no legitimate consumer impact. Pinned new-stack-only so the old-stack golden suite stays green.

## Review

5-agent review wave (code, tests, silent-failures, type design, comments) + human-ruled fix wave (4 criticals, 3 highs, 4 importants) + targeted adversarial re-review (mutation probes confirmed the 405/HEAD/spec-classification pins catch regressions). Follow-ups filed: #148 (tag-lint), #149 (last_used_date).

Gate: build, vet, `go test -count=1 ./...`, `make test-integration` (MariaDB harness), race on rest/types/contract — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)