### PR TITLE
Phase 3: profile lookup routes — id, username, discord, gamertag (#126)

### DIFF
--- a/datastores/datastore.go
+++ b/datastores/datastore.go
@@ -67,6 +67,10 @@ func ParseBearerToken(raw string, maxLen int) string {
 }
 
 type Datastore interface {
+	// FindProfilesById and FindProfilesByUsername return a NON-EMPTY slice of
+	// non-nil profiles on a nil error — no-match is gorm.ErrRecordNotFound,
+	// never an empty slice. Handlers index [0] under this invariant (with a
+	// defensive 500 guard for implementations that break it).
 	FindProfilesById(userId ...uint64) ([]*proto.Profile, error)
 	FindProfilesByUsername(username string) ([]*proto.Profile, error)
 	FindRosterByType(rosterType proto.RosterType) (*proto.Roster, error)

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -1,11 +1,14 @@
 package rest
 
 import (
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/proto"
 	"github.com/7cav/api/types"
+	"gorm.io/gorm"
 )
 
 // getAllRanks serves GET /api/v1/milpacs/ranks: the rank reference list,
@@ -20,6 +23,105 @@ func getAllRanks(ds datastores.Datastore) http.Handler {
 		}
 		writeJSON(w, r, types.RanksResponse{Ranks: ranksFromProto(ranks)})
 	})
+}
+
+// getProfileByID serves GET /api/v1/milpacs/profile/id/{user_id}: the full
+// profile looked up by MILPAC RELATION KEY — the path value matches the
+// milpac relation key, not the forum user id (frozen as-is, PRD #112; the
+// profile_by_id_happy golden proves relation wins). Error message strings
+// frozen from the old stack (servers/grpc GetProfile + the gateway's
+// type-mismatch text).
+func getProfileByID(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, err := strconv.ParseUint(r.PathValue("user_id"), 10, 64)
+		if err != nil {
+			// Gateway type-mismatch tier, parse-error text leaked. Frozen.
+			writeError(w, r, codeInvalidArgument, "type mismatch, parameter: %s, error: %v", "user_id", err)
+			return
+		}
+		if userID == 0 {
+			// id 0 parses but is the proto zero value. Frozen.
+			writeError(w, r, codeInvalidArgument, "no username or user ID provided")
+			return
+		}
+		profiles, err := ds.FindProfilesById(userID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				writeError(w, r, codeNotFound, "no profile found for user ID: %d", userID)
+				return
+			}
+			writeError(w, r, codeInternal, "fetch profile by user id: %v", err)
+			return
+		}
+		writeProfile(w, r, profiles[0])
+	})
+}
+
+// writeProfile maps one datastore profile to the wire type and writes it.
+func writeProfile(w http.ResponseWriter, r *http.Request, p *proto.Profile) {
+	writeJSON(w, r, profileFromProto(p))
+}
+
+// profileFromProto maps the datastore's proto-typed profile to the wire type.
+// Allocation discipline: collections are always allocated ([] on the wire,
+// never null); unset nested messages stay nil (null on the wire). keycloakId
+// is dropped here — the wire type never had the field (documented break).
+func profileFromProto(p *proto.Profile) *types.Profile {
+	out := &types.Profile{
+		RealName:          p.GetRealName(),
+		UniformUrl:        p.GetUniformUrl(),
+		Roster:            types.RosterType(p.GetRoster()),
+		Secondaries:       make([]*types.Position, 0, len(p.GetSecondaries())),
+		Records:           make([]*types.Record, 0, len(p.GetRecords())),
+		Awards:            make([]*types.Award, 0, len(p.GetAwards())),
+		JoinDate:          p.GetJoinDate(),
+		PromotionDate:     p.GetPromotionDate(),
+		DiscordId:         p.GetDiscordId(),
+		LastForumPostDate: p.GetLastForumPostDate(),
+		Mos:               p.GetMos(),
+		ConsoleGamertag:   p.GetConsoleGamertag(),
+	}
+	if u := p.GetUser(); u != nil {
+		out.User = &types.User{UserId: u.GetUserId(), Username: u.GetUsername()}
+	}
+	if rk := p.GetRank(); rk != nil {
+		out.Rank = &types.Rank{
+			RankShort:    rk.GetRankShort(),
+			RankFull:     rk.GetRankFull(),
+			RankImageUrl: rk.GetRankImageUrl(),
+			RankId:       rk.GetRankId(),
+		}
+	}
+	out.Primary = positionFromProto(p.GetPrimary())
+	for _, s := range p.GetSecondaries() {
+		out.Secondaries = append(out.Secondaries, positionFromProto(s))
+	}
+	for _, rec := range p.GetRecords() {
+		out.Records = append(out.Records, &types.Record{
+			RecordDetails: rec.GetRecordDetails(),
+			RecordType:    types.RecordType(rec.GetRecordType()),
+			RecordDate:    rec.GetRecordDate(),
+			RecordUid:     rec.GetRecordUid(),
+		})
+	}
+	for _, a := range p.GetAwards() {
+		out.Awards = append(out.Awards, &types.Award{
+			AwardDetails:  a.GetAwardDetails(),
+			AwardName:     a.GetAwardName(),
+			AwardDate:     a.GetAwardDate(),
+			AwardImageUrl: a.GetAwardImageUrl(),
+			AwardUid:      a.GetAwardUid(),
+		})
+	}
+	return out
+}
+
+// positionFromProto maps a position, preserving nil (null on the wire).
+func positionFromProto(p *proto.Position) *types.Position {
+	if p == nil {
+		return nil
+	}
+	return &types.Position{PositionTitle: p.GetPositionTitle(), PositionId: p.GetPositionId()}
 }
 
 // ranksFromProto maps the datastore's proto-typed rows to the wire types.

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -100,6 +100,52 @@ func getProfileByUsername(ds datastores.Datastore) http.Handler {
 	})
 }
 
+// getProfileByDiscordID serves GET /api/v1/milpac/discord/{discord_id}
+// (singular "milpac" — the historical path, frozen): the full profile looked
+// up by Discord snowflake. Error message strings frozen from the old handler
+// (servers/grpc GetUserViaDiscordId). DiscordIdRequest's only field is
+// path-bound, so nothing is query-bindable here; the old handler's
+// empty-value guard is unreachable through the mux (an empty segment never
+// matches the pattern).
+func getProfileByDiscordID(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		discordID := r.PathValue("discord_id")
+		profile, err := ds.FindProfileByDiscordID(discordID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				writeError(w, r, codeNotFound, "no user found for discordid: %s", discordID)
+				return
+			}
+			writeError(w, r, codeInternal, "fetch profile by discord id: %v", err)
+			return
+		}
+		writeProfile(w, r, profile)
+	})
+}
+
+// getProfileByGamertag serves GET /api/v1/milpac/gamertag/{gamertag}: the
+// full profile looked up by console gamertag. Error message strings frozen
+// from the old handler (servers/grpc GetGamertagProfile — note its NotFound
+// formats the gamertag with %v where the discord handler uses %s; identical
+// output for strings, kept verbatim anyway). Single path-bound field, so
+// nothing is query-bindable; the empty-value guard is unreachable through
+// the mux.
+func getProfileByGamertag(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gamertag := r.PathValue("gamertag")
+		profile, err := ds.FindProfileByGamertag(gamertag)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				writeError(w, r, codeNotFound, "no user found for gamertag: %v", gamertag)
+				return
+			}
+			writeError(w, r, codeInternal, "fetch profile by gamertag: %v", err)
+			return
+		}
+		writeProfile(w, r, profile)
+	})
+}
+
 // serveProfileByUsername is the shared username lookup: the by-username
 // route's body, and the by-id route's username-query override path.
 func serveProfileByUsername(w http.ResponseWriter, r *http.Request, ds datastores.Datastore, username string) {

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -45,7 +45,14 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Path binding first, query binding second — gateway order: a
 		// malformed path id 400s even when a username query is present.
-		userID, err := strconv.ParseUint(r.PathValue("user_id"), 10, 64)
+		//
+		// BASE 0, not 10 — the gateway's runtime.Uint64 was
+		// strconv.ParseUint(val, 0, 64) (grpc-gateway v2.29.0
+		// runtime/convert.go), so the path id inherits Go integer-literal
+		// parsing: 0x1 is hex 1, 010 is OCTAL 8 (a wrong-profile hazard if
+		// parsed base 10), 0b1 is binary 1, 1_0 is 10, and 09 is invalid
+		// syntax (octal with a 9). Frozen as-is (PRD #112 leniency tier).
+		userID, err := strconv.ParseUint(r.PathValue("user_id"), 0, 64)
 		if err != nil {
 			// Gateway type-mismatch tier, parse-error text leaked. Frozen.
 			writeError(w, r, codeInvalidArgument, "type mismatch, parameter: %s, error: %v", "user_id", err)

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -87,6 +87,13 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 			writeError(w, r, codeInternal, "fetch profile by user id: %v", err)
 			return
 		}
+		if len(profiles) == 0 {
+			// Datastore invariant violated (non-empty slice on nil error —
+			// see datastores.Datastore): unreachable through the real
+			// datastore, guarded so a future bug is a clean 500, not a panic.
+			writeError(w, r, codeInternal, "datastore returned no profiles")
+			return
+		}
 		writeProfile(w, r, profiles[0])
 	})
 }
@@ -188,6 +195,13 @@ func serveProfileByUsername(w http.ResponseWriter, r *http.Request, ds datastore
 		writeError(w, r, codeInternal, "fetch profile by username: %v", err)
 		return
 	}
+	if len(profiles) == 0 {
+		// Datastore invariant violated (non-empty slice on nil error — see
+		// datastores.Datastore): unreachable through the real datastore,
+		// guarded so a future bug is a clean 500, not a panic.
+		writeError(w, r, codeInternal, "datastore returned no profiles")
+		return
+	}
 	writeProfile(w, r, profiles[0])
 }
 
@@ -239,8 +253,15 @@ func queryField(r *http.Request, protoName, jsonName string) (vals []string, err
 	return vals, nil
 }
 
-// writeProfile maps one datastore profile to the wire type and writes it.
+// writeProfile maps one datastore profile to the wire type and writes it. A
+// nil profile with no error is a datastore-invariant violation (unreachable
+// through the real datastore): a clean 500, not a fabricated sparse 200 —
+// the proto getters would happily marshal a zero-value profile.
 func writeProfile(w http.ResponseWriter, r *http.Request, p *proto.Profile) {
+	if p == nil {
+		writeError(w, r, codeInternal, "datastore returned no profile")
+		return
+	}
 	writeJSON(w, r, profileFromProto(p))
 }
 

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -37,8 +37,10 @@ func getAllRanks(ds datastores.Datastore) http.Handler {
 //
 // Binding quirk (PRD request-side leniency, frozen): username — the
 // ProfileRequest field the path does NOT bind — remains query-bindable, and
-// the old handler checked username BEFORE user_id, so a username query
-// overrides the path id entirely (including the zero-id guard).
+// the old handler checked username BEFORE user_id, so a NON-EMPTY username
+// query overrides the path id entirely (including the zero-id guard). A
+// present-but-empty ?username= does not override: the gateway bound "" and
+// the old handler treated "" as unset.
 func getProfileByID(ds datastores.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Path binding first, query binding second — gateway order: a
@@ -53,11 +55,16 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
 		}
-		username, err := queryField(r, "username", "username")
+		username, _, err := queryField(r, "username", "username")
 		if err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
 		}
