### PR TITLE
Phase 3: roster routes in all three profile shapes (#127)

### DIFF
--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/pb33f/libopenapi-validator/paths"
 	"github.com/pb33f/libopenapi-validator/responses"
 	"github.com/pb33f/libopenapi-validator/schema_validation"
+
+	"github.com/7cav/api/internal/spectest"
 )
 
 const specPath = "../openapi/openapi.yaml"
@@ -894,14 +896,22 @@ func TestSpec_EveryOperationHasGolden(t *testing.T) {
 // (rest.New + contract.RunCase, not a replayed golden) and (b) validates
 // the observed response via validateObserved, whose explicit-status rule
 // makes the spec line load-bearing — deleting the declared status turns
-// the witness red. The coupling is asymmetric: deleting the WITNESS fails
-// nothing automatically, so an entry whose witness is removed must be
-// removed with it. An entry without an asserting witness is a spec bug,
-// not a carve-out — carve-outs are never grandfathered.
-var liveWitnessedStatuses = map[string]map[string]bool{
-	"GET /api/v1/roster/{roster}/lite": {"500": true},
-	"GET /api/v1/s1/uniforms/{roster}": {"500": true},
-}
+// the witness red. The reverse direction is enforced mechanically too:
+// the entries live in internal/spectest, and rest/spec_test.go DRIVES its
+// witness subtests from that registry with a 1:1 meta-assertion, so an
+// entry whose witness is deleted fails there instead of relying on review.
+// An entry without an asserting witness is a spec bug, not a carve-out —
+// carve-outs are never grandfathered.
+var liveWitnessedStatuses = func() map[string]map[string]bool {
+	m := map[string]map[string]bool{}
+	for _, lw := range spectest.LiveWitnessedStatuses {
+		if m[lw.Op] == nil {
+			m[lw.Op] = map[string]bool{}
+		}
+		m[lw.Op][lw.Status] = true
+	}
+	return m
+}()
 
 func TestSpec_DeclaredStatusesAreCorpusWitnessed(t *testing.T) {
 	_, model := loadSpec(t)

--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -888,6 +888,16 @@ func TestSpec_EveryOperationHasGolden(t *testing.T) {
 // observation in rest/spec_test.go (TestNewStack_SpecValidation's
 // lite_roster_500_outage / s1_uniforms_500_outage subtests), with the frozen
 // bodies pinned by TestNewStack_LiteAndS1OutagesAreInternalJSON.
+//
+// CONSTRAINT (ratified at the #127 review): every entry in this map MUST
+// name a live witness that (a) drives the status through the real stack
+// (rest.New + contract.RunCase, not a replayed golden) and (b) validates
+// the observed response via validateObserved, whose explicit-status rule
+// makes the spec line load-bearing — deleting the declared status turns
+// the witness red. The coupling is asymmetric: deleting the WITNESS fails
+// nothing automatically, so an entry whose witness is removed must be
+// removed with it. An entry without an asserting witness is a spec bug,
+// not a carve-out — carve-outs are never grandfathered.
 var liveWitnessedStatuses = map[string]map[string]bool{
 	"GET /api/v1/roster/{roster}/lite": {"500": true},
 	"GET /api/v1/s1/uniforms/{roster}": {"500": true},

--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -877,10 +877,22 @@ func TestSpec_EveryOperationHasGolden(t *testing.T) {
 // TestSpec_DeclaredStatusesAreCorpusWitnessed is the inverse of the replay
 // loop's explicit-status rule. The replay loop demands every witnessed
 // status be declared; this test demands every DECLARED status be witnessed,
-// so a fictional response code cannot ride along undetected. The single
-// carve-out is "401": the pre-routing auth tier is uniform across the
-// surface, declared on every operation, but witnessed by goldens on only
-// two of them — every other residual entry is a spec bug.
+// so a fictional response code cannot ride along undetected. Carve-outs:
+// "401" (the pre-routing auth tier is uniform across the surface, declared
+// on every operation, but witnessed by goldens on only two of them) and the
+// enumerated liveWitnessedStatuses — every other residual entry is a spec
+// bug.
+//
+// liveWitnessedStatuses are statuses the new stack demonstrably emits but
+// the FROZEN corpus never recorded: the witness is a live per-test outage
+// observation in rest/spec_test.go (TestNewStack_SpecValidation's
+// lite_roster_500_outage / s1_uniforms_500_outage subtests), with the frozen
+// bodies pinned by TestNewStack_LiteAndS1OutagesAreInternalJSON.
+var liveWitnessedStatuses = map[string]map[string]bool{
+	"GET /api/v1/roster/{roster}/lite": {"500": true},
+	"GET /api/v1/s1/uniforms/{roster}": {"500": true},
+}
+
 func TestSpec_DeclaredStatusesAreCorpusWitnessed(t *testing.T) {
 	_, model := loadSpec(t)
 
@@ -923,7 +935,12 @@ func TestSpec_DeclaredStatusesAreCorpusWitnessed(t *testing.T) {
 					unwitnessed401Ops++
 					continue
 				}
-				t.Errorf("declared status %s on %s is witnessed by no golden — explicit statuses must be corpus-witnessed (401 carve-out only)", code, id)
+				if liveWitnessedStatuses[key][code] {
+					// Witnessed live against the new stack (see the map's
+					// doc comment) — the frozen corpus cannot grow a golden.
+					continue
+				}
+				t.Errorf("declared status %s on %s is witnessed by no golden — explicit statuses must be corpus-witnessed (401 and liveWitnessedStatuses carve-outs only)", code, id)
 			}
 		}
 	}

--- a/internal/spectest/spectest.go
+++ b/internal/spectest/spectest.go
@@ -1,0 +1,47 @@
+// Package spectest carries the cross-package registry that couples the
+// spec's live-witnessed status carve-outs to the tests that witness them.
+//
+// Two test suites consume it, from opposite ends:
+//
+//   - contract/spec_test.go builds TestSpec_DeclaredStatusesAreCorpusWitnessed's
+//     carve-out map from the registry: a declared status with a registry
+//     entry is exempt from the corpus-witness rule.
+//   - rest/spec_test.go DRIVES its live-witness subtests from the registry:
+//     every entry must have a matching witness spec (fake override + request
+//     path) or the suite fails before any witness runs.
+//
+// That closes the asymmetry a doc comment cannot: deleting a witness
+// orphans its registry entry and fails rest's 1:1 meta-assertion; deleting
+// a registry entry while the spec still declares the status fails contract's
+// corpus-witness test; deleting both while the spec line stays fails the
+// corpus-witness test too. There is no editing order that silently
+// suppresses the invariant (ratified at the #127 review).
+//
+// The registry lives in internal/ deliberately: contract/'s public surface
+// is frozen at five entries (Cases/RunCase/CompareGolden/SaveGolden/
+// LoadGolden) and must not widen for test bookkeeping.
+package spectest
+
+// LiveWitness names one spec-declared status the FROZEN golden corpus never
+// recorded, together with the live observation that witnesses it instead.
+type LiveWitness struct {
+	// Op is the spec operation key, "METHOD /spec/path/{template}".
+	Op string
+	// Status is the declared response code the corpus cannot witness.
+	Status string
+	// Witness is the rest/spec_test.go subtest name (under
+	// TestNewStack_SpecValidation) that observes Status live against the
+	// real stack and validates it under the explicit-status rule.
+	Witness string
+}
+
+// LiveWitnessedStatuses is the registry. Constraint (ratified at the #127
+// review): every entry's witness must (a) drive the status through the real
+// stack (rest.New + contract.RunCase, not a replayed golden) and (b)
+// validate the observed response via validateObserved, whose explicit-status
+// rule makes the spec line load-bearing. Entries without an asserting
+// witness are spec bugs, not carve-outs — carve-outs are never grandfathered.
+var LiveWitnessedStatuses = []LiveWitness{
+	{Op: "GET /api/v1/roster/{roster}/lite", Status: "500", Witness: "lite_roster_500_outage"},
+	{Op: "GET /api/v1/s1/uniforms/{roster}", Status: "500", Witness: "s1_uniforms_500_outage"},
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -217,6 +217,8 @@ paths:
           $ref: '#/components/responses/Error'
         "401":
           $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/Error'
         default:
           $ref: '#/components/responses/Error'
 
@@ -239,6 +241,8 @@ paths:
           $ref: '#/components/responses/Error'
         "401":
           $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/Error'
         default:
           $ref: '#/components/responses/Error'
 

--- a/rest/fake_rosters_test.go
+++ b/rest/fake_rosters_test.go
@@ -40,13 +40,15 @@ func (f *fakeDatastore) FindS1UniformsRosterByType(t proto.RosterType) (*proto.S
 	if f.findS1UniformsRosterByType != nil {
 		return f.findS1UniformsRosterByType(t)
 	}
-	if t != proto.RosterType_ROSTER_TYPE_COMBAT {
+	switch t {
+	case proto.RosterType_ROSTER_TYPE_COMBAT:
+		return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{
+			1: seedJarvisS1Uniforms(),
+			2: seedDoeS1Uniforms(),
+		}}, nil
+	default:
 		return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{}}, nil
 	}
-	return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{
-		1: seedJarvisS1Uniforms(),
-		2: seedDoeS1Uniforms(),
-	}}, nil
 }
 
 // seedJarvisLite mirrors the recording seed's lite view of the rich profile:

--- a/rest/fake_rosters_test.go
+++ b/rest/fake_rosters_test.go
@@ -1,0 +1,123 @@
+package rest_test
+
+import (
+	"github.com/7cav/api/proto"
+)
+
+// Roster seeds for the golden replay, mirroring the recording seed
+// (contract/fake_datastore_test.go, "Rosters" section) exactly: COMBAT
+// carries the two seed profiles keyed by relation id, ARLINGTON is the
+// injected outage on the FULL roster route, and every other roster is
+// empty-but-present ({"profiles":{}} on the wire).
+
+func (f *fakeDatastore) FindRosterByType(t proto.RosterType) (*proto.Roster, error) {
+	if f.findRosterByType != nil {
+		return f.findRosterByType(t)
+	}
+	switch t {
+	case proto.RosterType_ROSTER_TYPE_COMBAT:
+		return &proto.Roster{Profiles: map[uint64]*proto.Profile{1: seedJarvis(), 2: seedDoe()}}, nil
+	case proto.RosterType_ROSTER_TYPE_ARLINGTON:
+		return nil, errOutage
+	default:
+		return &proto.Roster{Profiles: map[uint64]*proto.Profile{}}, nil
+	}
+}
+
+func (f *fakeDatastore) FindLiteRosterByType(t proto.RosterType) (*proto.LiteRoster, error) {
+	if f.findLiteRosterByType != nil {
+		return f.findLiteRosterByType(t)
+	}
+	switch t {
+	case proto.RosterType_ROSTER_TYPE_COMBAT:
+		return &proto.LiteRoster{Profiles: map[uint64]*proto.LiteProfile{1: seedJarvisLite(), 2: seedDoeLite()}}, nil
+	default:
+		return &proto.LiteRoster{Profiles: map[uint64]*proto.LiteProfile{}}, nil
+	}
+}
+
+func (f *fakeDatastore) FindS1UniformsRosterByType(t proto.RosterType) (*proto.S1UniformsRoster, error) {
+	if f.findS1UniformsRosterByType != nil {
+		return f.findS1UniformsRosterByType(t)
+	}
+	if t != proto.RosterType_ROSTER_TYPE_COMBAT {
+		return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{}}, nil
+	}
+	return &proto.S1UniformsRoster{Profiles: map[uint64]*proto.S1UniformsProfile{
+		1: seedJarvisS1Uniforms(),
+		2: seedDoeS1Uniforms(),
+	}}, nil
+}
+
+// seedJarvisLite mirrors the recording seed's lite view of the rich profile:
+// the records/awards collections collapse to the two scalar summary dates.
+// KeycloakId stays set so the mapper dropping it is observable in the replay.
+func seedJarvisLite() *proto.LiteProfile {
+	j := seedJarvis()
+	return &proto.LiteProfile{
+		User:              j.User,
+		Rank:              j.Rank,
+		RealName:          j.RealName,
+		UniformUrl:        j.UniformUrl,
+		Roster:            j.Roster,
+		Primary:           j.Primary,
+		Secondaries:       j.Secondaries,
+		JoinDate:          j.JoinDate,
+		PromotionDate:     j.PromotionDate,
+		KeycloakId:        j.KeycloakId,
+		DiscordId:         j.DiscordId,
+		AwardDate:         "2021-03-01",
+		RecordDate:        "2020-10-17",
+		LastForumPostDate: j.LastForumPostDate,
+		Mos:               j.Mos,
+	}
+}
+
+// seedDoeLite mirrors the recording seed's sparse lite profile: unset nested
+// messages nil, collections empty, summary dates "".
+func seedDoeLite() *proto.LiteProfile {
+	d := seedDoe()
+	return &proto.LiteProfile{
+		User:            d.User,
+		Rank:            d.Rank,
+		RealName:        d.RealName,
+		UniformUrl:      d.UniformUrl,
+		Roster:          d.Roster,
+		Secondaries:     []*proto.Position{},
+		JoinDate:        d.JoinDate,
+		ConsoleGamertag: d.ConsoleGamertag,
+	}
+}
+
+// seedJarvisS1Uniforms mirrors the recording seed's S1 uniforms view: the
+// tool-specific shape (S1UniformsRank without rankId, title-only secondary
+// positions, the uniform dates and area of responsibility).
+func seedJarvisS1Uniforms() *proto.S1UniformsProfile {
+	return &proto.S1UniformsProfile{
+		User:                     &proto.User{UserId: 3, Username: "Jarvis.A"},
+		Rank:                     &proto.S1UniformsRank{RankShort: "MG", RankFull: "Major General", RankImageUrl: "https://7cav.us/data/roster_ranks/0/4.jpg?1741364618"},
+		RealName:                 "Adam Jarvis",
+		UniformUrl:               "https://7cav.us/data/roster_uniforms/0/1.jpg",
+		UniformDate:              "2025-11-02",
+		UniformUpdateTriggerDate: "2025-12-01",
+		Roster:                   proto.RosterType_ROSTER_TYPE_COMBAT,
+		PrimaryPositionTitle:     "Regimental Technical Aide",
+		Secondaries:              []*proto.S1UniformsPosition{{PositionTitle: "S6 Web Developer"}},
+		JoinDate:                 "2014-02-08",
+		PromotionDate:            "2020-10-17",
+		AreaOfResponsibility:     "S6",
+	}
+}
+
+func seedDoeS1Uniforms() *proto.S1UniformsProfile {
+	return &proto.S1UniformsProfile{
+		User:                 &proto.User{UserId: 8, Username: "John.Doe"},
+		Rank:                 &proto.S1UniformsRank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "https://7cav.us/data/roster_ranks/0/22.jpg"},
+		RealName:             "John Doe",
+		UniformUrl:           "https://7cav.us/data/roster_uniforms/0/2.jpg",
+		Roster:               proto.RosterType_ROSTER_TYPE_COMBAT,
+		PrimaryPositionTitle: "Rifleman",
+		Secondaries:          []*proto.S1UniformsPosition{},
+		JoinDate:             "2026-01-15",
+	}
+}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -113,6 +113,11 @@ func routes(ds datastores.Datastore, rc datastores.TicketReferenceCache) *http.S
 	// lookups, plural "milpacs" everywhere else. Frozen by the corpus.
 	handle(mux, "GET /api/v1/milpac/discord/{discord_id}", "read", getProfileByDiscordID(ds))
 	handle(mux, "GET /api/v1/milpac/gamertag/{gamertag}", "read", getProfileByGamertag(ds))
+	// Roster routes (#127): one member set, three profile shapes. {roster}
+	// binds the RosterType enum by name OR number (see types.ParseRosterType).
+	handle(mux, "GET /api/v1/roster/{roster}", "read", getRoster(ds))
+	handle(mux, "GET /api/v1/roster/{roster}/lite", "read", getLiteRoster(ds))
+	handle(mux, "GET /api/v1/s1/uniforms/{roster}", "read", getS1UniformsRoster(ds))
 
 	// --- tickets (scope: read:tickets) -----------------------------------
 	// The literal /categories segment wins over {ticket_id} (mux precedence,

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -53,6 +53,11 @@ type fakeDatastore struct {
 	listTicketMessages     func(ticketID uint32, afterCursor string, perPage uint32, includeHidden bool) ([]*proto.Message, string, bool, error)
 	listCategories         func() ([]*proto.Category, error)
 
+	// Roster overrides (seeded defaults live in fake_rosters_test.go).
+	findRosterByType           func(proto.RosterType) (*proto.Roster, error)
+	findLiteRosterByType       func(proto.RosterType) (*proto.LiteRoster, error)
+	findS1UniformsRosterByType func(proto.RosterType) (*proto.S1UniformsRoster, error)
+
 	// lastRC records the TicketReferenceCache the handlers handed the most
 	// recent rc-consuming datastore call — the identity pin asserts it IS the
 	// cache rest.New received (no copy, no substitute).
@@ -287,6 +292,21 @@ var implementedCases = []string{
 	"tickets/messages_invalid_cursor_snake",
 	"tickets/messages_unknown_ticket",
 	"tickets/messages_parse_error",
+	"roster/combat_by_name",
+	"roster/combat_by_number",
+	"roster/reserve_empty",
+	"roster/unspecified_by_name",
+	"roster/unspecified_by_number",
+	"roster/bogus_enum",
+	"roster/internal_error",
+	"roster/unknown_query_param_ignored",
+	"roster/lite_combat_by_name",
+	"roster/lite_combat_by_number",
+	"roster/lite_reserve_empty",
+	"roster/lite_unspecified",
+	"s1/uniforms_combat_by_name",
+	"s1/uniforms_combat_by_number",
+	"s1/uniforms_unspecified",
 	"auth/milpacs_missing_header",
 	"auth/milpacs_raw_key",
 	"auth/milpacs_invalid_key",

--- a/rest/rosters.go
+++ b/rest/rosters.go
@@ -1,0 +1,210 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/types"
+)
+
+// The three roster routes (#127) serve the SAME member set in three profile
+// shapes (the domain glossary's Profile / LiteProfile / S1UniformsProfile):
+//
+//	GET /api/v1/roster/{roster}        → Roster            (full)
+//	GET /api/v1/roster/{roster}/lite   → LiteRoster        (lite)
+//	GET /api/v1/s1/uniforms/{roster}   → S1UniformsRoster  (S1 uniforms tool)
+//
+// All three bind the RosterType enum path parameter in both golden-pinned
+// forms (name or number — see types.ParseRosterType), reject the zero value
+// with the frozen 'cannot request null roster type' 400, and serialize the
+// native wire types directly to JSON (single marshal — the old stack's
+// proto→JSON double-marshal was a known latency bug on the multi-megabyte
+// rosters; do not reproduce it).
+//
+// RosterRequest's only field is path-bound, so nothing is query-bindable on
+// these routes and the generated gateway handlers never called ParseForm
+// (verified against proto/milpacs.pb.gw.go) — unknown parameters AND
+// malformed query syntax are ignored alike (the unknown_query_param_ignored
+// golden pins the former).
+
+// bindRosterPath binds the {roster} path parameter: the gateway's enum parse
+// (wrapped in the frozen type-mismatch 400 on failure, parameter name
+// "roster" — the proto field the gateway cited) followed by the old
+// handlers' zero-value guard. The guard ran in the RPC body AFTER the
+// gateway bind, so a bogus literal answers the type-mismatch text while
+// ROSTER_TYPE_UNSPECIFIED / 0 answer the null-roster text — order frozen by
+// the bogus_enum and unspecified_* goldens. On failure the response is
+// already written.
+func bindRosterPath(w http.ResponseWriter, r *http.Request) (types.RosterType, bool) {
+	rt, err := types.ParseRosterType(r.PathValue("roster"))
+	if err != nil {
+		// Gateway type-mismatch tier, enum-parse text leaked. Frozen.
+		writeError(w, r, codeInvalidArgument, "type mismatch, parameter: %s, error: %v", "roster", err)
+		return 0, false
+	}
+	if rt == types.RosterTypeUnspecified {
+		// Old handler guard (servers/grpc GetRoster et al.). Frozen.
+		writeError(w, r, codeInvalidArgument, "cannot request null roster type")
+		return 0, false
+	}
+	return rt, true
+}
+
+// getRoster serves GET /api/v1/roster/{roster}: the full roster. Error
+// message strings frozen from the old handler (servers/grpc GetRoster — the
+// enum NAME interpolates into the Internal message via %s).
+func getRoster(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rt, ok := bindRosterPath(w, r)
+		if !ok {
+			return
+		}
+		roster, err := ds.FindRosterByType(proto.RosterType(rt))
+		if err != nil {
+			writeError(w, r, codeInternal, "fetch roster %s: %v", rt, err)
+			return
+		}
+		if roster == nil {
+			// Datastore invariant violated (non-nil roster on nil error):
+			// unreachable through the real datastore, guarded so a future bug
+			// is a clean 500, not a panic.
+			writeError(w, r, codeInternal, "datastore returned no roster")
+			return
+		}
+		out := types.Roster{Profiles: make(map[uint64]*types.Profile, len(roster.GetProfiles()))}
+		for id, p := range roster.GetProfiles() {
+			out.Profiles[id] = profileFromProto(p)
+		}
+		writeJSON(w, r, out)
+	})
+}
+
+// getLiteRoster serves GET /api/v1/roster/{roster}/lite: the same member set
+// as LiteProfile views. Error message strings frozen from the old handler
+// (servers/grpc GetLiteRoster).
+func getLiteRoster(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rt, ok := bindRosterPath(w, r)
+		if !ok {
+			return
+		}
+		roster, err := ds.FindLiteRosterByType(proto.RosterType(rt))
+		if err != nil {
+			writeError(w, r, codeInternal, "fetch lite roster %s: %v", rt, err)
+			return
+		}
+		if roster == nil {
+			writeError(w, r, codeInternal, "datastore returned no roster")
+			return
+		}
+		out := types.LiteRoster{Profiles: make(map[uint64]*types.LiteProfile, len(roster.GetProfiles()))}
+		for id, p := range roster.GetProfiles() {
+			out.Profiles[id] = liteProfileFromProto(p)
+		}
+		writeJSON(w, r, out)
+	})
+}
+
+// liteProfileFromProto maps the datastore's proto-typed lite profile to the
+// wire type. Same discipline as profileFromProto: collections always
+// allocated, unset nested messages stay nil, keycloakId dropped (the wire
+// type never had the field — documented break).
+func liteProfileFromProto(p *proto.LiteProfile) *types.LiteProfile {
+	out := &types.LiteProfile{
+		RealName:          p.GetRealName(),
+		UniformUrl:        p.GetUniformUrl(),
+		Roster:            types.RosterType(p.GetRoster()),
+		Secondaries:       make([]*types.Position, 0, len(p.GetSecondaries())),
+		JoinDate:          p.GetJoinDate(),
+		PromotionDate:     p.GetPromotionDate(),
+		DiscordId:         p.GetDiscordId(),
+		AwardDate:         p.GetAwardDate(),
+		RecordDate:        p.GetRecordDate(),
+		LastForumPostDate: p.GetLastForumPostDate(),
+		Mos:               p.GetMos(),
+		ConsoleGamertag:   p.GetConsoleGamertag(),
+	}
+	if u := p.GetUser(); u != nil {
+		out.User = &types.User{UserId: u.GetUserId(), Username: u.GetUsername()}
+	}
+	if rk := p.GetRank(); rk != nil {
+		out.Rank = &types.Rank{
+			RankShort:    rk.GetRankShort(),
+			RankFull:     rk.GetRankFull(),
+			RankImageUrl: rk.GetRankImageUrl(),
+			RankId:       rk.GetRankId(),
+		}
+	}
+	out.Primary = positionFromProto(p.GetPrimary())
+	for _, s := range p.GetSecondaries() {
+		out.Secondaries = append(out.Secondaries, positionFromProto(s))
+	}
+	return out
+}
+
+// getS1UniformsRoster serves GET /api/v1/s1/uniforms/{roster}: the same
+// member set as S1UniformsProfile views. Error message strings frozen from
+// the old handler (servers/grpc GetS1UniformsRoster).
+func getS1UniformsRoster(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rt, ok := bindRosterPath(w, r)
+		if !ok {
+			return
+		}
+		roster, err := ds.FindS1UniformsRosterByType(proto.RosterType(rt))
+		if err != nil {
+			writeError(w, r, codeInternal, "fetch s1 uniforms roster %s: %v", rt, err)
+			return
+		}
+		if roster == nil {
+			writeError(w, r, codeInternal, "datastore returned no roster")
+			return
+		}
+		out := types.S1UniformsRoster{Profiles: make(map[uint64]*types.S1UniformsProfile, len(roster.GetProfiles()))}
+		for id, p := range roster.GetProfiles() {
+			out.Profiles[id] = s1UniformsProfileFromProto(p)
+		}
+		writeJSON(w, r, out)
+	})
+}
+
+// s1UniformsProfileFromProto maps the datastore's proto-typed S1 uniforms
+// profile to the wire type — same discipline as the other two mappers.
+func s1UniformsProfileFromProto(p *proto.S1UniformsProfile) *types.S1UniformsProfile {
+	out := &types.S1UniformsProfile{
+		RealName:                 p.GetRealName(),
+		UniformUrl:               p.GetUniformUrl(),
+		UniformDate:              p.GetUniformDate(),
+		UniformUpdateTriggerDate: p.GetUniformUpdateTriggerDate(),
+		Roster:                   types.RosterType(p.GetRoster()),
+		PrimaryPositionTitle:     p.GetPrimaryPositionTitle(),
+		Secondaries:              make([]*types.S1UniformsPosition, 0, len(p.GetSecondaries())),
+		JoinDate:                 p.GetJoinDate(),
+		PromotionDate:            p.GetPromotionDate(),
+		AreaOfResponsibility:     p.GetAreaOfResponsibility(),
+	}
+	if u := p.GetUser(); u != nil {
+		out.User = &types.User{UserId: u.GetUserId(), Username: u.GetUsername()}
+	}
+	if rk := p.GetRank(); rk != nil {
+		out.Rank = &types.S1UniformsRank{
+			RankShort:    rk.GetRankShort(),
+			RankFull:     rk.GetRankFull(),
+			RankImageUrl: rk.GetRankImageUrl(),
+		}
+	}
+	for _, s := range p.GetSecondaries() {
+		out.Secondaries = append(out.Secondaries, s1PositionFromProto(s))
+	}
+	return out
+}
+
+// s1PositionFromProto maps an S1 uniforms position, preserving nil (null on
+// the wire) — the S1 counterpart of positionFromProto.
+func s1PositionFromProto(p *proto.S1UniformsPosition) *types.S1UniformsPosition {
+	if p == nil {
+		return nil
+	}
+	return &types.S1UniformsPosition{PositionTitle: p.GetPositionTitle()}
+}