+		// Non-empty, not merely present: username is a STRING field, so the
+		// gateway bound a present-but-empty value as "" without error, and the
+		// old handler treated "" as unset — ?username= falls through to the
+		// path id (the asymmetry with the numeric user_id binding, where
+		// present-empty 400s in the parser).
 		if username != "" {
 			serveProfileByUsername(w, r, ds, username)
 			return
@@ -85,19 +92,23 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 // the old handler (servers/grpc GetProfile, username branch).
 //
 // Binding quirk (PRD request-side leniency, frozen): user_id remains
-// query-bindable here — the value still parses (a malformed one 400s, as the
-// gateway did before the handler ran) but the handler's username-first
-// precedence makes a valid one invisible.
+// query-bindable here — every PRESENT value still parses (a malformed OR
+// EMPTY one 400s, as the gateway did before the handler ran: no empty-value
+// guard in runtime/query.go) but the handler's username-first precedence
+// makes a valid one invisible.
 func getProfileByUsername(ds datastores.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := checkQuerySyntax(r); err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
 		}
-		if raw, err := queryField(r, "user_id", "userId"); err != nil {
+		if raw, present, err := queryField(r, "user_id", "userId"); err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
-		} else if raw != "" {
+		} else if present {
+			// PRESENT, not non-empty: the gateway parsed every present value
+			// (no empty-value guard in runtime/query.go), so ?user_id= is a
+			// 400 — "" fails ParseUint exactly as it did then.
 			if _, err := strconv.ParseUint(raw, 10, 64); err != nil {
 				// Gateway query-binding parse error, text frozen from
 				// grpc-gateway runtime (populateField).
@@ -187,10 +198,13 @@ func checkQuerySyntax(r *http.Request) error {
 
 // queryField reads a singular query-bindable message field, accepting both
 // the proto (snake_case) and JSON (camelCase) key spellings — the gateway's
-// dual-spelling leniency (PRD-frozen). Absent → "". Repeated values on a
-// singular field are an error with the gateway's message shape; the proto
-// field name is the one error messages cite.
-func queryField(r *http.Request, protoName, jsonName string) (string, error) {
+// dual-spelling leniency (PRD-frozen). present reports whether the key
+// appeared at all: the gateway parsed every PRESENT value (runtime/query.go
+// has no empty-value guard), so a present-but-empty numeric field must still
+// reach the parser — present and non-empty are distinct states. Repeated
+// values on a singular field are an error with the gateway's message shape;
+// the proto field name is the one error messages cite.
+func queryField(r *http.Request, protoName, jsonName string) (value string, present bool, err error) {
 	q := r.URL.Query()
 	vals := q[protoName]
 	if jsonName != protoName {
@@ -198,11 +212,11 @@ func queryField(r *http.Request, protoName, jsonName string) (string, error) {
 	}
 	switch len(vals) {
 	case 0:
-		return "", nil
+		return "", false, nil
 	case 1:
-		return vals[0], nil
+		return vals[0], true, nil
 	default:
-		return "", fmt.Errorf("too many values for field %q: %s", protoName, strings.Join(vals, ", "))
+		return "", true, fmt.Errorf("too many values for field %q: %s", protoName, strings.Join(vals, ", "))
 	}
 }
 

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -55,10 +55,14 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
 		}
-		username, _, err := queryField(r, "username", "username")
+		usernameVals, err := queryField(r, "username", "username")
 		if err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
+		}
+		username := ""
+		if len(usernameVals) > 0 {
+			username = usernameVals[len(usernameVals)-1]
 		}
 		// Non-empty, not merely present: username is a STRING field, so the
 		// gateway bound a present-but-empty value as "" without error, and the
@@ -102,13 +106,19 @@ func getProfileByUsername(ds datastores.Datastore) http.Handler {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
 		}
-		if raw, present, err := queryField(r, "user_id", "userId"); err != nil {
+		userIDVals, err := queryField(r, "user_id", "userId")
+		if err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
-		} else if present {
-			// PRESENT, not non-empty: the gateway parsed every present value
-			// (no empty-value guard in runtime/query.go), so ?user_id= is a
-			// 400 — "" fails ParseUint exactly as it did then.
+		}
+		// Parse EVERY present value — both spellings, including "" (the
+		// gateway had no empty-value guard, so ?user_id= is a 400). A bad
+		// value always errored in the old gateway regardless of map order;
+		// the snake-spelling value parsing first here is the deterministic
+		// stand-in. When all parse, the last (camelCase) value is the bound
+		// one — a RULING (see queryField), invisible anyway under the
+		// handler's username-first precedence.
+		for _, raw := range userIDVals {
 			if _, err := strconv.ParseUint(raw, 10, 64); err != nil {
 				// Gateway query-binding parse error, text frozen from
 				// grpc-gateway runtime (populateField).
@@ -198,26 +208,35 @@ func checkQuerySyntax(r *http.Request) error {
 
 // queryField reads a singular query-bindable message field, accepting both
 // the proto (snake_case) and JSON (camelCase) key spellings — the gateway's
-// dual-spelling leniency (PRD-frozen). present reports whether the key
-// appeared at all: the gateway parsed every PRESENT value (runtime/query.go
-// has no empty-value guard), so a present-but-empty numeric field must still
-// reach the parser — present and non-empty are distinct states. Repeated
-// values on a singular field are an error with the gateway's message shape;
-// the proto field name is the one error messages cite.
-func queryField(r *http.Request, protoName, jsonName string) (value string, present bool, err error) {
+// dual-spelling leniency (PRD-frozen). It returns every present value, one
+// per spelling, because the gateway processed each url.Values KEY
+// independently: each value parsed, each set the field, no cross-spelling
+// error. The proto field name is the one error messages cite (the gateway
+// cited fieldDescriptor.FullName().Name() whatever the key spelling).
+//
+//   - len(vals) == 0: field absent. Present-but-EMPTY is NOT absent — the
+//     gateway parsed every present value (no empty-value guard in
+//     runtime/query.go), so "" still reaches the caller's parser.
+//   - Repetition under ONE key errors with the gateway's deterministic
+//     "too many values" shape (per-key check, that key's values joined).
+//   - Order is deterministic: snake-spelling value first, camelCase last —
+//     so a caller binding last-value-wins lands on the camelCase value. That
+//     precedence is a RULING (converged with #129's query binder), standing
+//     in for the old gateway's map-iteration nondeterminism, not parity.
+func queryField(r *http.Request, protoName, jsonName string) (vals []string, err error) {
 	q := r.URL.Query()
-	vals := q[protoName]
+	keys := []string{protoName}
 	if jsonName != protoName {
-		vals = append(vals, q[jsonName]...)
+		keys = append(keys, jsonName)
 	}
-	switch len(vals) {
-	case 0:
-		return "", false, nil
-	case 1:
-		return vals[0], true, nil
-	default:
-		return "", true, fmt.Errorf("too many values for field %q: %s", protoName, strings.Join(vals, ", "))
+	for _, key := range keys {
+		kv := q[key]
+		if len(kv) > 1 {
+			return nil, fmt.Errorf("too many values for field %q: %s", protoName, strings.Join(kv, ", "))
+		}
+		vals = append(vals, kv...)
 	}
+	return vals, nil
 }
 
 // writeProfile maps one datastore profile to the wire type and writes it.

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -48,6 +49,10 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 			writeError(w, r, codeInvalidArgument, "type mismatch, parameter: %s, error: %v", "user_id", err)
 			return
 		}
+		if err := checkQuerySyntax(r); err != nil {
+			writeError(w, r, codeInvalidArgument, "%v", err)
+			return
+		}
 		username, err := queryField(r, "username", "username")
 		if err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
@@ -85,6 +90,10 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 // precedence makes a valid one invisible.
 func getProfileByUsername(ds datastores.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := checkQuerySyntax(r); err != nil {
+			writeError(w, r, codeInvalidArgument, "%v", err)
+			return
+		}
 		if raw, err := queryField(r, "user_id", "userId"); err != nil {
 			writeError(w, r, codeInvalidArgument, "%v", err)
 			return
@@ -159,6 +168,21 @@ func serveProfileByUsername(w http.ResponseWriter, r *http.Request, ds datastore
 		return
 	}
 	writeProfile(w, r, profiles[0])
+}
+
+// checkQuerySyntax rejects malformed query-string SYNTAX on the two profile
+// routes whose old generated gateway handlers called req.ParseForm() and 400'd
+// on its error (request_MilpacService_GetProfile_0/_1 in proto/milpacs.pb.gw.go,
+// wrapped as InvalidArgument "%v" — text leaked verbatim, e.g. `invalid URL
+// escape "%zz"`, `invalid semicolon separator in query`). The error fired even
+// when the malformed pair was an unknown parameter, BEFORE field filtering.
+// r.URL.Query() would silently drop bad pairs, so the parse is explicit.
+//
+// SCOPE: the discord and gamertag routes must NOT call this — their generated
+// handlers never called ParseForm (single path-bound field, no query binding).
+func checkQuerySyntax(r *http.Request) error {
+	_, err := url.ParseQuery(r.URL.RawQuery)
+	return err
 }
 
 // queryField reads a singular query-bindable message field, accepting both

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -227,6 +229,15 @@ func checkQuerySyntax(r *http.Request) error {
 	return err
 }
 
+// bracketKeyRegexp is the old gateway's bracket-key rewrite, mirrored exactly
+// (grpc-gateway v2.29.0 runtime/query.go valuesKeyRegexp): a query key
+// matching ^(.*)\[(.*)\]$ folds into its base key (match 1) with the bracket
+// CONTENT (match 2) PREPENDED as an extra value — ?user_id[0]=1 is key
+// "user_id", values ["0","1"]. The content is a VALUE, never an index, so a
+// matching bracket key on these singular fields is always the too-many-values
+// 400. Greedy: a[b][c] folds to base "a[b]" — matching no field, ignored.
+var bracketKeyRegexp = regexp.MustCompile(`^(.*)\[(.*)\]$`)
+
 // queryField reads a singular query-bindable message field, accepting both
 // the proto (snake_case) and JSON (camelCase) key spellings — the gateway's
 // dual-spelling leniency (PRD-frozen). It returns every present value, one
@@ -240,18 +251,36 @@ func checkQuerySyntax(r *http.Request) error {
 //     runtime/query.go), so "" still reaches the caller's parser.
 //   - Repetition under ONE key errors with the gateway's deterministic
 //     "too many values" shape (per-key check, that key's values joined).
-//   - Order is deterministic: snake-spelling value first, camelCase last —
-//     so a caller binding last-value-wins lands on the camelCase value. That
-//     precedence is a RULING (converged with #129's query binder), standing
-//     in for the old gateway's map-iteration nondeterminism, not parity.
+//   - Bracket keys whose base (bracketKeyRegexp match 1) is either spelling
+//     FOLD into the field as their own per-key group, bracket content first —
+//     the gateway rewrote the key before binding, and resolved the rewritten
+//     key by text name AND JSON name, so both spellings fold. The fold always
+//     carries ≥2 values on a singular field → the too-many-values 400,
+//     quoting the folded group. Non-matching bracket keys are just unknown
+//     parameters — ignored.
+//   - Order is deterministic: snake-spelling value first, camelCase next,
+//     bracket groups last sorted by raw key — so a caller binding
+//     last-value-wins lands on the camelCase value. That precedence is a
+//     RULING (converged with #129's query binder), standing in for the old
+//     gateway's map-iteration nondeterminism, not parity.
 func queryField(r *http.Request, protoName, jsonName string) (vals []string, err error) {
 	q := r.URL.Query()
-	keys := []string{protoName}
+	groups := [][]string{q[protoName]}
 	if jsonName != protoName {
-		keys = append(keys, jsonName)
+		groups = append(groups, q[jsonName])
 	}
-	for _, key := range keys {
-		kv := q[key]
+	var bracketKeys []string
+	for key := range q {
+		if m := bracketKeyRegexp.FindStringSubmatch(key); len(m) == 3 && (m[1] == protoName || m[1] == jsonName) {
+			bracketKeys = append(bracketKeys, key)
+		}
+	}
+	sort.Strings(bracketKeys)
+	for _, key := range bracketKeys {
+		m := bracketKeyRegexp.FindStringSubmatch(key)
+		groups = append(groups, append([]string{m[2]}, q[key]...))
+	}
+	for _, kv := range groups {
 		if len(kv) > 1 {
 			return nil, fmt.Errorf("too many values for field %q: %s", protoName, strings.Join(kv, ", "))
 		}

--- a/rest/milpacs.go
+++ b/rest/milpacs.go
@@ -2,8 +2,10 @@ package rest
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/7cav/api/datastores"
 	"github.com/7cav/api/proto"
@@ -31,12 +33,28 @@ func getAllRanks(ds datastores.Datastore) http.Handler {
 // profile_by_id_happy golden proves relation wins). Error message strings
 // frozen from the old stack (servers/grpc GetProfile + the gateway's
 // type-mismatch text).
+//
+// Binding quirk (PRD request-side leniency, frozen): username — the
+// ProfileRequest field the path does NOT bind — remains query-bindable, and
+// the old handler checked username BEFORE user_id, so a username query
+// overrides the path id entirely (including the zero-id guard).
 func getProfileByID(ds datastores.Datastore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path binding first, query binding second — gateway order: a
+		// malformed path id 400s even when a username query is present.
 		userID, err := strconv.ParseUint(r.PathValue("user_id"), 10, 64)
 		if err != nil {
 			// Gateway type-mismatch tier, parse-error text leaked. Frozen.
 			writeError(w, r, codeInvalidArgument, "type mismatch, parameter: %s, error: %v", "user_id", err)
+			return
+		}
+		username, err := queryField(r, "username", "username")
+		if err != nil {
+			writeError(w, r, codeInvalidArgument, "%v", err)
+			return
+		}
+		if username != "" {
+			serveProfileByUsername(w, r, ds, username)
 			return
 		}
 		if userID == 0 {
@@ -55,6 +73,67 @@ func getProfileByID(ds datastores.Datastore) http.Handler {
 		}
 		writeProfile(w, r, profiles[0])
 	})
+}
+
+// getProfileByUsername serves GET /api/v1/milpacs/profile/username/{username}:
+// the username binding of the same lookup. Error message strings frozen from
+// the old handler (servers/grpc GetProfile, username branch).
+//
+// Binding quirk (PRD request-side leniency, frozen): user_id remains
+// query-bindable here — the value still parses (a malformed one 400s, as the
+// gateway did before the handler ran) but the handler's username-first
+// precedence makes a valid one invisible.
+func getProfileByUsername(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if raw, err := queryField(r, "user_id", "userId"); err != nil {
+			writeError(w, r, codeInvalidArgument, "%v", err)
+			return
+		} else if raw != "" {
+			if _, err := strconv.ParseUint(raw, 10, 64); err != nil {
+				// Gateway query-binding parse error, text frozen from
+				// grpc-gateway runtime (populateField).
+				writeError(w, r, codeInvalidArgument, "parsing field %q: %v", "user_id", err)
+				return
+			}
+		}
+		serveProfileByUsername(w, r, ds, r.PathValue("username"))
+	})
+}
+
+// serveProfileByUsername is the shared username lookup: the by-username
+// route's body, and the by-id route's username-query override path.
+func serveProfileByUsername(w http.ResponseWriter, r *http.Request, ds datastores.Datastore, username string) {
+	profiles, err := ds.FindProfilesByUsername(username)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			writeError(w, r, codeNotFound, "no profile found for username: %s", username)
+			return
+		}
+		writeError(w, r, codeInternal, "fetch profile by username: %v", err)
+		return
+	}
+	writeProfile(w, r, profiles[0])
+}
+
+// queryField reads a singular query-bindable message field, accepting both
+// the proto (snake_case) and JSON (camelCase) key spellings — the gateway's
+// dual-spelling leniency (PRD-frozen). Absent → "". Repeated values on a
+// singular field are an error with the gateway's message shape; the proto
+// field name is the one error messages cite.
+func queryField(r *http.Request, protoName, jsonName string) (string, error) {
+	q := r.URL.Query()
+	vals := q[protoName]
+	if jsonName != protoName {
+		vals = append(vals, q[jsonName]...)
+	}
+	switch len(vals) {
+	case 0:
+		return "", nil
+	case 1:
+		return vals[0], nil
+	default:
+		return "", fmt.Errorf("too many values for field %q: %s", protoName, strings.Join(vals, ", "))
+	}
 }
 
 // writeProfile maps one datastore profile to the wire type and writes it.

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -85,6 +85,7 @@ func routes(ds datastores.Datastore) *http.ServeMux {
 
 	// --- milpacs (scope: read) -------------------------------------------
 	handle(mux, "GET /api/v1/milpacs/ranks", "read", getAllRanks(ds))
+	handle(mux, "GET /api/v1/milpacs/profile/id/{user_id}", "read", getProfileByID(ds))
 
 	mux.HandleFunc("/", fallback(mux))
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -87,6 +87,10 @@ func routes(ds datastores.Datastore) *http.ServeMux {
 	handle(mux, "GET /api/v1/milpacs/ranks", "read", getAllRanks(ds))
 	handle(mux, "GET /api/v1/milpacs/profile/id/{user_id}", "read", getProfileByID(ds))
 	handle(mux, "GET /api/v1/milpacs/profile/username/{username}", "read", getProfileByUsername(ds))
+	// Historical path prefix: singular "milpac" on the connected-account
+	// lookups, plural "milpacs" everywhere else. Frozen by the corpus.
+	handle(mux, "GET /api/v1/milpac/discord/{discord_id}", "read", getProfileByDiscordID(ds))
+	handle(mux, "GET /api/v1/milpac/gamertag/{gamertag}", "read", getProfileByGamertag(ds))
 
 	mux.HandleFunc("/", fallback(mux))
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -86,6 +86,7 @@ func routes(ds datastores.Datastore) *http.ServeMux {
 	// --- milpacs (scope: read) -------------------------------------------
 	handle(mux, "GET /api/v1/milpacs/ranks", "read", getAllRanks(ds))
 	handle(mux, "GET /api/v1/milpacs/profile/id/{user_id}", "read", getProfileByID(ds))
+	handle(mux, "GET /api/v1/milpacs/profile/username/{username}", "read", getProfileByUsername(ds))
 
 	mux.HandleFunc("/", fallback(mux))
 

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -782,6 +782,67 @@ func TestNewStack_ConnectedAccountRoutes_MalformedQuerySyntaxIgnored(t *testing.
 	}
 }
 
+// --- Path-id parse base (gateway base-0 quirk, frozen) ----------------------
+//
+// The old gateway's runtime.Uint64 is strconv.ParseUint(val, 0, 64) — BASE 0
+// (grpc-gateway v2.29.0 runtime/convert.go), so the path id accepts Go
+// integer-literal prefixes (0x hex, 0b binary, leading-0 octal) and digit
+// underscores. Verified against the real old stack in-process: /profile/id/0x1
+// resolved relation 1, /profile/id/010 resolved relation EIGHT (octal!),
+// /profile/id/09 was a 400 (octal with a 9 — invalid syntax), /profile/id/1_0
+// resolved relation 10. Wrong-profile-resolution risk if the new stack parses
+// base 10; frozen as-is, base 0.
+//
+// The not-found message names the PARSED number, not the raw path text — the
+// old handler built it from the already-bound request field.
+func TestNewStack_ByIdRoute_PathIdParsesBaseZero(t *testing.T) {
+	h := newStack(t)
+
+	cases := []struct {
+		name     string
+		path     string
+		wantCode int
+		check    func(t *testing.T, body string)
+	}{
+		{"hex_0x1_resolves_relation_1", "/api/v1/milpacs/profile/id/0x1", http.StatusOK,
+			func(t *testing.T, body string) {
+				assert.Contains(t, body, `"username":"Jarvis.A"`)
+				assert.Contains(t, body, `"userId":"3"`)
+			}},
+		{"binary_0b1_resolves_relation_1", "/api/v1/milpacs/profile/id/0b1", http.StatusOK,
+			func(t *testing.T, body string) {
+				assert.Contains(t, body, `"username":"Jarvis.A"`)
+			}},
+		{"octal_010_is_relation_8", "/api/v1/milpacs/profile/id/010", http.StatusNotFound,
+			func(t *testing.T, body string) {
+				// The fake seeds no relation 8: the not-found shape naming the
+				// PARSED number 8 (not 10, not "010") proves base-0 + the
+				// parsed-value message in one observation.
+				assert.JSONEq(t, `{"code":5,"message":"no profile found for user ID: 8","details":[]}`, body)
+			}},
+		{"underscore_1_0_is_relation_10", "/api/v1/milpacs/profile/id/1_0", http.StatusNotFound,
+			func(t *testing.T, body string) {
+				assert.JSONEq(t, `{"code":5,"message":"no profile found for user ID: 10","details":[]}`, body)
+			}},
+		{"octal_09_is_invalid_syntax_400", "/api/v1/milpacs/profile/id/09", http.StatusBadRequest,
+			func(t *testing.T, body string) {
+				// Base 0 reads the leading 0 as octal; 9 is no octal digit.
+				assert.JSONEq(t, `{"code":3,"message":"type mismatch, parameter: user_id, error: strconv.ParseUint: parsing \"09\": invalid syntax","details":[]}`, body)
+			}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.wantCode, rr.Code)
+			tc.check(t, rr.Body.String())
+		})
+	}
+}
+
 // Path parse precedes the username-override: a malformed path id 400s with
 // the gateway's type-mismatch tier even when a valid ?username= is present —
 // the generated handler parsed pathParams before ParseForm/query binding.

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -2,6 +2,7 @@ package rest_test
 
 import (
 	"compress/gzip"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/7cav/api/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 const goldensDir = "../contract/goldens"
@@ -27,12 +29,15 @@ func init() {
 
 // fakeDatastore seeds the new stack for golden replay. It must agree with
 // the recording seed (contract/fake_datastore_test.go) for everything the
-// implemented routes serve: the battery's bearer tokens and the two-rank
-// catalog. Unimplemented methods panic via the embedded nil interface — a
-// loud failure if a test reaches further than the routes it mounts.
+// implemented routes serve: the battery's bearer tokens, the two-rank
+// catalog, and the two seed profiles (relation 1 ↔ user 3 Jarvis.A, relation
+// 2 ↔ user 8 John.Doe — the divergence keeps the relation-key semantic
+// observable). Unimplemented methods panic via the embedded nil interface —
+// a loud failure if a test reaches further than the routes it mounts.
 type fakeDatastore struct {
 	datastores.Datastore
-	findAllRanks func() ([]*proto.RankExpanded, error)
+	findAllRanks     func() ([]*proto.RankExpanded, error)
+	findProfilesById func(userIds ...uint64) ([]*proto.Profile, error)
 }
 
 func (f *fakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
@@ -65,6 +70,102 @@ func (f *fakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error) {
 	}, nil
 }
 
+// errOutage is the injected failure for the Internal-error goldens: the
+// message leaks into the response body via the handlers' error wrapping —
+// that leak is frozen behavior (mirrors the recording seed's errOutage).
+var errOutage = errors.New("simulated datastore outage")
+
+// seedJarvis mirrors the recording seed's rich profile: every collection
+// populated, relation 1 ↔ user 3. KeycloakId is deliberately set — the
+// corpus transform stripped it from the goldens, so the mapper dropping it
+// is observable in the replay.
+func seedJarvis() *proto.Profile {
+	return &proto.Profile{
+		User: &proto.User{UserId: 3, Username: "Jarvis.A"},
+		Rank: &proto.Rank{
+			RankShort:    "MG",
+			RankFull:     "Major General",
+			RankImageUrl: "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618",
+			RankId:       4,
+		},
+		RealName:   "Adam Jarvis",
+		UniformUrl: "https://7cav.us/data/roster_uniforms/0/1.jpg",
+		Roster:     proto.RosterType_ROSTER_TYPE_COMBAT,
+		Primary:    &proto.Position{PositionTitle: "Regimental Technical Aide", PositionId: 773},
+		Secondaries: []*proto.Position{
+			{PositionTitle: "S6 Web Developer", PositionId: 812},
+		},
+		Records: []*proto.Record{
+			{
+				RecordDetails: "Promoted to Major General (O-8)",
+				RecordType:    proto.RecordType_RECORD_TYPE_PROMOTION,
+				RecordDate:    "2020-10-17",
+				RecordUid:     46,
+			},
+			{
+				RecordDetails: "Completed 18th Combat Mission (Operation Pride of Charlie, Fall 2020)",
+				RecordType:    proto.RecordType_RECORD_TYPE_OPERATION,
+				RecordDate:    "2020-09-27",
+				RecordUid:     13863,
+			},
+		},
+		Awards: []*proto.Award{
+			{
+				AwardDetails:  "For technical excellence & dedication <est. 2014>",
+				AwardName:     "Commendation Medal",
+				AwardDate:     "2021-03-01",
+				AwardImageUrl: "https://7cav.us/data/awards/ccm.jpg",
+				AwardUid:      901,
+			},
+		},
+		JoinDate:          "2014-02-08",
+		PromotionDate:     "2020-10-17",
+		KeycloakId:        "3f8e2a10-dead-beef-cafe-0123456789ab",
+		DiscordId:         "112233445566778899",
+		LastForumPostDate: "2026-05-30",
+		Mos:               "11B",
+		ConsoleGamertag:   "",
+	}
+}
+
+// seedDoe mirrors the recording seed's sparse profile: unset nested messages
+// nil (null on the wire), collections empty ([]), strings "". Relation 2 ↔
+// user 8.
+func seedDoe() *proto.Profile {
+	return &proto.Profile{
+		User:            &proto.User{UserId: 8, Username: "John.Doe"},
+		Rank:            &proto.Rank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "https://7cav.us/data/roster_ranks/0/22.jpg", RankId: 22},
+		RealName:        "John Doe",
+		UniformUrl:      "https://7cav.us/data/roster_uniforms/0/2.jpg",
+		Roster:          proto.RosterType_ROSTER_TYPE_COMBAT,
+		Primary:         nil, // → "primary": null
+		Secondaries:     []*proto.Position{},
+		Records:         []*proto.Record{},
+		Awards:          []*proto.Award{},
+		JoinDate:        "2026-01-15",
+		ConsoleGamertag: "CavGamer77",
+	}
+}
+
+// FindProfilesById keys on the MILPAC RELATION ID, mirroring the recording
+// seed (and datastores.Mysql: gorm First keys on the milpacs.Profile primary
+// key = relation_id). 777 is the injected-outage id for the 500 golden.
+func (f *fakeDatastore) FindProfilesById(userIds ...uint64) ([]*proto.Profile, error) {
+	if f.findProfilesById != nil {
+		return f.findProfilesById(userIds...)
+	}
+	switch userIds[0] {
+	case 1:
+		return []*proto.Profile{seedJarvis()}, nil
+	case 2:
+		return []*proto.Profile{seedDoe()}, nil
+	case 777:
+		return nil, errOutage
+	default:
+		return nil, gorm.ErrRecordNotFound
+	}
+}
+
 func newStack(t *testing.T) http.Handler {
 	t.Helper()
 	return rest.New(&fakeDatastore{})
@@ -79,9 +180,19 @@ func newStack(t *testing.T) http.Handler {
 // including ones whose routes don't exist yet.
 var implementedCases = []string{
 	"milpacs/ranks",
+	"milpacs/profile_by_id_happy",
+	"milpacs/profile_by_id_sparse",
+	"milpacs/profile_by_id_not_found",
+	"milpacs/profile_by_id_zero",
+	"milpacs/profile_by_id_parse_error",
+	"milpacs/profile_by_id_internal_error",
 	"auth/milpacs_missing_header",
 	"auth/milpacs_raw_key",
 	"auth/milpacs_invalid_key",
+	// The 403 scope tier needs a real route to reach (requireScope is
+	// per-route, inside the mux) — reachable since the profile-by-id slice.
+	"auth/milpacs_wrong_scope",
+	"auth/milpacs_no_scopes",
 	"auth/tickets_missing_header",
 	"auth/tickets_raw_key",
 	"auth/tickets_invalid_key",

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -441,6 +441,58 @@ func TestNewStack_ProfileLookupOutagesAreInternalJSON(t *testing.T) {
 	}
 }
 
+// A datastore returning an EMPTY slice (or nil profile) with a nil error
+// violates the documented invariant (non-empty slice on nil error) — possible
+// only from a future datastore bug, never the real one, so no golden can
+// witness it. It must surface as the frozen Internal shape, not a panic or a
+// fabricated sparse 200.
+func TestNewStack_EmptyProfileSliceWithNilErrorIsInternalJSON(t *testing.T) {
+	h := rest.New(&fakeDatastore{
+		findProfilesById:       func(...uint64) ([]*proto.Profile, error) { return []*proto.Profile{}, nil },
+		findProfilesByUsername: func(string) ([]*proto.Profile, error) { return nil, nil },
+	})
+
+	for _, path := range []string{
+		"/api/v1/milpacs/profile/id/1",
+		"/api/v1/milpacs/profile/username/Jarvis.A",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.JSONEq(t, `{"code":13,"message":"datastore returned no profiles","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+func TestNewStack_NilProfileWithNilErrorIsInternalJSON(t *testing.T) {
+	h := rest.New(&fakeDatastore{
+		findProfileByDiscordID: func(string) (*proto.Profile, error) { return nil, nil },
+		findProfileByGamertag:  func(string) (*proto.Profile, error) { return nil, nil },
+		// A non-empty slice carrying a nil element hits the same guard.
+		findProfilesById: func(...uint64) ([]*proto.Profile, error) { return []*proto.Profile{nil}, nil },
+	})
+
+	for _, path := range []string{
+		"/api/v1/milpac/discord/112233445566778899",
+		"/api/v1/milpac/gamertag/CavGamer77",
+		"/api/v1/milpacs/profile/id/1",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.JSONEq(t, `{"code":13,"message":"datastore returned no profile","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
 // --- Profile query-binding quirks (PRD #112, request-side leniency) --------
 //
 // Unbound message fields remain query-bindable on profile routes: the old

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -36,8 +36,9 @@ func init() {
 // a loud failure if a test reaches further than the routes it mounts.
 type fakeDatastore struct {
 	datastores.Datastore
-	findAllRanks     func() ([]*proto.RankExpanded, error)
-	findProfilesById func(userIds ...uint64) ([]*proto.Profile, error)
+	findAllRanks           func() ([]*proto.RankExpanded, error)
+	findProfilesById       func(userIds ...uint64) ([]*proto.Profile, error)
+	findProfilesByUsername func(username string) ([]*proto.Profile, error)
 }
 
 func (f *fakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
@@ -166,6 +167,20 @@ func (f *fakeDatastore) FindProfilesById(userIds ...uint64) ([]*proto.Profile, e
 	}
 }
 
+func (f *fakeDatastore) FindProfilesByUsername(username string) ([]*proto.Profile, error) {
+	if f.findProfilesByUsername != nil {
+		return f.findProfilesByUsername(username)
+	}
+	switch username {
+	case "Jarvis.A":
+		return []*proto.Profile{seedJarvis()}, nil
+	case "John.Doe":
+		return []*proto.Profile{seedDoe()}, nil
+	default:
+		return nil, gorm.ErrRecordNotFound
+	}
+}
+
 func newStack(t *testing.T) http.Handler {
 	t.Helper()
 	return rest.New(&fakeDatastore{})
@@ -186,6 +201,8 @@ var implementedCases = []string{
 	"milpacs/profile_by_id_zero",
 	"milpacs/profile_by_id_parse_error",
 	"milpacs/profile_by_id_internal_error",
+	"milpacs/profile_by_username_happy",
+	"milpacs/profile_by_username_not_found",
 	"auth/milpacs_missing_header",
 	"auth/milpacs_raw_key",
 	"auth/milpacs_invalid_key",
@@ -363,6 +380,113 @@ func TestNewStack_RanksDatastoreOutageIsInternalJSON(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.JSONEq(t, `{"code":13,"message":"error fetching ranks: unexpected EOF","details":[]}`, rr.Body.String())
+}
+
+// --- Profile query-binding quirks (PRD #112, request-side leniency) --------
+//
+// Unbound message fields remain query-bindable on profile routes: the old
+// gateway bound any ProfileRequest field NOT consumed by the path template
+// from the query string (filter_MilpacService_GetProfile_0/_1 in the
+// generated gateway code), and the old handler checked username BEFORE
+// user_id — so ?username= on the by-id route silently overrides the path
+// value. Frozen as-is by the PRD; no goldens witness it (the corpus records
+// path-only requests), so these new-stack tests pin it instead.
+
+func TestNewStack_ByIdRoute_UsernameQueryOverridesPathId(t *testing.T) {
+	h := newStack(t)
+
+	// Path id 2 is John.Doe; the username query must win and return Jarvis.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/2?username=Jarvis.A", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+	assert.Contains(t, rr.Body.String(), `"userId":"3"`)
+}
+
+func TestNewStack_ByIdRoute_UsernameQueryPrecedesZeroIdGuard(t *testing.T) {
+	h := newStack(t)
+
+	// The old handler checks username first: id 0 with a username query is a
+	// successful username lookup, not the zero-id 400.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/0?username=Jarvis.A", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+}
+
+func TestNewStack_ByIdRoute_UnknownUsernameQueryIs404NamingUsername(t *testing.T) {
+	h := newStack(t)
+
+	// Precedence holds on the error path too: the 404 names the username,
+	// even though the path id would have resolved.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/1?username=Ghost.User", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.JSONEq(t, `{"code":5,"message":"no profile found for username: Ghost.User","details":[]}`, rr.Body.String())
+}
+
+func TestNewStack_ByIdRoute_UnknownQueryParamsIgnored(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/1?totally_unknown=1&alsoUnknown=x", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+}
+
+func TestNewStack_UsernameRoute_UserIdQueryBindsButPathUsernameWins(t *testing.T) {
+	h := newStack(t)
+
+	// user_id is the username route's query-bindable field; the handler's
+	// username-first precedence makes a valid value invisible.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?user_id=999", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+}
+
+func TestNewStack_UsernameRoute_MalformedUserIdQueryIs400(t *testing.T) {
+	h := newStack(t)
+
+	// Binding still parses the value (the old gateway 400'd before the
+	// handler ran) — camelCase spelling accepted, proto field name in the
+	// message, parse-error text leaked, exactly the gateway's wording.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?userId=abc", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.JSONEq(t, `{"code":3,"message":"parsing field \"user_id\": strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
+}
+
+func TestNewStack_ByIdRoute_RepeatedUsernameQueryIs400(t *testing.T) {
+	h := newStack(t)
+
+	// Singular fields reject repeated values (gateway behavior, message
+	// shape preserved).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/2?username=a&username=b", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.JSONEq(t, `{"code":3,"message":"too many values for field \"username\": a, b","details":[]}`, rr.Body.String())
 }
 
 // --- Wrong-method contract (human ruling on review Critical 1, #125) -------

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -548,6 +548,62 @@ func TestNewStack_ByIdRoute_RepeatedUsernameQueryIs400(t *testing.T) {
 	assert.JSONEq(t, `{"code":3,"message":"too many values for field \"username\": a, b","details":[]}`, rr.Body.String())
 }
 
+// Malformed query SYNTAX is a 400 on the profile by-id and by-username routes:
+// the old gateway's generated handlers called req.ParseForm() and wrapped its
+// error as InvalidArgument "%v" (request_MilpacService_GetProfile_0/_1) — even
+// when the malformed pair was an unknown parameter. r.URL.Query() would drop
+// the bad pair silently; the explicit ParseQuery guard preserves the 400.
+func TestNewStack_ProfileRoutes_MalformedQuerySyntaxIs400(t *testing.T) {
+	h := newStack(t)
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"by_id_bad_escape", "/api/v1/milpacs/profile/id/1?username=%zz", `invalid URL escape \"%zz\"`},
+		{"by_id_semicolon", "/api/v1/milpacs/profile/id/1?a=1;b=2", `invalid semicolon separator in query`},
+		{"by_username_bad_escape", "/api/v1/milpacs/profile/username/Jarvis.A?user_id=%zz", `invalid URL escape \"%zz\"`},
+		{"by_username_semicolon", "/api/v1/milpacs/profile/username/Jarvis.A?a=1;b=2", `invalid semicolon separator in query`},
+		// The malformed pair being an UNKNOWN param changed nothing: ParseForm
+		// ran before any field filtering.
+		{"by_id_unknown_param_bad_escape", "/api/v1/milpacs/profile/id/1?junk=%zz", `invalid URL escape \"%zz\"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.JSONEq(t, `{"code":3,"message":"`+tc.want+`","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// The discord and gamertag routes must NOT gain the ParseForm guard: their
+// generated gateway handlers never called ParseForm (verified against
+// proto/milpacs.pb.gw.go — single path-bound field, no query binding), so
+// malformed query syntax fell through to the lookup.
+func TestNewStack_ConnectedAccountRoutes_MalformedQuerySyntaxIgnored(t *testing.T) {
+	h := newStack(t)
+
+	for _, path := range []string{
+		"/api/v1/milpac/discord/112233445566778899?junk=%zz",
+		"/api/v1/milpac/gamertag/CavGamer77?junk=%zz",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code, "old gateway never ParseForm'd these routes")
+		})
+	}
+}
+
 // --- Wrong-method contract (human ruling on review Critical 1, #125) -------
 //
 // Wrong-method on an existing route returns 405 Method Not Allowed with an

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -534,6 +534,41 @@ func TestNewStack_UsernameRoute_MalformedUserIdQueryIs400(t *testing.T) {
 	assert.JSONEq(t, `{"code":3,"message":"parsing field \"user_id\": strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
 }
 
+// Present-but-EMPTY ?user_id= on the username route is a 400: the old gateway
+// parsed every PRESENT value — runtime/query.go has no empty-value guard, so
+// "" went straight into strconv.ParseUint and errored. Present and non-empty
+// are distinct states; treating present-empty as absent would be a silent 200.
+func TestNewStack_UsernameRoute_EmptyUserIdQueryIs400(t *testing.T) {
+	h := newStack(t)
+
+	for _, spelling := range []string{"user_id", "userId"} {
+		t.Run(spelling, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?"+spelling+"=", nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.JSONEq(t, `{"code":3,"message":"parsing field \"user_id\": strconv.ParseUint: parsing \"\": invalid syntax","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// The asymmetry, pinned: present-but-empty ?username= on the by-id route IS a
+// 200 — username is a STRING field, so the gateway bound "" without error and
+// the old handler treated "" as unset, falling through to the path id.
+func TestNewStack_ByIdRoute_EmptyUsernameQueryFallsThroughToPathId(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/2?username=", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"username":"John.Doe"`, "empty username binds as unset; path id 2 resolves")
+}
+
 func TestNewStack_ByIdRoute_RepeatedUsernameQueryIs400(t *testing.T) {
 	h := newStack(t)
 

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -39,6 +39,8 @@ type fakeDatastore struct {
 	findAllRanks           func() ([]*proto.RankExpanded, error)
 	findProfilesById       func(userIds ...uint64) ([]*proto.Profile, error)
 	findProfilesByUsername func(username string) ([]*proto.Profile, error)
+	findProfileByDiscordID func(discordId string) (*proto.Profile, error)
+	findProfileByGamertag  func(gamertag string) (*proto.Profile, error)
 }
 
 func (f *fakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
@@ -181,6 +183,26 @@ func (f *fakeDatastore) FindProfilesByUsername(username string) ([]*proto.Profil
 	}
 }
 
+func (f *fakeDatastore) FindProfileByDiscordID(discordId string) (*proto.Profile, error) {
+	if f.findProfileByDiscordID != nil {
+		return f.findProfileByDiscordID(discordId)
+	}
+	if discordId == "112233445566778899" {
+		return seedJarvis(), nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (f *fakeDatastore) FindProfileByGamertag(gamertag string) (*proto.Profile, error) {
+	if f.findProfileByGamertag != nil {
+		return f.findProfileByGamertag(gamertag)
+	}
+	if gamertag == "CavGamer77" {
+		return seedDoe(), nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
 func newStack(t *testing.T) http.Handler {
 	t.Helper()
 	return rest.New(&fakeDatastore{})
@@ -203,6 +225,10 @@ var implementedCases = []string{
 	"milpacs/profile_by_id_internal_error",
 	"milpacs/profile_by_username_happy",
 	"milpacs/profile_by_username_not_found",
+	"milpacs/discord_happy",
+	"milpacs/discord_not_found",
+	"milpacs/gamertag_happy",
+	"milpacs/gamertag_not_found",
 	"auth/milpacs_missing_header",
 	"auth/milpacs_raw_key",
 	"auth/milpacs_invalid_key",
@@ -380,6 +406,39 @@ func TestNewStack_RanksDatastoreOutageIsInternalJSON(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.JSONEq(t, `{"code":13,"message":"error fetching ranks: unexpected EOF","details":[]}`, rr.Body.String())
+}
+
+// A datastore failure on each profile lookup must surface as the frozen
+// Internal error shape with the handler-specific wrapped message (the by-id
+// variant is golden-pinned via profile_by_id_internal_error; the corpus has
+// no outage cases for the other three, so these pin them).
+func TestNewStack_ProfileLookupOutagesAreInternalJSON(t *testing.T) {
+	outage := func() ([]*proto.Profile, error) { return nil, io.ErrUnexpectedEOF }
+	h := rest.New(&fakeDatastore{
+		findProfilesByUsername: func(string) ([]*proto.Profile, error) { return outage() },
+		findProfileByDiscordID: func(string) (*proto.Profile, error) { return nil, io.ErrUnexpectedEOF },
+		findProfileByGamertag:  func(string) (*proto.Profile, error) { return nil, io.ErrUnexpectedEOF },
+	})
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/api/v1/milpacs/profile/username/Jarvis.A", "fetch profile by username: unexpected EOF"},
+		{"/api/v1/milpac/discord/112233445566778899", "fetch profile by discord id: unexpected EOF"},
+		{"/api/v1/milpac/gamertag/CavGamer77", "fetch profile by gamertag: unexpected EOF"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.JSONEq(t, `{"code":13,"message":"`+tc.want+`","details":[]}`, rr.Body.String())
+		})
+	}
 }
 
 // --- Profile query-binding quirks (PRD #112, request-side leniency) --------

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -561,14 +561,20 @@ func TestNewStack_UsernameRoute_UserIdQueryBindsButPathUsernameWins(t *testing.T
 	h := newStack(t)
 
 	// user_id is the username route's query-bindable field; the handler's
-	// username-first precedence makes a valid value invisible.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?user_id=999", nil)
-	req.Header.Set("Authorization", "Bearer cav7_readkey")
-	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, req)
+	// username-first precedence makes a valid value invisible — under either
+	// spelling (the camelCase one exercises the dual-spelling leniency on the
+	// parsed-but-invisible path, not just the error path).
+	for _, query := range []string{"user_id=999", "userId=999"} {
+		t.Run(query, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?"+query, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
 
-	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+		})
+	}
 }
 
 func TestNewStack_UsernameRoute_MalformedUserIdQueryIs400(t *testing.T) {
@@ -772,6 +778,46 @@ func TestNewStack_ConnectedAccountRoutes_MalformedQuerySyntaxIgnored(t *testing.
 			h.ServeHTTP(rr, req)
 
 			require.Equal(t, http.StatusOK, rr.Code, "old gateway never ParseForm'd these routes")
+		})
+	}
+}
+
+// Path parse precedes the username-override: a malformed path id 400s with
+// the gateway's type-mismatch tier even when a valid ?username= is present —
+// the generated handler parsed pathParams before ParseForm/query binding.
+func TestNewStack_ByIdRoute_MalformedPathIdBeatsUsernameQuery(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/abc?username=Jarvis.A", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.JSONEq(t, `{"code":3,"message":"type mismatch, parameter: user_id, error: strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
+}
+
+// The scope gate is witnessed PER profile route: a ticket-scoped key
+// (read:tickets, not read) must 403 with the frozen body on each of the four.
+// The golden tier only witnesses one path; this loop proves no route was
+// registered without its requireScope gate.
+func TestNewStack_AllProfileRoutes403UnderTicketScopedKey(t *testing.T) {
+	h := newStack(t)
+
+	for _, path := range []string{
+		"/api/v1/milpacs/profile/id/1",
+		"/api/v1/milpacs/profile/username/Jarvis.A",
+		"/api/v1/milpac/discord/112233445566778899",
+		"/api/v1/milpac/gamertag/CavGamer77",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_ticketskey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code)
+			assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, rr.Body.String())
 		})
 	}
 }

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -569,6 +569,91 @@ func TestNewStack_ByIdRoute_EmptyUsernameQueryFallsThroughToPathId(t *testing.T)
 	assert.Contains(t, rr.Body.String(), `"username":"John.Doe"`, "empty username binds as unset; path id 2 resolves")
 }
 
+// Cross-spelling: ?user_id=1&userId=2 is NOT a repeated-value error — the old
+// gateway processed each url.Values key independently (each parsed, each set
+// the field, last-iterated-wins nondeterministically, no error). Every value
+// must parse; a bad one 400s with the gateway's parsing-field text regardless
+// of order. When all parse, the camelCase value wins deterministically — a
+// ruling standing in for the old map-order nondeterminism (converged with
+// #129's query binder) — and is invisible anyway under username precedence.
+func TestNewStack_UsernameRoute_CrossSpellingUserIdQuery(t *testing.T) {
+	h := newStack(t)
+
+	// The reference: the path-username profile with no query at all.
+	ref := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A", nil)
+	ref.Header.Set("Authorization", "Bearer cav7_readkey")
+	refRec := httptest.NewRecorder()
+	h.ServeHTTP(refRec, ref)
+	require.Equal(t, http.StatusOK, refRec.Code)
+
+	t.Run("both_parse_200_snake_first", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?user_id=1&userId=2", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, refRec.Body.String(), rr.Body.String(),
+			"bound user_id is invisible under username precedence — response equals the path-username profile")
+	})
+
+	t.Run("both_parse_200_camel_first", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?userId=2&user_id=1", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, refRec.Body.String(), rr.Body.String())
+	})
+
+	t.Run("bad_snake_400_snake_first", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?user_id=abc&userId=5", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.JSONEq(t, `{"code":3,"message":"parsing field \"user_id\": strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
+	})
+
+	t.Run("bad_snake_400_camel_first", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?userId=5&user_id=abc", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.JSONEq(t, `{"code":3,"message":"parsing field \"user_id\": strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
+	})
+}
+
+// Same-key repetition stays the deterministic gateway error (per-key check:
+// runtime/query.go errored whenever ONE key carried multiple values for a
+// singular field, citing the proto field name and that key's values).
+func TestNewStack_UsernameRoute_RepeatedUserIdQueryIs400(t *testing.T) {
+	h := newStack(t)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"snake_repeated", "user_id=1&user_id=2"},
+		{"camel_repeated", "userId=1&userId=2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?"+tc.query, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.JSONEq(t, `{"code":3,"message":"too many values for field \"user_id\": 1, 2","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
 func TestNewStack_ByIdRoute_RepeatedUsernameQueryIs400(t *testing.T) {
 	h := newStack(t)
 

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -712,6 +712,51 @@ func TestNewStack_UsernameRoute_RepeatedUserIdQueryIs400(t *testing.T) {
 	}
 }
 
+// --- Bracket-key folding (gateway DefaultQueryParser rewrite, frozen) -------
+//
+// The old gateway rewrote any query key matching ^(.*)\[(.*)\]$ to its base
+// key with the bracket CONTENT prepended as an extra value (grpc-gateway
+// v2.29.0 runtime/query.go valuesKeyRegexp): ?user_id[0]=1 became key
+// "user_id", values ["0","1"] — which then tripped the singular-field
+// too-many-values check. Verified against the real old stack in-process on
+// both routes below. A bracket key whose base matches no bindable field is
+// just another unknown parameter — ignored. Semantics converged with #129's
+// query binder (same fold, implemented per-branch).
+func TestNewStack_ProfileRoutes_BracketKeyFoldsIntoField(t *testing.T) {
+	h := newStack(t)
+
+	t.Run("username_route_user_id_bracket_is_too_many_values", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/username/Jarvis.A?user_id[0]=1", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		// Folded group, bracket content first: ["0","1"].
+		assert.JSONEq(t, `{"code":3,"message":"too many values for field \"user_id\": 0, 1","details":[]}`, rr.Body.String())
+	})
+
+	t.Run("by_id_route_username_bracket_is_too_many_values", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/2?username[x]=y", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.JSONEq(t, `{"code":3,"message":"too many values for field \"username\": x, y","details":[]}`, rr.Body.String())
+	})
+
+	t.Run("unmatched_bracket_key_ignored", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/1?junk[0]=x", nil)
+		req.Header.Set("Authorization", "Bearer cav7_readkey")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "bracket key folding to a non-bindable base is unknown-param leniency")
+		assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+	})
+}
+
 func TestNewStack_ByIdRoute_RepeatedUsernameQueryIs400(t *testing.T) {
 	h := newStack(t)
 

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -903,6 +903,68 @@ func TestNewStack_ByIdRoute_MalformedPathIdBeatsUsernameQuery(t *testing.T) {
 	assert.JSONEq(t, `{"code":3,"message":"type mismatch, parameter: user_id, error: strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
 }
 
+// Combined malformed path AND malformed query syntax: the PATH error wins —
+// the generated gateway handler parsed pathParams before ParseForm, so the
+// type-mismatch tier answers even when the query would also 400. Pinned
+// (verified against the real old stack in-process).
+func TestNewStack_ByIdRoute_MalformedPathBeatsMalformedQuerySyntax(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/abc?username=%zz", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.JSONEq(t, `{"code":3,"message":"type mismatch, parameter: user_id, error: strconv.ParseUint: parsing \"abc\": invalid syntax","details":[]}`, rr.Body.String())
+}
+
+// On the by-id route user_id is PATH-bound, so the gateway's field filter
+// (filter_MilpacService_GetProfile_0) excluded it from query binding — under
+// BOTH spellings (the filter keyed on the resolved field, not the query-key
+// text). A ?user_id=abc / ?userId=abc that would 400 on the username route is
+// just an ignored unknown parameter here.
+func TestNewStack_ByIdRoute_UserIdQueryIgnoredBecausePathFiltered(t *testing.T) {
+	h := newStack(t)
+
+	for _, query := range []string{"user_id=abc", "userId=abc"} {
+		t.Run(query, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/1?"+query, nil)
+			req.Header.Set("Authorization", "Bearer cav7_readkey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code, "path-filtered field: the query spelling binds nothing")
+			assert.Contains(t, rr.Body.String(), `"username":"Jarvis.A"`)
+		})
+	}
+}
+
+// --- Scope-vs-binding ordering (ruled cutover break) -------------------------
+//
+// The OLD stack answered binding-400s before scope-403s: RequireScope lived
+// inside the RPC bodies, after the gateway had already parsed path params —
+// a wrong-scope key with a malformed path id got the 400. The new stack's
+// uniform tier order (401 → 403 → route semantics) answers the 403 first.
+// RULING: keep 403-first — a deliberate, documented cutover break (same
+// precedent tier as the 405 ruling on review Critical 1/#125, recorded in
+// PRD #112's enumerated breaks; ratified in the PR body). The sibling branch
+// (#129) documents the same ruling at its scope gate. This pin is
+// new-stack-only by design: no golden can witness it without poisoning the
+// old-stack replay.
+func TestNewStack_WrongScopeBeatsMalformedPath_RuledBreak(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/profile/id/abc", nil)
+	req.Header.Set("Authorization", "Bearer cav7_ticketskey") // read:tickets ≠ read
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code,
+		"403 answers before the path-binding 400 — ruled, NOT old-stack parity (old stack: 400 first)")
+	assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, rr.Body.String())
+}
+
 // The scope gate is witnessed PER profile route: a ticket-scoped key
 // (read:tickets, not read) must 403 with the frozen body on each of the four.
 // The golden tier only witnesses one path; this loop proves no route was

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -4,13 +4,14 @@ package rest_test
 // against the NEW stack too: every implemented battery case's OBSERVED
 // response (not the committed golden — contract/spec_test.go already covers
 // those) is validated against the document. Today that means the ranks
-// operation's full surface plus the 401 tiers observed on the profile-by-id
-// and tickets-list operations — the rest of the spec's operations are
-// witnessed only once their routes land (#126–#129). Same non-vacuousness
-// rules as the contract replay loop: the observed status must be EXPLICITLY
-// documented on the operation, a JSON response requires an application/json
-// schema to validate against, and every implemented case's path must be
-// classified in specRoutes — unclassified paths fail, never skip.
+// operation and the four profile lookup operations (id, username, discord,
+// gamertag — #126) plus the 401 tiers observed on the tickets-list
+// operation — the rest of the spec's operations are witnessed only once
+// their routes land (#127–#129). Same non-vacuousness rules as the contract
+// replay loop: the observed status must be EXPLICITLY documented on the
+// operation, a JSON response requires an application/json schema to
+// validate against, and every implemented case's path must be classified in
+// specRoutes — unclassified paths fail, never skip.
 
 import (
 	"bytes"

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -56,6 +56,12 @@ var specRoutes = map[string]string{
 	// Profile by username: happy, not-found.
 	"/api/v1/milpacs/profile/username/Jarvis.A":   "/api/v1/milpacs/profile/username/{username}",
 	"/api/v1/milpacs/profile/username/Ghost.User": "/api/v1/milpacs/profile/username/{username}",
+	// Discord lookup: happy, not-found.
+	"/api/v1/milpac/discord/112233445566778899": "/api/v1/milpac/discord/{discordId}",
+	"/api/v1/milpac/discord/999000999":          "/api/v1/milpac/discord/{discordId}",
+	// Gamertag lookup: happy, not-found.
+	"/api/v1/milpac/gamertag/CavGamer77": "/api/v1/milpac/gamertag/{gamertag}",
+	"/api/v1/milpac/gamertag/GhostTag":   "/api/v1/milpac/gamertag/{gamertag}",
 	// The tickets 401-tier battery cases replay against this path before the
 	// route is implemented (auth runs before routing, so the observed 401s
 	// are route-independent); the operation documents 401 explicitly.

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -53,6 +53,9 @@ var specRoutes = map[string]string{
 	"/api/v1/milpacs/profile/id/0":   "/api/v1/milpacs/profile/id/{userId}",
 	"/api/v1/milpacs/profile/id/abc": "/api/v1/milpacs/profile/id/{userId}",
 	"/api/v1/milpacs/profile/id/777": "/api/v1/milpacs/profile/id/{userId}",
+	// Profile by username: happy, not-found.
+	"/api/v1/milpacs/profile/username/Jarvis.A":   "/api/v1/milpacs/profile/username/{username}",
+	"/api/v1/milpacs/profile/username/Ghost.User": "/api/v1/milpacs/profile/username/{username}",
 	// The tickets 401-tier battery cases replay against this path before the
 	// route is implemented (auth runs before routing, so the observed 401s
 	// are route-independent); the operation documents 401 explicitly.

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -44,12 +44,20 @@ const specPath = "../openapi/openapi.yaml"
 // to stay unmatched.
 var specRoutes = map[string]string{
 	"/api/v1/milpacs/ranks": "/api/v1/milpacs/ranks",
-	// The 401-tier battery cases replay against these two paths before their
-	// routes are implemented (auth runs before routing, so the observed 401s
-	// are route-independent); the operations document 401 explicitly.
-	"/api/v1/milpacs/profile/id/1": "/api/v1/milpacs/profile/id/{userId}",
-	"/api/v1/tickets":              "/api/v1/tickets",
-	"/api/v1/does/not/exist":       "", // off-spec: unknown-path tier (mux behavior, not an operation)
+	// Profile by id: happy (1), sparse (2), not-found (999), zero (0),
+	// parse-error (abc), injected outage (777) — plus the 401-tier battery
+	// cases that replay against /id/1.
+	"/api/v1/milpacs/profile/id/1":   "/api/v1/milpacs/profile/id/{userId}",
+	"/api/v1/milpacs/profile/id/2":   "/api/v1/milpacs/profile/id/{userId}",
+	"/api/v1/milpacs/profile/id/999": "/api/v1/milpacs/profile/id/{userId}",
+	"/api/v1/milpacs/profile/id/0":   "/api/v1/milpacs/profile/id/{userId}",
+	"/api/v1/milpacs/profile/id/abc": "/api/v1/milpacs/profile/id/{userId}",
+	"/api/v1/milpacs/profile/id/777": "/api/v1/milpacs/profile/id/{userId}",
+	// The tickets 401-tier battery cases replay against this path before the
+	// route is implemented (auth runs before routing, so the observed 401s
+	// are route-independent); the operation documents 401 explicitly.
+	"/api/v1/tickets":        "/api/v1/tickets",
+	"/api/v1/does/not/exist": "", // off-spec: unknown-path tier (mux behavior, not an operation)
 }
 
 func loadSpecModel(t *testing.T) *v3.Document {

--- a/types/list.go
+++ b/types/list.go
@@ -1,0 +1,24 @@
+package types
+
+import "encoding/json"
+
+// List is a nil-safe JSON array: a nil List marshals as [] — never null —
+// and an allocated one delegates to encoding/json byte-identically to the
+// plain slice. It moves the "empty collections serialize as []" wire
+// convention (see the package doc) from mapper discipline into the type
+// itself: handlers keep their make() calls for capacity, but a zero-value
+// struct is wire-valid without them — load-bearing from #127 on, where
+// profile shapes become map values built outside the mappers.
+//
+// Use it for every repeated field in a wire type. It changes nothing for
+// allocated slices, so adopting it on an existing type is contract-neutral
+// (the golden replay suite proves it).
+type List[T any] []T
+
+// MarshalJSON emits [] for a nil list and delegates otherwise.
+func (l List[T]) MarshalJSON() ([]byte, error) {
+	if l == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]T(l))
+}

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -1,0 +1,63 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A nil List marshals as [] — the allocation discipline (empty collections
+// are [], never null) enforced by the TYPE, so a forgotten make() in a
+// mapper can no longer leak null onto the wire.
+func TestList_NilMarshalsAsEmptyArray(t *testing.T) {
+	var l types.List[*types.Position]
+	b, err := json.Marshal(l)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+// An allocated List delegates to encoding/json — byte-identical to the plain
+// slice, so adopting the type changes nothing on the wire (the golden replay
+// suite proves it end-to-end).
+func TestList_AllocatedDelegatesByteIdentical(t *testing.T) {
+	plain := []*types.Position{
+		{PositionTitle: "S6 Web Developer", PositionId: 812},
+		nil,
+	}
+	wantBytes, err := json.Marshal(plain)
+	require.NoError(t, err)
+
+	got, err := json.Marshal(types.List[*types.Position](plain))
+	require.NoError(t, err)
+	assert.Equal(t, string(wantBytes), string(got))
+
+	empty, err := json.Marshal(types.List[*types.Position]{})
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(empty))
+}
+
+// A zero-value Profile is wire-valid: every collection marshals as [], not
+// null — relevant from #127 on, where Profile becomes a roster map value and
+// zero values can exist outside the mappers' make() discipline.
+func TestProfile_ZeroValueMarshalsWireValid(t *testing.T) {
+	b, err := json.Marshal(types.Profile{})
+	require.NoError(t, err)
+
+	// Unset nested messages (user, rank, primary) stay null — that part of
+	// the wire convention is pointer-field behavior, untouched here.
+	s := string(b)
+	assert.Contains(t, s, `"secondaries":[]`)
+	assert.Contains(t, s, `"records":[]`)
+	assert.Contains(t, s, `"awards":[]`)
+	assert.Contains(t, s, `"roster":"ROSTER_TYPE_UNSPECIFIED"`)
+}
+
+// Zero-value RanksResponse: ranks is [], not null.
+func TestRanksResponse_ZeroValueMarshalsWireValid(t *testing.T) {
+	b, err := json.Marshal(types.RanksResponse{})
+	require.NoError(t, err)
+	assert.Equal(t, `{"ranks":[]}`, string(b))
+}

--- a/types/profile.go
+++ b/types/profile.go
@@ -1,8 +1,10 @@
 package types
 
 // Profile is the full milpac view: rank, positions, awards, records, and the
-// connected-account identifiers. Served by the four profile lookup routes
-// (by id, username, Discord id, gamertag).
+// connected-account identifiers. It is the shared profile shape of the API,
+// not a single route's response: today the four profile lookup routes (by
+// id, username, Discord id, gamertag) serve it as the top-level body, and
+// from #127 on it also appears as the roster map's value type.
 //
 // Deliberately ABSENT: keycloakId. The new types never had the field — the
 // corpus transform documents the break (the Keycloak surface dies at

--- a/types/profile.go
+++ b/types/profile.go
@@ -8,21 +8,21 @@ package types
 // corpus transform documents the break (the Keycloak surface dies at
 // cutover, #134).
 type Profile struct {
-	User              *User       `json:"user"`
-	Rank              *Rank       `json:"rank"`
-	RealName          string      `json:"realName"`
-	UniformUrl        string      `json:"uniformUrl"`
-	Roster            RosterType  `json:"roster"`
-	Primary           *Position   `json:"primary"`
-	Secondaries       []*Position `json:"secondaries"`
-	Records           []*Record   `json:"records"`
-	Awards            []*Award    `json:"awards"`
-	JoinDate          string      `json:"joinDate"`
-	PromotionDate     string      `json:"promotionDate"`
-	DiscordId         string      `json:"discordId"`
-	LastForumPostDate string      `json:"lastForumPostDate"`
-	Mos               string      `json:"mos"`
-	ConsoleGamertag   string      `json:"consoleGamertag"`
+	User              *User           `json:"user"`
+	Rank              *Rank           `json:"rank"`
+	RealName          string          `json:"realName"`
+	UniformUrl        string          `json:"uniformUrl"`
+	Roster            RosterType      `json:"roster"`
+	Primary           *Position       `json:"primary"`
+	Secondaries       List[*Position] `json:"secondaries"`
+	Records           List[*Record]   `json:"records"`
+	Awards            List[*Award]    `json:"awards"`
+	JoinDate          string          `json:"joinDate"`
+	PromotionDate     string          `json:"promotionDate"`
+	DiscordId         string          `json:"discordId"`
+	LastForumPostDate string          `json:"lastForumPostDate"`
+	Mos               string          `json:"mos"`
+	ConsoleGamertag   string          `json:"consoleGamertag"`
 }
 
 // User is the forum identity embedded in profile shapes. UserId is the FORUM

--- a/types/profile.go
+++ b/types/profile.go
@@ -1,0 +1,65 @@
+package types
+
+// Profile is the full milpac view: rank, positions, awards, records, and the
+// connected-account identifiers. Served by the four profile lookup routes
+// (by id, username, Discord id, gamertag).
+//
+// Deliberately ABSENT: keycloakId. The new types never had the field — the
+// corpus transform documents the break (the Keycloak surface dies at
+// cutover, #134).
+type Profile struct {
+	User              *User       `json:"user"`
+	Rank              *Rank       `json:"rank"`
+	RealName          string      `json:"realName"`
+	UniformUrl        string      `json:"uniformUrl"`
+	Roster            RosterType  `json:"roster"`
+	Primary           *Position   `json:"primary"`
+	Secondaries       []*Position `json:"secondaries"`
+	Records           []*Record   `json:"records"`
+	Awards            []*Award    `json:"awards"`
+	JoinDate          string      `json:"joinDate"`
+	PromotionDate     string      `json:"promotionDate"`
+	DiscordId         string      `json:"discordId"`
+	LastForumPostDate string      `json:"lastForumPostDate"`
+	Mos               string      `json:"mos"`
+	ConsoleGamertag   string      `json:"consoleGamertag"`
+}
+
+// User is the forum identity embedded in profile shapes. UserId is the FORUM
+// user id — distinct from the milpac relation key the by-id route binds.
+type User struct {
+	UserId   uint64 `json:"userId,string"`
+	Username string `json:"username"`
+}
+
+// Rank is the pay-grade entry embedded in profiles — the plain variant
+// without the display order (the catalog variant is RankExpanded).
+type Rank struct {
+	RankShort    string `json:"rankShort"`
+	RankFull     string `json:"rankFull"`
+	RankImageUrl string `json:"rankImageUrl"`
+	RankId       uint64 `json:"rankId,string"`
+}
+
+// Position is an org-chart slot held by a member (primary or secondary).
+type Position struct {
+	PositionTitle string `json:"positionTitle"`
+	PositionId    uint64 `json:"positionId,string"`
+}
+
+// Record is one entry on a member's service history.
+type Record struct {
+	RecordDetails string     `json:"recordDetails"`
+	RecordType    RecordType `json:"recordType"`
+	RecordDate    string     `json:"recordDate"`
+	RecordUid     uint64     `json:"recordUid,string"`
+}
+
+// Award is a decoration entry on a member's milpac.
+type Award struct {
+	AwardDetails  string `json:"awardDetails"`
+	AwardName     string `json:"awardName"`
+	AwardDate     string `json:"awardDate"`
+	AwardImageUrl string `json:"awardImageUrl"`
+	AwardUid      uint64 `json:"awardUid,string"`
+}

--- a/types/profile_test.go
+++ b/types/profile_test.go
@@ -1,0 +1,105 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The populated form: every nested message present, 64-bit ids as decimal
+// strings, enums as name strings — the shape the profile goldens freeze
+// (contract/goldens/milpacs/profile_by_id_happy.golden.json).
+func TestProfile_WireForm(t *testing.T) {
+	m := marshalToMap(t, types.Profile{
+		User:        &types.User{UserId: 3, Username: "Jarvis.A"},
+		Rank:        &types.Rank{RankShort: "MG", RankFull: "Major General", RankImageUrl: "img", RankId: 4},
+		RealName:    "Adam Jarvis",
+		UniformUrl:  "uniform",
+		Roster:      types.RosterTypeCombat,
+		Primary:     &types.Position{PositionTitle: "Regimental Technical Aide", PositionId: 773},
+		Secondaries: []*types.Position{{PositionTitle: "S6 Web Developer", PositionId: 812}},
+		Records: []*types.Record{
+			{RecordDetails: "Promoted", RecordType: types.RecordTypePromotion, RecordDate: "2020-10-17", RecordUid: 46},
+		},
+		Awards: []*types.Award{
+			{AwardDetails: "details", AwardName: "Commendation Medal", AwardDate: "2021-03-01", AwardImageUrl: "ccm", AwardUid: 901},
+		},
+		JoinDate:          "2014-02-08",
+		PromotionDate:     "2020-10-17",
+		DiscordId:         "112233445566778899",
+		LastForumPostDate: "2026-05-30",
+		Mos:               "11B",
+		ConsoleGamertag:   "",
+	})
+
+	assert.Equal(t, map[string]any{
+		"user":        map[string]any{"userId": "3", "username": "Jarvis.A"},
+		"rank":        map[string]any{"rankShort": "MG", "rankFull": "Major General", "rankImageUrl": "img", "rankId": "4"},
+		"realName":    "Adam Jarvis",
+		"uniformUrl":  "uniform",
+		"roster":      "ROSTER_TYPE_COMBAT",
+		"primary":     map[string]any{"positionTitle": "Regimental Technical Aide", "positionId": "773"},
+		"secondaries": []any{map[string]any{"positionTitle": "S6 Web Developer", "positionId": "812"}},
+		"records": []any{map[string]any{
+			"recordDetails": "Promoted", "recordType": "RECORD_TYPE_PROMOTION", "recordDate": "2020-10-17", "recordUid": "46",
+		}},
+		"awards": []any{map[string]any{
+			"awardDetails": "details", "awardName": "Commendation Medal", "awardDate": "2021-03-01", "awardImageUrl": "ccm", "awardUid": "901",
+		}},
+		"joinDate":          "2014-02-08",
+		"promotionDate":     "2020-10-17",
+		"discordId":         "112233445566778899",
+		"lastForumPostDate": "2026-05-30",
+		"mos":               "11B",
+		"consoleGamertag":   "",
+	}, m)
+}
+
+// Emit-everything: unset nested messages are null, empty (allocated)
+// collections are [], unset strings are "" — and NO keycloakId key anywhere:
+// the new types never had the field (the corpus transform documents the
+// break; route-level Keycloak removal rides cutover #134).
+func TestProfile_SparseFormEmitsNullsAndEmpties(t *testing.T) {
+	m := marshalToMap(t, types.Profile{
+		User:        &types.User{UserId: 8, Username: "John.Doe"},
+		Rank:        &types.Rank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "img22", RankId: 22},
+		RealName:    "John Doe",
+		UniformUrl:  "uniform2",
+		Roster:      types.RosterTypeCombat,
+		Primary:     nil,
+		Secondaries: []*types.Position{},
+		Records:     []*types.Record{},
+		Awards:      []*types.Award{},
+		JoinDate:    "2026-01-15",
+	})
+
+	assert.Equal(t, map[string]any{
+		"user":              map[string]any{"userId": "8", "username": "John.Doe"},
+		"rank":              map[string]any{"rankShort": "PVT", "rankFull": "Private", "rankImageUrl": "img22", "rankId": "22"},
+		"realName":          "John Doe",
+		"uniformUrl":        "uniform2",
+		"roster":            "ROSTER_TYPE_COMBAT",
+		"primary":           nil,
+		"secondaries":       []any{},
+		"records":           []any{},
+		"awards":            []any{},
+		"joinDate":          "2026-01-15",
+		"promotionDate":     "",
+		"discordId":         "",
+		"lastForumPostDate": "",
+		"mos":               "",
+		"consoleGamertag":   "",
+	}, m)
+	require.NotContains(t, m, "keycloakId")
+}
+
+// json.Marshal must never see a keycloak field even via embedding tricks —
+// pin the raw bytes too, belt and braces for the documented break.
+func TestProfile_NoKeycloakIdOnTheWire(t *testing.T) {
+	raw, err := json.Marshal(types.Profile{})
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "keycloak")
+}

--- a/types/ranks.go
+++ b/types/ranks.go
@@ -11,8 +11,8 @@ type RankExpanded struct {
 	RankDisplayOrder uint32 `json:"rankDisplayOrder"`
 }
 
-// RanksResponse is the GET /api/v1/milpacs/ranks envelope. Ranks must be
-// allocated even when empty ([] on the wire, never null).
+// RanksResponse is the GET /api/v1/milpacs/ranks envelope. Ranks is a List,
+// so even the zero value serializes as [] on the wire, never null.
 type RanksResponse struct {
-	Ranks []*RankExpanded `json:"ranks"`
+	Ranks List[*RankExpanded] `json:"ranks"`
 }

--- a/types/recordtype.go
+++ b/types/recordtype.go
@@ -35,6 +35,17 @@ var recordTypeNames = map[RecordType]string{
 	RecordTypeGraduation:   "RECORD_TYPE_GRADUATION",
 }
 
+// String returns the wire name, or the bare decimal number for values the
+// catalog has no name for — mirroring the generated proto String() (the
+// RosterType worked example), so enum values interpolate identically into
+// error-message strings and logs.
+func (rt RecordType) String() string {
+	if name, ok := recordTypeNames[rt]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(rt), 10)
+}
+
 // MarshalJSON emits the enum name as a JSON string; values without a name
 // emit the bare number (protojson behavior for unknown enum values).
 func (rt RecordType) MarshalJSON() ([]byte, error) {

--- a/types/recordtype.go
+++ b/types/recordtype.go
@@ -1,0 +1,45 @@
+package types
+
+import "strconv"
+
+// RecordType enumerates the categories of service-record entries. The
+// numeric values match the proto enum being retired at Phase 4 exactly; the
+// wire form is the NAME string (enum convention — see RosterType, the worked
+// example).
+type RecordType int32
+
+const (
+	RecordTypeUnspecified  RecordType = 0
+	RecordTypePromotion    RecordType = 1
+	RecordTypeOperation    RecordType = 2
+	RecordTypeTransfer     RecordType = 3
+	RecordTypeDisciplinary RecordType = 4
+	RecordTypeDischarge    RecordType = 5
+	RecordTypeAssignment   RecordType = 6
+	RecordTypeNameChange   RecordType = 7
+	RecordTypeEloa         RecordType = 8
+	RecordTypeGraduation   RecordType = 9
+)
+
+// recordTypeNames is the wire-name catalog, keyed by enum value.
+var recordTypeNames = map[RecordType]string{
+	RecordTypeUnspecified:  "RECORD_TYPE_UNSPECIFIED",
+	RecordTypePromotion:    "RECORD_TYPE_PROMOTION",
+	RecordTypeOperation:    "RECORD_TYPE_OPERATION",
+	RecordTypeTransfer:     "RECORD_TYPE_TRANSFER",
+	RecordTypeDisciplinary: "RECORD_TYPE_DISCIPLINARY",
+	RecordTypeDischarge:    "RECORD_TYPE_DISCHARGE",
+	RecordTypeAssignment:   "RECORD_TYPE_ASSIGNMENT",
+	RecordTypeNameChange:   "RECORD_TYPE_NAME_CHANGE",
+	RecordTypeEloa:         "RECORD_TYPE_ELOA",
+	RecordTypeGraduation:   "RECORD_TYPE_GRADUATION",
+}
+
+// MarshalJSON emits the enum name as a JSON string; values without a name
+// emit the bare number (protojson behavior for unknown enum values).
+func (rt RecordType) MarshalJSON() ([]byte, error) {
+	if name, ok := recordTypeNames[rt]; ok {
+		return strconv.AppendQuote(nil, name), nil
+	}
+	return strconv.AppendInt(nil, int64(rt), 10), nil
+}

--- a/types/recordtype_test.go
+++ b/types/recordtype_test.go
@@ -42,3 +42,12 @@ func TestRecordType_UnknownValueMarshalsAsNumber(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `99`, string(raw))
 }
+
+// String mirrors the wire name (and the number fallback), matching the
+// RosterType worked example — enum values format the same way in error
+// messages and logs as they do in JSON.
+func TestRecordType_StringMatchesWireName(t *testing.T) {
+	assert.Equal(t, "RECORD_TYPE_PROMOTION", types.RecordTypePromotion.String())
+	assert.Equal(t, "RECORD_TYPE_UNSPECIFIED", types.RecordType(0).String())
+	assert.Equal(t, "99", types.RecordType(99).String())
+}

--- a/types/recordtype_test.go
+++ b/types/recordtype_test.go
@@ -1,0 +1,44 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Enum convention (see RosterType, the worked example): the wire form is the
+// NAME string, the zero value emits the _UNSPECIFIED name.
+func TestRecordType_MarshalsAsNameString(t *testing.T) {
+	cases := []struct {
+		value types.RecordType
+		want  string
+	}{
+		{types.RecordTypeUnspecified, `"RECORD_TYPE_UNSPECIFIED"`},
+		{types.RecordType(0), `"RECORD_TYPE_UNSPECIFIED"`}, // zero value == unspecified
+		{types.RecordTypePromotion, `"RECORD_TYPE_PROMOTION"`},
+		{types.RecordTypeOperation, `"RECORD_TYPE_OPERATION"`},
+		{types.RecordTypeTransfer, `"RECORD_TYPE_TRANSFER"`},
+		{types.RecordTypeDisciplinary, `"RECORD_TYPE_DISCIPLINARY"`},
+		{types.RecordTypeDischarge, `"RECORD_TYPE_DISCHARGE"`},
+		{types.RecordTypeAssignment, `"RECORD_TYPE_ASSIGNMENT"`},
+		{types.RecordTypeNameChange, `"RECORD_TYPE_NAME_CHANGE"`},
+		{types.RecordTypeEloa, `"RECORD_TYPE_ELOA"`},
+		{types.RecordTypeGraduation, `"RECORD_TYPE_GRADUATION"`},
+	}
+	for _, c := range cases {
+		raw, err := json.Marshal(c.value)
+		require.NoError(t, err)
+		assert.Equal(t, c.want, string(raw))
+	}
+}
+
+// Unnamed values fall back to the bare number (protojson behavior), so
+// upstream data ahead of the catalog still round-trips.
+func TestRecordType_UnknownValueMarshalsAsNumber(t *testing.T) {
+	raw, err := json.Marshal(types.RecordType(99))
+	require.NoError(t, err)
+	assert.Equal(t, `99`, string(raw))
+}


### PR DESCRIPTION
Closes #126. Part of #112 (Goodbye gRPC), Phase 3 fan-out over the tracer's pattern (#125/#150).

## What

The four profile lookup routes on the new net/http stack, goldens to green: by id (relation-key semantic), by username, by Discord id, by gamertag. 14 corpus cases flipped into `implementedCases` (12 profile + 2 scope-tier 403s); all observed paths classified in `specRoutes`; `openapi.yaml` needed no edits (#147 already documented the four operations — two-way coverage confirms).

New wire types: `types.Profile`/`User`/`Rank`/`Position`/`Record`/`Award` + `RecordType` enum (no `keycloakId` — pinned at three levels). `types.List[T]` moves the never-nil-collection invariant into the type layer (nil marshals `[]`) ahead of the #127/#128 mappers that reuse these types.

## Quirk parity (verified against the real old stack in-process)

- Gateway ParseForm guard restored: malformed query syntax 400s on the two profile routes; discord/gamertag deliberately stay lenient (their generated handlers never parsed queries)
- Present-but-empty `?user_id=` → 400 (gateway fed `""` to ParseUint); `?username=` empty on by-id stays 200 (string-field asymmetry, pinned)
- Path id parses **base 0**, inheriting `runtime.Uint64`'s integer-literal quirk: `0x1`→1, `010`→octal 8 (wrong-profile hazard under base 10), `09`→400, `1_0`→10. Pinned
- Bracket keys fold per the gateway's `valuesKeyRegexp` rewrite: `?user_id[0]=1` → too-many-values 400. Pinned
- Same-key scalar repeats → 400 too-many-values (gateway-verbatim text)

## Rulings for ratification (deliberate breaks / deterministic stand-ins, 405-ruling precedent)

1. **403-before-binding-400**: old stack answered binding 400s before scope 403s (RequireScope lived inside RPC bodies); new stack layers uniformly 401 → 403 → route semantics. A wrong-scoped key sending `/profile/id/abc` now gets 403, not 400. Pinned by test, marked in code.
2. **Cross-spelling determinism**: `?user_id=1&userId=2` parses every value (any malformed → 400, as old), camelCase wins when all parse — deterministic stand-in for the gateway's map-order nondeterminism.
3. Noted, not coded: `%2F` inside a path segment 404s on both stacks with different message text (old mux rejected the segment; new mux routes it to a not-found lookup).

## Hardening (contract-invisible, golden replay proves byte-identity)

Empty-slice/nil-profile guards route datastore-invariant violations through the frozen 500 shape instead of panicking/fabricating a sparse 200; the non-empty-on-nil-error invariant is documented on the `Datastore` interface.

## Process

Built by a TDD worker agent, then two review rounds (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer; verification round replayed quirk requests through the real old stack mounted in-process) with fixes applied between rounds.

Gate: build/vet green; `go test ./...` green with skips intact; `make test-integration` green on the MariaDB harness; `contract/goldens/**` diff vs develop empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)