--- a/rest/rosters_test.go
+++ b/rest/rosters_test.go
@@ -204,17 +204,33 @@ func TestNewStack_NilRosterWithNilErrorIsInternalJSON(t *testing.T) {
 }
 
 // A roster message whose profiles map is nil (distinct from empty) still
-// serves {"profiles":{}} — the old stack's EmitUnpopulated marshaler emitted
-// {} for a nil proto map, and the mapper's unconditional allocation preserves
-// that.
+// serves {"profiles":{}} on ALL THREE shapes — the old stack's
+// EmitUnpopulated marshaler emitted {} for a nil proto map, and each mapper's
+// unconditional allocation preserves that. The loop closes the S1-empty and
+// nil-proto-map gaps in one stroke: no shape can serve null.
 func TestNewStack_NilProfilesMapServesEmptyObject(t *testing.T) {
-	h := rest.New(&fakeDatastore{
-		findRosterByType: func(proto.RosterType) (*proto.Roster, error) { return &proto.Roster{}, nil },
-	}, &stubReferenceCache{})
-
-	rr := rosterGet(t, h, "/api/v1/roster/ROSTER_TYPE_COMBAT")
-	require.Equal(t, http.StatusOK, rr.Code)
-	assert.JSONEq(t, `{"profiles":{}}`, rr.Body.String())
+	cases := []struct {
+		path string
+		fake *fakeDatastore
+	}{
+		{"/api/v1/roster/ROSTER_TYPE_COMBAT", &fakeDatastore{
+			findRosterByType: func(proto.RosterType) (*proto.Roster, error) { return &proto.Roster{}, nil },
+		}},
+		{"/api/v1/roster/ROSTER_TYPE_COMBAT/lite", &fakeDatastore{
+			findLiteRosterByType: func(proto.RosterType) (*proto.LiteRoster, error) { return &proto.LiteRoster{}, nil },
+		}},
+		{"/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", &fakeDatastore{
+			findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) { return &proto.S1UniformsRoster{}, nil },
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			h := rest.New(tc.fake, &stubReferenceCache{})
+			rr := rosterGet(t, h, tc.path)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.JSONEq(t, `{"profiles":{}}`, rr.Body.String())
+		})
+	}
 }
 
 // Wrong-method on a roster route keeps the ruled 405 + Allow (the fallback's

--- a/rest/rosters_test.go
+++ b/rest/rosters_test.go
@@ -1,0 +1,304 @@
+package rest_test
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/7cav/api/contract"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rosterGet drives one authenticated GET against the mounted stack.
+func rosterGet(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+// rosterRoutePaths is the three-shape surface under one happy path value —
+// the per-route loops below witness shared behavior on every shape, so no
+// route can be registered without it.
+var rosterRoutePaths = []string{
+	"/api/v1/roster/ROSTER_TYPE_COMBAT",
+	"/api/v1/roster/ROSTER_TYPE_COMBAT/lite",
+	"/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT",
+}
+
+// The scope gate is witnessed PER roster route: a ticket-scoped key
+// (read:tickets, not read) must 403 with the frozen body on each of the
+// three shapes (same loop as the profile routes — proves no route was
+// registered without its requireScope gate).
+func TestNewStack_AllRosterRoutes403UnderTicketScopedKey(t *testing.T) {
+	h := newStack(t)
+
+	for _, path := range rosterRoutePaths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_ticketskey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code)
+			assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// Uniform tier order on the roster surface (the ruled cutover break, same
+// ruling as the profile routes): a wrong-scope key with a BOGUS enum literal
+// gets the 403, not the binding 400 — requireScope wraps the handler, so the
+// scope gate answers before bindRosterPath runs.
+func TestNewStack_RosterWrongScopeBeatsBogusEnum_RuledBreak(t *testing.T) {
+	h := newStack(t)
+
+	for _, path := range []string{
+		"/api/v1/roster/IMAGINARY_ROSTER",
+		"/api/v1/roster/IMAGINARY_ROSTER/lite",
+		"/api/v1/s1/uniforms/IMAGINARY_ROSTER",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer cav7_ticketskey")
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code,
+				"403 answers before the enum-binding 400 — ruled, NOT old-stack parity")
+			assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// The bogus-enum 400 wraps the leaked parse text on ALL three bindings (the
+// corpus pins it on the full roster only; lite and s1 share bindRosterPath,
+// pinned here).
+func TestNewStack_BogusEnumIs400OnEveryRosterBinding(t *testing.T) {
+	h := newStack(t)
+
+	for _, path := range []string{
+		"/api/v1/roster/IMAGINARY_ROSTER/lite",
+		"/api/v1/s1/uniforms/IMAGINARY_ROSTER",
+	} {
+		t.Run(path, func(t *testing.T) {
+			rr := rosterGet(t, h, path)
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.JSONEq(t, `{"code":3,"message":"type mismatch, parameter: roster, error: IMAGINARY_ROSTER is not valid","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// A number that parses but names no cataloged roster is the same gateway
+// rejection — the old gateway checked the enum's VALUE set, not just syntax.
+func TestNewStack_OutOfCatalogNumberIs400(t *testing.T) {
+	h := newStack(t)
+
+	rr := rosterGet(t, h, "/api/v1/roster/7")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.JSONEq(t, `{"code":3,"message":"type mismatch, parameter: roster, error: 7 is not valid","details":[]}`, rr.Body.String())
+}
+
+// The number form inherits the gateway's base-0 parse on the live route:
+// /roster/0x1 is the combat roster — byte-identical to /roster/1 (the same
+// frozen leniency tier as the profile path id, witnessed end-to-end).
+func TestNewStack_RosterNumberFormParsesBaseZero(t *testing.T) {
+	h := newStack(t)
+
+	want := rosterGet(t, h, "/api/v1/roster/1")
+	require.Equal(t, http.StatusOK, want.Code)
+
+	got := rosterGet(t, h, "/api/v1/roster/0x1")
+	require.Equal(t, http.StatusOK, got.Code)
+	assert.Equal(t, want.Body.String(), got.Body.String())
+}
+
+// Every cataloged non-zero number serves: the numeric form is the upstream
+// roster_id FK, golden-pinned for 1 — the rest of the catalog answers 200
+// with the seeded empty-roster shape.
+func TestNewStack_EveryCatalogedRosterNumberServes(t *testing.T) {
+	h := newStack(t)
+
+	for n := 2; n <= 6; n++ {
+		path := fmt.Sprintf("/api/v1/roster/%d", n)
+		if n == 5 {
+			continue // ROSTER_TYPE_ARLINGTON is the seeded outage (golden-pinned 500)
+		}
+		t.Run(path, func(t *testing.T) {
+			rr := rosterGet(t, h, path)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.JSONEq(t, `{"profiles":{}}`, rr.Body.String())
+		})
+	}
+}
+
+// RosterRequest's only field is path-bound, so the generated gateway
+// handlers never called ParseForm (verified against proto/milpacs.pb.gw.go):
+// malformed query SYNTAX falls through on all three routes — same leniency
+// as the discord/gamertag routes, the opposite of the profile id/username
+// routes. The unknown_query_param_ignored golden pins the unknown-param half.
+func TestNewStack_RosterRoutes_MalformedQuerySyntaxIgnored(t *testing.T) {
+	h := newStack(t)
+
+	for _, base := range rosterRoutePaths {
+		path := base + "?junk=%zz"
+		t.Run(path, func(t *testing.T) {
+			rr := rosterGet(t, h, path)
+			require.Equal(t, http.StatusOK, rr.Code, "old gateway never ParseForm'd the roster routes")
+		})
+	}
+}
+
+// A datastore failure on the lite and s1 bindings surfaces as the frozen
+// Internal shape with each handler's own wrapped message — the full-roster
+// variant is golden-pinned (roster/internal_error); the corpus has no outage
+// cases for these two, so these pin them. The enum NAME interpolates via %s.
+func TestNewStack_LiteAndS1OutagesAreInternalJSON(t *testing.T) {
+	h := rest.New(&fakeDatastore{
+		findLiteRosterByType:       func(proto.RosterType) (*proto.LiteRoster, error) { return nil, io.ErrUnexpectedEOF },
+		findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) { return nil, io.ErrUnexpectedEOF },
+	}, &stubReferenceCache{})
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/api/v1/roster/ROSTER_TYPE_COMBAT/lite", "fetch lite roster ROSTER_TYPE_COMBAT: unexpected EOF"},
+		{"/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", "fetch s1 uniforms roster ROSTER_TYPE_COMBAT: unexpected EOF"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			rr := rosterGet(t, h, tc.path)
+			require.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.JSONEq(t, `{"code":13,"message":"`+tc.want+`","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// A nil roster with a nil error violates the datastore invariant (possible
+// only from a future datastore bug): a clean 500 on every shape, not a panic
+// or a fabricated empty 200.
+func TestNewStack_NilRosterWithNilErrorIsInternalJSON(t *testing.T) {
+	h := rest.New(&fakeDatastore{
+		findRosterByType:           func(proto.RosterType) (*proto.Roster, error) { return nil, nil },
+		findLiteRosterByType:       func(proto.RosterType) (*proto.LiteRoster, error) { return nil, nil },
+		findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) { return nil, nil },
+	}, &stubReferenceCache{})
+
+	for _, path := range rosterRoutePaths {
+		t.Run(path, func(t *testing.T) {
+			rr := rosterGet(t, h, path)
+			require.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.JSONEq(t, `{"code":13,"message":"datastore returned no roster","details":[]}`, rr.Body.String())
+		})
+	}
+}
+
+// A roster message whose profiles map is nil (distinct from empty) still
+// serves {"profiles":{}} — the old stack's EmitUnpopulated marshaler emitted
+// {} for a nil proto map, and the mapper's unconditional allocation preserves
+// that.
+func TestNewStack_NilProfilesMapServesEmptyObject(t *testing.T) {
+	h := rest.New(&fakeDatastore{
+		findRosterByType: func(proto.RosterType) (*proto.Roster, error) { return &proto.Roster{}, nil },
+	}, &stubReferenceCache{})
+
+	rr := rosterGet(t, h, "/api/v1/roster/ROSTER_TYPE_COMBAT")
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `{"profiles":{}}`, rr.Body.String())
+}
+
+// Wrong-method on a roster route keeps the ruled 405 + Allow (the fallback's
+// GET probe is pattern-based, so the parameterized roster patterns are
+// covered — witnessed once per fan-out surface).
+func TestNewStack_WrongMethodOnRosterRouteIs405WithAllow(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/roster/ROSTER_TYPE_COMBAT", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	assert.Equal(t, "GET, HEAD", rr.Header().Get("Allow"))
+	assert.JSONEq(t, `{"code":12,"message":"Method Not Allowed","details":[]}`, rr.Body.String())
+}
+
+// The large-roster criterion (#127): the combat roster is 15.7MB of JSON in
+// production — the shape must hold at full size, not just on the two-member
+// golden. The fake serves 4000 members cloned from the SAME seeds the golden
+// freezes; the response (through the real gzip layer) must compare clean
+// member-by-member against the golden's own profile objects — semantic
+// equality at full size, with the gzip layer earning its keep on the way.
+func TestNewStack_LargeRosterComparesCleanAtFullSize(t *testing.T) {
+	const members = 4000
+
+	h := rest.New(&fakeDatastore{
+		findRosterByType: func(proto.RosterType) (*proto.Roster, error) {
+			profiles := make(map[uint64]*proto.Profile, members)
+			for i := uint64(1); i <= members; i++ {
+				if i%2 == 1 {
+					profiles[i] = seedJarvis()
+				} else {
+					profiles[i] = seedDoe()
+				}
+			}
+			return &proto.Roster{Profiles: profiles}, nil
+		},
+	}, &stubReferenceCache{})
+
+	// The expectation comes from the committed golden, not from re-running
+	// the mappers: each cloned member must equal the golden's recording of
+	// the same seed.
+	g, err := contract.LoadGolden(goldensDir, "roster/combat_by_name")
+	require.NoError(t, err)
+	var golden struct {
+		Profiles map[string]json.RawMessage `json:"profiles"`
+	}
+	require.NoError(t, json.Unmarshal(g.Body, &golden))
+	var wantJarvis, wantDoe any
+	require.NoError(t, json.Unmarshal(golden.Profiles["1"], &wantJarvis))
+	require.NoError(t, json.Unmarshal(golden.Profiles["2"], &wantDoe))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/roster/ROSTER_TYPE_COMBAT", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "gzip", rr.Result().Header.Get("Content-Encoding"))
+	zr, err := gzip.NewReader(rr.Body)
+	require.NoError(t, err)
+	raw, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close(), "gzip trailer must be intact at full size")
+
+	var got struct {
+		Profiles map[string]json.RawMessage `json:"profiles"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Len(t, got.Profiles, members)
+
+	for i := uint64(1); i <= members; i++ {
+		key := fmt.Sprintf("%d", i)
+		var member any
+		require.NoError(t, json.Unmarshal(got.Profiles[key], &member))
+		want := wantJarvis
+		if i%2 == 0 {
+			want = wantDoe
+		}
+		if !assert.ObjectsAreEqual(want, member) {
+			require.Equal(t, want, member, "member %s diverges from the golden seed shape", key)
+		}
+	}
+}

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/7cav/api/contract"
+	"github.com/7cav/api/internal/spectest"
 	"github.com/7cav/api/proto"
 	"github.com/7cav/api/rest"
 	"github.com/pb33f/libopenapi"
@@ -238,33 +239,64 @@ func TestNewStack_SpecValidation(t *testing.T) {
 		validateObserved(t, model, rv, "/api/v1/milpacs/ranks", g)
 	})
 
-	// The lite and S1-uniforms outage tier, observed live against per-test
-	// outage fakes — the corpus has no committed outage goldens for these two
-	// operations (TestNewStack_LiteAndS1OutagesAreInternalJSON pins the frozen
-	// bodies), so the spec's explicit "500" on each operation is witnessed
-	// here, per the explicit-status rule.
-	t.Run("lite_roster_500_outage", func(t *testing.T) {
-		oh := rest.New(&fakeDatastore{
-			findLiteRosterByType: func(proto.RosterType) (*proto.LiteRoster, error) { return nil, io.ErrUnexpectedEOF },
-		}, &stubReferenceCache{})
-		g, _, err := contract.RunCase(oh, contract.Case{
-			Name: "lite-roster-500", Method: http.MethodGet, Path: "/api/v1/roster/ROSTER_TYPE_COMBAT/lite", Auth: contract.AuthRead,
-			Notes: "synthesized: outage tier observed on the lite-roster operation",
+	// The live-witnessed statuses (spec carve-outs the FROZEN corpus cannot
+	// witness — TestNewStack_LiteAndS1OutagesAreInternalJSON pins the frozen
+	// bodies). The subtests are DRIVEN by the internal/spectest registry the
+	// contract-side carve-out map is built from, with a 1:1 meta-assertion
+	// in both directions, so the coupling is mechanical: deleting a witness
+	// spec here orphans its registry entry and fails below; deleting a
+	// registry entry while the spec still declares the status fails
+	// contract's TestSpec_DeclaredStatusesAreCorpusWitnessed. No editing
+	// order silently suppresses the invariant (ratified at #127 review).
+	type liveWitnessSpec struct {
+		status int
+		path   string
+		ds     *fakeDatastore
+	}
+	liveWitnesses := map[string]liveWitnessSpec{
+		"lite_roster_500_outage": {
+			status: http.StatusInternalServerError,
+			path:   "/api/v1/roster/ROSTER_TYPE_COMBAT/lite",
+			ds: &fakeDatastore{
+				findLiteRosterByType: func(proto.RosterType) (*proto.LiteRoster, error) { return nil, io.ErrUnexpectedEOF },
+			},
+		},
+		"s1_uniforms_500_outage": {
+			status: http.StatusInternalServerError,
+			path:   "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT",
+			ds: &fakeDatastore{
+				findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) { return nil, io.ErrUnexpectedEOF },
+			},
+		},
+	}
+	registered := map[string]bool{}
+	for _, lw := range spectest.LiveWitnessedStatuses {
+		require.False(t, registered[lw.Witness],
+			"registry names witness %q twice", lw.Witness)
+		registered[lw.Witness] = true
+		spec, ok := liveWitnesses[lw.Witness]
+		require.True(t, ok,
+			"registry entry %s %s names witness %q but no witness spec exists — an entry without an asserting witness is a spec bug, remove the entry or write the witness",
+			lw.Op, lw.Status, lw.Witness)
+		require.Equal(t, lw.Status, strconv.Itoa(spec.status),
+			"witness %q observes a different status than its registry entry declares", lw.Witness)
+		ran := false
+		t.Run(lw.Witness, func(t *testing.T) {
+			oh := rest.New(spec.ds, &stubReferenceCache{})
+			g, _, err := contract.RunCase(oh, contract.Case{
+				Name: lw.Witness, Method: http.MethodGet, Path: spec.path, Auth: contract.AuthRead,
+				Notes: "synthesized: live witness for the spec's explicit " + lw.Status + " (internal/spectest registry)",
+			})
+			require.NoError(t, err)
+			require.Equal(t, spec.status, g.Status)
+			validateObserved(t, model, rv, spec.path, g)
+			ran = true
 		})
-		require.NoError(t, err)
-		require.Equal(t, http.StatusInternalServerError, g.Status)
-		validateObserved(t, model, rv, "/api/v1/roster/ROSTER_TYPE_COMBAT/lite", g)
-	})
-	t.Run("s1_uniforms_500_outage", func(t *testing.T) {
-		oh := rest.New(&fakeDatastore{
-			findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) { return nil, io.ErrUnexpectedEOF },
-		}, &stubReferenceCache{})
-		g, _, err := contract.RunCase(oh, contract.Case{
-			Name: "s1-uniforms-500", Method: http.MethodGet, Path: "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", Auth: contract.AuthRead,
-			Notes: "synthesized: outage tier observed on the S1-uniforms operation",
-		})
-		require.NoError(t, err)
-		require.Equal(t, http.StatusInternalServerError, g.Status)
-		validateObserved(t, model, rv, "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", g)
-	})
+		require.True(t, ran,
+			"witness %q did not run to completion — a skipped witness leaves its carve-out unenforced", lw.Witness)
+	}
+	for name := range liveWitnesses {
+		require.True(t, registered[name],
+			"witness spec %q has no registry entry — remove the spec or register the carve-out in internal/spectest", name)
+	}
 }

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -7,8 +7,8 @@ package rest_test
 // operation, the four profile lookup operations (id, username, discord,
 // gamertag — #126), all five tickets operations (#129), and the three roster
 // operations (full/lite/S1 uniforms — #127) — the remaining operations are
-// witnessed once their routes land (#128). Same
-// non-vacuousness rules as the contract replay loop: the observed status
+// witnessed once their routes land (#128). Same non-vacuousness rules as the
+// contract replay loop: the observed status
 // must be EXPLICITLY documented on the operation, a JSON response requires
 // an application/json schema to validate against, and every implemented
 // case's path must be classified in specRoutes — unclassified paths fail,
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/7cav/api/contract"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/rest"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi-validator/paths"
 	"github.com/pb33f/libopenapi-validator/responses"
@@ -234,5 +236,35 @@ func TestNewStack_SpecValidation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusUnauthorized, g.Status)
 		validateObserved(t, model, rv, "/api/v1/milpacs/ranks", g)
+	})
+
+	// The lite and S1-uniforms outage tier, observed live against per-test
+	// outage fakes — the corpus has no committed outage goldens for these two
+	// operations (TestNewStack_LiteAndS1OutagesAreInternalJSON pins the frozen
+	// bodies), so the spec's explicit "500" on each operation is witnessed
+	// here, per the explicit-status rule.
+	t.Run("lite_roster_500_outage", func(t *testing.T) {
+		oh := rest.New(&fakeDatastore{
+			findLiteRosterByType: func(proto.RosterType) (*proto.LiteRoster, error) { return nil, io.ErrUnexpectedEOF },
+		}, &stubReferenceCache{})
+		g, _, err := contract.RunCase(oh, contract.Case{
+			Name: "lite-roster-500", Method: http.MethodGet, Path: "/api/v1/roster/ROSTER_TYPE_COMBAT/lite", Auth: contract.AuthRead,
+			Notes: "synthesized: outage tier observed on the lite-roster operation",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, g.Status)
+		validateObserved(t, model, rv, "/api/v1/roster/ROSTER_TYPE_COMBAT/lite", g)
+	})
+	t.Run("s1_uniforms_500_outage", func(t *testing.T) {
+		oh := rest.New(&fakeDatastore{
+			findS1UniformsRosterByType: func(proto.RosterType) (*proto.S1UniformsRoster, error) { return nil, io.ErrUnexpectedEOF },
+		}, &stubReferenceCache{})
+		g, _, err := contract.RunCase(oh, contract.Case{
+			Name: "s1-uniforms-500", Method: http.MethodGet, Path: "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", Auth: contract.AuthRead,
+			Notes: "synthesized: outage tier observed on the S1-uniforms operation",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, g.Status)
+		validateObserved(t, model, rv, "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT", g)
 	})
 }

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -5,8 +5,9 @@ package rest_test
 // response (not the committed golden — contract/spec_test.go already covers
 // those) is validated against the document. Today that means the ranks
 // operation, the four profile lookup operations (id, username, discord,
-// gamertag — #126), and all five tickets operations (#129) — the remaining
-// operations are witnessed once their routes land (#127–#128). Same
+// gamertag — #126), all five tickets operations (#129), and the three roster
+// operations (full/lite/S1 uniforms — #127) — the remaining operations are
+// witnessed once their routes land (#128). Same
 // non-vacuousness rules as the contract replay loop: the observed status
 // must be EXPLICITLY documented on the operation, a JSON response requires
 // an application/json schema to validate against, and every implemented
@@ -77,7 +78,26 @@ var specRoutes = map[string]string{
 	// Gamertag lookup: happy, not-found.
 	"/api/v1/milpac/gamertag/CavGamer77": "/api/v1/milpac/gamertag/{gamertag}",
 	"/api/v1/milpac/gamertag/GhostTag":   "/api/v1/milpac/gamertag/{gamertag}",
-	"/api/v1/does/not/exist":             "", // off-spec: unknown-path tier (mux behavior, not an operation)
+	// Full roster (#127): both enum path forms (name/number), empty roster,
+	// zero enum under both forms, bogus literal, injected outage — the
+	// unknown-query case's base path is the by-name happy path.
+	"/api/v1/roster/ROSTER_TYPE_COMBAT":      "/api/v1/roster/{roster}",
+	"/api/v1/roster/1":                       "/api/v1/roster/{roster}",
+	"/api/v1/roster/ROSTER_TYPE_RESERVE":     "/api/v1/roster/{roster}",
+	"/api/v1/roster/ROSTER_TYPE_UNSPECIFIED": "/api/v1/roster/{roster}",
+	"/api/v1/roster/0":                       "/api/v1/roster/{roster}",
+	"/api/v1/roster/IMAGINARY_ROSTER":        "/api/v1/roster/{roster}",
+	"/api/v1/roster/ROSTER_TYPE_ARLINGTON":   "/api/v1/roster/{roster}",
+	// Lite roster: name/number forms, empty roster, zero enum.
+	"/api/v1/roster/ROSTER_TYPE_COMBAT/lite":      "/api/v1/roster/{roster}/lite",
+	"/api/v1/roster/1/lite":                       "/api/v1/roster/{roster}/lite",
+	"/api/v1/roster/2/lite":                       "/api/v1/roster/{roster}/lite",
+	"/api/v1/roster/ROSTER_TYPE_UNSPECIFIED/lite": "/api/v1/roster/{roster}/lite",
+	// S1 uniforms: name/number forms, zero enum.
+	"/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT": "/api/v1/s1/uniforms/{roster}",
+	"/api/v1/s1/uniforms/1":                  "/api/v1/s1/uniforms/{roster}",
+	"/api/v1/s1/uniforms/0":                  "/api/v1/s1/uniforms/{roster}",
+	"/api/v1/does/not/exist":                 "", // off-spec: unknown-path tier (mux behavior, not an operation)
 }
 
 func loadSpecModel(t *testing.T) *v3.Document {

--- a/types/roster.go
+++ b/types/roster.go
@@ -3,7 +3,10 @@ package types
 // Roster is the full-roster response shape: the requested roster's complete
 // member set as full Profile views, keyed by milpac relation id (uint64 —
 // decimal string keys on the wire, the encoding/json integer-key form that
-// matches protojson's map encoding). The profiles map is always allocated:
+// matches protojson's map encoding; note encoding/json sorts the stringified
+// keys LEXICALLY ("10" before "2") where protojson ordered them numerically,
+// so responses are JSON-equal, not byte-equal, to the old stack). The
+// profiles map is always allocated:
 // an empty roster serializes as {"profiles":{}}, never null (the allocation
 // discipline lives in the handler's mapper; the reserve_empty golden proves
 // it).
@@ -20,8 +23,12 @@ type LiteRoster struct {
 // LiteProfile is the lite milpac view (the domain glossary's second profile
 // shape): the full Profile minus the records and awards collections, carrying
 // instead the two scalar summary dates (awardDate = most recent award,
-// recordDate = most recent promotion record — computed upstream by the
-// datastore, passed through here).
+// recordDate = most recent service-record entry of ANY type — all nine
+// record types, transfers and ELOAs included, not just promotions; see
+// getLatestServiceRecordDate, datastores/mysql.go — computed upstream by the
+// datastore, passed through here). Caveat: on the lite-roster query path the
+// datastore omits the Records/AwardRecords preloads, so these helpers compute
+// over whatever the query loaded.
 //
 // Deliberately ABSENT: keycloakId — same documented break as Profile.
 type LiteProfile struct {

--- a/types/roster.go
+++ b/types/roster.go
@@ -1,0 +1,43 @@
+package types
+
+// Roster is the full-roster response shape: the requested roster's complete
+// member set as full Profile views, keyed by milpac relation id (uint64 —
+// decimal string keys on the wire, the encoding/json integer-key form that
+// matches protojson's map encoding). The profiles map is always allocated:
+// an empty roster serializes as {"profiles":{}}, never null (the allocation
+// discipline lives in the handler's mapper; the reserve_empty golden proves
+// it).
+type Roster struct {
+	Profiles map[uint64]*Profile `json:"profiles"`
+}
+
+// LiteRoster is the lite-roster response shape: the same member set as
+// LiteProfile views (no records/awards arrays), keyed by milpac relation id.
+type LiteRoster struct {
+	Profiles map[uint64]*LiteProfile `json:"profiles"`
+}
+
+// LiteProfile is the lite milpac view (the domain glossary's second profile
+// shape): the full Profile minus the records and awards collections, carrying
+// instead the two scalar summary dates (awardDate = most recent award,
+// recordDate = most recent promotion record — computed upstream by the
+// datastore, passed through here).
+//
+// Deliberately ABSENT: keycloakId — same documented break as Profile.
+type LiteProfile struct {
+	User              *User           `json:"user"`
+	Rank              *Rank           `json:"rank"`
+	RealName          string          `json:"realName"`
+	UniformUrl        string          `json:"uniformUrl"`
+	Roster            RosterType      `json:"roster"`
+	Primary           *Position       `json:"primary"`
+	Secondaries       List[*Position] `json:"secondaries"`
+	JoinDate          string          `json:"joinDate"`
+	PromotionDate     string          `json:"promotionDate"`
+	DiscordId         string          `json:"discordId"`
+	AwardDate         string          `json:"awardDate"`
+	RecordDate        string          `json:"recordDate"`
+	LastForumPostDate string          `json:"lastForumPostDate"`
+	Mos               string          `json:"mos"`
+	ConsoleGamertag   string          `json:"consoleGamertag"`
+}

--- a/types/roster_test.go
+++ b/types/roster_test.go
@@ -1,0 +1,104 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The populated lite form: the full Profile minus records/awards arrays,
+// plus the two scalar summary dates — the shape the lite roster goldens
+// freeze (contract/goldens/roster/lite_combat_by_name.golden.json).
+func TestLiteProfile_WireForm(t *testing.T) {
+	m := marshalToMap(t, types.LiteProfile{
+		User:              &types.User{UserId: 3, Username: "Jarvis.A"},
+		Rank:              &types.Rank{RankShort: "MG", RankFull: "Major General", RankImageUrl: "img", RankId: 4},
+		RealName:          "Adam Jarvis",
+		UniformUrl:        "uniform",
+		Roster:            types.RosterTypeCombat,
+		Primary:           &types.Position{PositionTitle: "Regimental Technical Aide", PositionId: 773},
+		Secondaries:       []*types.Position{{PositionTitle: "S6 Web Developer", PositionId: 812}},
+		JoinDate:          "2014-02-08",
+		PromotionDate:     "2020-10-17",
+		DiscordId:         "112233445566778899",
+		AwardDate:         "2021-03-01",
+		RecordDate:        "2020-10-17",
+		LastForumPostDate: "2026-05-30",
+		Mos:               "11B",
+		ConsoleGamertag:   "",
+	})
+
+	assert.Equal(t, map[string]any{
+		"user":              map[string]any{"userId": "3", "username": "Jarvis.A"},
+		"rank":              map[string]any{"rankShort": "MG", "rankFull": "Major General", "rankImageUrl": "img", "rankId": "4"},
+		"realName":          "Adam Jarvis",
+		"uniformUrl":        "uniform",
+		"roster":            "ROSTER_TYPE_COMBAT",
+		"primary":           map[string]any{"positionTitle": "Regimental Technical Aide", "positionId": "773"},
+		"secondaries":       []any{map[string]any{"positionTitle": "S6 Web Developer", "positionId": "812"}},
+		"joinDate":          "2014-02-08",
+		"promotionDate":     "2020-10-17",
+		"discordId":         "112233445566778899",
+		"awardDate":         "2021-03-01",
+		"recordDate":        "2020-10-17",
+		"lastForumPostDate": "2026-05-30",
+		"mos":               "11B",
+		"consoleGamertag":   "",
+	}, m)
+}
+
+// Emit-everything on the lite shape: unset nested messages null, empty
+// collections [], unset strings "" — and NO keycloakId key (the new types
+// never had the field; same documented break as Profile).
+func TestLiteProfile_SparseFormEmitsNullsAndEmpties(t *testing.T) {
+	m := marshalToMap(t, types.LiteProfile{
+		User:        &types.User{UserId: 8, Username: "John.Doe"},
+		Rank:        &types.Rank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "img22", RankId: 22},
+		RealName:    "John Doe",
+		UniformUrl:  "uniform2",
+		Roster:      types.RosterTypeCombat,
+		Secondaries: []*types.Position{},
+		JoinDate:    "2026-01-15",
+	})
+
+	assert.Nil(t, m["primary"])
+	assert.Equal(t, []any{}, m["secondaries"])
+	assert.Equal(t, "", m["awardDate"])
+	assert.Equal(t, "", m["recordDate"])
+	assert.Equal(t, "", m["promotionDate"])
+	assert.NotContains(t, m, "keycloakId")
+	assert.Len(t, m, 15, "every LiteProfile key present, nothing extra")
+}
+
+// A zero-value LiteProfile is wire-valid (the List convention): secondaries
+// marshals as [], never null.
+func TestLiteProfile_ZeroValueMarshalsWireValid(t *testing.T) {
+	b, err := json.Marshal(types.LiteProfile{})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"secondaries":[]`)
+	assert.Contains(t, string(b), `"roster":"ROSTER_TYPE_UNSPECIFIED"`)
+}
+
+// The roster map keys on the milpac relation id and serializes uint64 keys
+// as decimal JSON strings (encoding/json integer-key form — matching the
+// protojson map encoding the goldens froze). An allocated-but-empty map is
+// {} — the empty-roster wire form.
+func TestRoster_MapWireForm(t *testing.T) {
+	b, err := json.Marshal(types.Roster{Profiles: map[uint64]*types.Profile{}})
+	require.NoError(t, err)
+	assert.Equal(t, `{"profiles":{}}`, string(b))
+
+	m := marshalToMap(t, types.Roster{Profiles: map[uint64]*types.Profile{42: {}}})
+	profiles, ok := m["profiles"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, profiles, "42", "uint64 keys serialize as decimal strings")
+}
+
+func TestLiteRoster_EmptyMapWireForm(t *testing.T) {
+	b, err := json.Marshal(types.LiteRoster{Profiles: map[uint64]*types.LiteProfile{}})
+	require.NoError(t, err)
+	assert.Equal(t, `{"profiles":{}}`, string(b))
+}

--- a/types/rostertype_parse.go
+++ b/types/rostertype_parse.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// rosterTypeValues is the inverse of the wire-name catalog: enum NAME →
+// value, built from rosterTypeNames so the two can never drift. It mirrors
+// the generated proto.RosterType_value map the old gateway bound path
+// parameters with.
+var rosterTypeValues = func() map[string]RosterType {
+	m := make(map[string]RosterType, len(rosterTypeNames))
+	for v, name := range rosterTypeNames {
+		m[name] = v
+	}
+	return m
+}()
+
+// ParseRosterType is the inverse parse for the RosterType path parameter,
+// mirroring grpc-gateway's runtime.Enum (v2.29.0 runtime/convert.go) exactly
+// — both accepted forms are golden-pinned (PRD #112):
+//
+//   - the enum NAME (ROSTER_TYPE_COMBAT), looked up in the catalog;
+//   - the enum NUMBER (the upstream roster_id FK), parsed via the gateway's
+//     runtime.Int32 = strconv.ParseInt(val, 0, 32) — BASE 0, so Go
+//     integer-literal forms (0x1 hex, 0b1 binary, leading-0 octal, digit
+//     underscores) parse too (the same frozen leniency tier as the profile
+//     path id). A parsed number must be a CATALOGED value: the gateway
+//     rejected numbers outside the enum's value set.
+//
+// Anything else fails with the gateway's leaked enum-parse text — "%s is not
+// valid" — which the roster handlers wrap in the frozen type-mismatch 400.
+func ParseRosterType(val string) (RosterType, error) {
+	if v, ok := rosterTypeValues[val]; ok {
+		return v, nil
+	}
+	i, err := strconv.ParseInt(val, 0, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%s is not valid", val)
+	}
+	if _, ok := rosterTypeNames[RosterType(i)]; !ok {
+		return 0, fmt.Errorf("%s is not valid", val)
+	}
+	return RosterType(i), nil
+}

--- a/types/rostertype_parse_test.go
+++ b/types/rostertype_parse_test.go
@@ -1,0 +1,82 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Both golden-pinned path forms parse: the enum NAME and the enum NUMBER
+// (the upstream roster_id FK) land on the same value — gateway runtime.Enum
+// parity (PRD #112).
+func TestParseRosterType_NameAndNumberForms(t *testing.T) {
+	cases := []struct {
+		in   string
+		want types.RosterType
+	}{
+		{"ROSTER_TYPE_UNSPECIFIED", types.RosterTypeUnspecified},
+		{"0", types.RosterTypeUnspecified},
+		{"ROSTER_TYPE_COMBAT", types.RosterTypeCombat},
+		{"1", types.RosterTypeCombat},
+		{"ROSTER_TYPE_RESERVE", types.RosterTypeReserve},
+		{"2", types.RosterTypeReserve},
+		{"ROSTER_TYPE_ELOA", types.RosterTypeEloa},
+		{"3", types.RosterTypeEloa},
+		{"ROSTER_TYPE_WALL_OF_HONOR", types.RosterTypeWallOfHonor},
+		{"4", types.RosterTypeWallOfHonor},
+		{"ROSTER_TYPE_ARLINGTON", types.RosterTypeArlington},
+		{"5", types.RosterTypeArlington},
+		{"ROSTER_TYPE_PAST_MEMBERS", types.RosterTypePastMembers},
+		{"6", types.RosterTypePastMembers},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := types.ParseRosterType(c.in)
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// The number form inherits the gateway's BASE-0 parse (runtime.Int32 =
+// strconv.ParseInt(val, 0, 32)): Go integer-literal prefixes parse — the
+// same frozen leniency tier as the profile path id. A literal that parses to
+// a number OUTSIDE the catalog still fails (the gateway checked the enum's
+// value set).
+func TestParseRosterType_NumberFormIsBaseZero(t *testing.T) {
+	got, err := types.ParseRosterType("0x1")
+	require.NoError(t, err)
+	assert.Equal(t, types.RosterTypeCombat, got, "hex form parses (base 0)")
+
+	got, err = types.ParseRosterType("0b10")
+	require.NoError(t, err)
+	assert.Equal(t, types.RosterTypeReserve, got, "binary form parses (base 0)")
+
+	got, err = types.ParseRosterType("06")
+	require.NoError(t, err)
+	assert.Equal(t, types.RosterTypePastMembers, got, "leading-0 octal form parses (base 0)")
+
+	_, err = types.ParseRosterType("1_0")
+	require.EqualError(t, err, "1_0 is not valid", "parses to 10 — outside the catalog")
+}
+
+// Anything else fails with the gateway's leaked enum-parse text verbatim —
+// the bogus_enum golden pins the wrapped form.
+func TestParseRosterType_InvalidLiterals(t *testing.T) {
+	for _, in := range []string{
+		"IMAGINARY_ROSTER",    // unknown name
+		"roster_type_combat",  // names are case-sensitive
+		"7",                   // number outside the catalog
+		"-1",                  // negative, outside the catalog
+		"09",                  // octal with a 9 — invalid syntax under base 0
+		"",                    // empty
+		"ROSTER_TYPE_COMBAT ", // stray whitespace
+	} {
+		t.Run(in, func(t *testing.T) {
+			_, err := types.ParseRosterType(in)
+			require.EqualError(t, err, in+" is not valid")
+		})
+	}
+}

--- a/types/s1uniforms.go
+++ b/types/s1uniforms.go
@@ -1,0 +1,42 @@
+package types
+
+// S1UniformsRoster is the S1-uniforms response shape: the requested roster's
+// member set as S1UniformsProfile views (the data the S1 uniforms tool
+// consumes), keyed by milpac relation id. Same allocation discipline as
+// Roster: the profiles map is always allocated, {} on the wire when empty.
+type S1UniformsRoster struct {
+	Profiles map[uint64]*S1UniformsProfile `json:"profiles"`
+}
+
+// S1UniformsProfile is the S1-uniforms milpac view (the domain glossary's
+// third profile shape): uniform-audit fields (the uniform dates, area of
+// responsibility) over a trimmed identity — rank without its id, positions
+// as bare titles, the primary collapsed to primaryPositionTitle.
+type S1UniformsProfile struct {
+	User                     *User                     `json:"user"`
+	Rank                     *S1UniformsRank           `json:"rank"`
+	RealName                 string                    `json:"realName"`
+	UniformUrl               string                    `json:"uniformUrl"`
+	UniformDate              string                    `json:"uniformDate"`
+	UniformUpdateTriggerDate string                    `json:"uniformUpdateTriggerDate"`
+	Roster                   RosterType                `json:"roster"`
+	PrimaryPositionTitle     string                    `json:"primaryPositionTitle"`
+	Secondaries              List[*S1UniformsPosition] `json:"secondaries"`
+	JoinDate                 string                    `json:"joinDate"`
+	PromotionDate            string                    `json:"promotionDate"`
+	AreaOfResponsibility     string                    `json:"areaOfResponsibility"`
+}
+
+// S1UniformsRank is the rank entry of the S1 uniforms shape — the plain Rank
+// minus rankId.
+type S1UniformsRank struct {
+	RankShort    string `json:"rankShort"`
+	RankFull     string `json:"rankFull"`
+	RankImageUrl string `json:"rankImageUrl"`
+}
+
+// S1UniformsPosition is a secondary position in the S1 uniforms shape —
+// title only, no id.
+type S1UniformsPosition struct {
+	PositionTitle string `json:"positionTitle"`
+}

--- a/types/s1uniforms_test.go
+++ b/types/s1uniforms_test.go
@@ -1,0 +1,80 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The populated S1 uniforms form: trimmed identity (rank without rankId,
+// title-only secondaries, primary collapsed to a title string) plus the
+// uniform-audit fields — the shape the s1 goldens freeze
+// (contract/goldens/s1/uniforms_combat_by_name.golden.json).
+func TestS1UniformsProfile_WireForm(t *testing.T) {
+	m := marshalToMap(t, types.S1UniformsProfile{
+		User:                     &types.User{UserId: 3, Username: "Jarvis.A"},
+		Rank:                     &types.S1UniformsRank{RankShort: "MG", RankFull: "Major General", RankImageUrl: "img"},
+		RealName:                 "Adam Jarvis",
+		UniformUrl:               "uniform",
+		UniformDate:              "2025-11-02",
+		UniformUpdateTriggerDate: "2025-12-01",
+		Roster:                   types.RosterTypeCombat,
+		PrimaryPositionTitle:     "Regimental Technical Aide",
+		Secondaries:              []*types.S1UniformsPosition{{PositionTitle: "S6 Web Developer"}},
+		JoinDate:                 "2014-02-08",
+		PromotionDate:            "2020-10-17",
+		AreaOfResponsibility:     "S6",
+	})
+
+	assert.Equal(t, map[string]any{
+		"user":                     map[string]any{"userId": "3", "username": "Jarvis.A"},
+		"rank":                     map[string]any{"rankShort": "MG", "rankFull": "Major General", "rankImageUrl": "img"},
+		"realName":                 "Adam Jarvis",
+		"uniformUrl":               "uniform",
+		"uniformDate":              "2025-11-02",
+		"uniformUpdateTriggerDate": "2025-12-01",
+		"roster":                   "ROSTER_TYPE_COMBAT",
+		"primaryPositionTitle":     "Regimental Technical Aide",
+		"secondaries":              []any{map[string]any{"positionTitle": "S6 Web Developer"}},
+		"joinDate":                 "2014-02-08",
+		"promotionDate":            "2020-10-17",
+		"areaOfResponsibility":     "S6",
+	}, m)
+}
+
+// Emit-everything on the S1 shape: unset strings "", empty collections [] —
+// the sparse member of the uniforms_combat goldens.
+func TestS1UniformsProfile_SparseFormEmitsEmpties(t *testing.T) {
+	m := marshalToMap(t, types.S1UniformsProfile{
+		User:                 &types.User{UserId: 8, Username: "John.Doe"},
+		Rank:                 &types.S1UniformsRank{RankShort: "PVT", RankFull: "Private", RankImageUrl: "img22"},
+		RealName:             "John Doe",
+		UniformUrl:           "uniform2",
+		Roster:               types.RosterTypeCombat,
+		PrimaryPositionTitle: "Rifleman",
+		Secondaries:          []*types.S1UniformsPosition{},
+		JoinDate:             "2026-01-15",
+	})
+
+	assert.Equal(t, []any{}, m["secondaries"])
+	assert.Equal(t, "", m["uniformDate"])
+	assert.Equal(t, "", m["uniformUpdateTriggerDate"])
+	assert.Equal(t, "", m["areaOfResponsibility"])
+	assert.Len(t, m, 12, "every S1UniformsProfile key present, nothing extra")
+}
+
+// A zero-value S1UniformsProfile is wire-valid (the List convention).
+func TestS1UniformsProfile_ZeroValueMarshalsWireValid(t *testing.T) {
+	b, err := json.Marshal(types.S1UniformsProfile{})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"secondaries":[]`)
+}
+
+func TestS1UniformsRoster_EmptyMapWireForm(t *testing.T) {
+	b, err := json.Marshal(types.S1UniformsRoster{Profiles: map[uint64]*types.S1UniformsProfile{}})
+	require.NoError(t, err)
+	assert.Equal(t, `{"profiles":{}}`, string(b))
+}


### PR DESCRIPTION
Closes #127. Part of #112 Phase 3 fan-out (wave 2 of the syni-swarm run).

## What
The three roster routes on the new net/http stack:
- `GET /api/v1/roster/{roster}` → full `Profile` map
- `GET /api/v1/roster/{roster}/lite` → `LiteProfile`
- `GET /api/v1/s1/uniforms/{roster}` → `S1UniformsProfile`

`RosterType` path param accepts name or number (exact `runtime.Enum` parity incl. base-0 parse and the leaked `"%s is not valid"` text, verified against the pinned v2.29.0 source). Native types serialize once — no proto→JSON double-marshal. Emit-everything allocation discipline golden-pinned; 4000-member large-roster compares clean through the real gzip layer against committed-golden expectations.

## Review trail
5 review agents (code/tests/errors/types/comments) + fixer round + red-validation pass: every unwitnessed-path pin mutation-verified red (lazy-alloc per shape, spec-line removal, base-10 parse). Spec gained explicit `"500"` on the lite/S1 ops with **live witnesses** — and the carve-out/witness coupling is mechanical, not documentary: `internal/spectest` registry drives both the contract-side carve-out map and the rest-side witness subtests with 1:1 meta-assertions + ran-flag (orphaned carve-out, unregistered witness, and skipped witness all red, each mutation-verified).

## Gate
gofmt/vet/build clean; `go test ./...` green; `make test-integration` green (MariaDB harness). Re-verified independently by the orchestrator.

## Note for merge order
**Merge this PR first.** #128's PR is stacked on this branch (shared `LiteProfile`/`LiteRoster` deduped there per the integration ruling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)