### PR TITLE
Phase 3: full Sentry wiring in the new stack (#132)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,6 +88,16 @@ jobs:
         go test ./...
       env:
         TESTDB_ADDR: 127.0.0.1:3310
+    # The race detector is load-bearing here, not belt-and-braces: the
+    # sentry concurrency guard (rest/sentry_test.go, #132) is
+    # deterministically red under -race against a shared-hub regression
+    # but only probabilistically red without it (~80% per plain run).
+    # More concurrency stacks on this surface from #131 on — the guard
+    # must be live in CI, not just in branch gates.
+    - name: Test with race detector
+      run: go test -race ./...
+      env:
+        TESTDB_ADDR: 127.0.0.1:3310
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/rest/metrics.go
+++ b/rest/metrics.go
@@ -151,9 +151,9 @@ func metricsMiddleware(next http.Handler) http.Handler {
 		// connection without writing anything; HTTP/2 resets the stream). A
 		// handler that already committed a status before panicking keeps that
 		// status — it is on the wire. The panic is re-raised AFTER recording
-		// (the inner defer fires as this deferred func returns) so net/http —
-		// and #132's recovery layer once it lands outside this one — sees
-		// semantics unchanged.
+		// (the inner defer fires as this deferred func returns) so the sentry
+		// recovery layer outside this one (#132) — and net/http when sentry
+		// is disabled — sees semantics unchanged.
 		defer func() {
 			status := sw.status()
 			if p := recover(); p != nil {

--- a/rest/metrics_test.go
+++ b/rest/metrics_test.go
@@ -259,8 +259,8 @@ func TestMetrics_ExoticMethodClampsToOther(t *testing.T) {
 // request still increments the counter — as status="500" when nothing was
 // written (the dashboard-honesty case: panic-per-request must not flatline
 // error rates while the service burns, #92). The panic itself must propagate
-// unchanged so net/http (and later #132's recovery layer) sees identical
-// semantics.
+// unchanged so the sentry recovery layer outside this one (#132) — and
+// net/http when sentry is disabled, as here — sees identical semantics.
 func TestMetrics_PanickingHandlerMetersAs500AndPanicPropagates(t *testing.T) {
 	h := rest.New(&fakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
 		panic("datastore exploded")

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -13,8 +13,13 @@
 //
 // Extension points, outermost first:
 //
-//   - sentryMiddleware (placeholder, #132): panic-recovery at the front of
-//     the chain; 5xx Sentry reports hook the writeError choke point.
+//   - sentryMiddleware (#132, sentry.go): panic recovery at the front of the
+//     chain — catches the metrics layer's re-panic, reports the event, and
+//     writes the contract 500; 5xx Sentry reports hook the writeError choke
+//     point. Env-gated by SENTRY_DSN (rest.SetupSentry): without a client it
+//     is a complete no-op. Its route/key-id tags reach this OUTER layer via
+//     the sentryLabels context holder, filled by the sentryLabel wrapper
+//     inside auth (the same mechanism as metricLabels below).
 //   - metricsMiddleware (#130, metrics.go): Prometheus request counter
 //     (route/method/status/key_id) and latency histogram (route/method).
 //     Outside auth, so rejected requests are counted. The route and key_id
@@ -94,8 +99,9 @@ func New(ds datastores.Datastore, rc datastores.TicketReferenceCache) http.Handl
 	return sentryMiddleware(
 		metricsMiddleware(
 			AuthMiddleware(ds,
-				GzipMiddleware(
-					routes(ds, rc)))))
+				sentryLabel(
+					GzipMiddleware(
+						routes(ds, rc))))))
 }
 
 // routes builds the pattern-routing mux: one handle call per public route,
@@ -227,13 +233,3 @@ func lastSegment(path string) string {
 	return path[strings.LastIndexByte(path, '/')+1:]
 }
 
-// sentryMiddleware is the documented extension point for #132 (full Sentry
-// wiring): panic-recovery middleware at the front of the chain, with 5xx
-// reports emitted from the writeError choke point. Pass-through until that
-// slice lands. Note for #132: metricsMiddleware already meters panics as
-// status="500" and re-raises — recovery must stay OUTSIDE metrics: a recovery
-// layer inside it that swallowed a panic without writing a response would
-// meter as the implied 200, flattening error rates.
-func sentryMiddleware(next http.Handler) http.Handler {
-	return next
-}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -90,8 +90,9 @@ var (
 // and the poller keeping it fresh), not merely non-nil: a cold cache
 // degrades silently — empty categories, blank status/priority/prefix names,
 // and category filters collapsing from subtree to exact-match. New refuses
-// nil outright: with no recovery middleware in the chain, a nil cache is a
-// guaranteed panic on the first tickets request against the real datastore.
+// nil outright: a nil cache is a guaranteed panic on the first tickets
+// request against the real datastore (recovery exists only when SENTRY_DSN
+// is set — and a panic-per-request service is broken either way).
 func New(ds datastores.Datastore, rc datastores.TicketReferenceCache) http.Handler {
 	if rc == nil {
 		panic("rest.New: nil TicketReferenceCache — pass the refreshed referencecache.Cache (see #134)")
@@ -232,4 +233,3 @@ func fallback(mux *http.ServeMux) http.HandlerFunc {
 func lastSegment(path string) string {
 	return path[strings.LastIndexByte(path, '/')+1:]
 }
-

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -9,7 +9,7 @@
 //
 // # Middleware chain (PRD order — assembled in New)
 //
-//	sentry → metrics → auth → gzip → mux
+//	sentry → metrics → auth (→ sentryLabel) → gzip → mux
 //
 // Extension points, outermost first:
 //
@@ -79,7 +79,7 @@ var (
 )
 
 // New assembles the new stack: the route mux wrapped in the PRD middleware
-// chain (sentry → metrics → auth → gzip → mux). The returned handler serves
+// chain (sentry → metrics → auth (→ sentryLabel) → gzip → mux). The returned handler serves
 // the /api surface; non-API paths (the docs UI) are the cutover slice's
 // concern (#134) and 404 here until then.
 //

--- a/rest/sentry.go
+++ b/rest/sentry.go
@@ -1,0 +1,301 @@
+package rest
+
+// First-class Sentry wiring for the new stack (#132, PRD #112): the
+// permanent replacement for Phase 0's temporary wrapping of the old stack
+// (servers/sentry.go + the gRPC interceptor + the gateway middleware), which
+// the cutover slice (#134) deletes with the stacks it wraps. Three pieces,
+// one file:
+//
+//   - SetupSentry — env-gated init (SENTRY_DSN, exactly as in Phase 0): no
+//     DSN means nothing is initialised, and every capture point below is a
+//     pass-through.
+//   - sentryMiddleware — panic recovery at the FRONT of the chain (PRD order:
+//     sentry → metrics → auth → gzip → mux). Sits OUTSIDE metrics, which
+//     meters a panic as status="500" and re-raises — this layer catches the
+//     re-panic, reports it, and writes the contract 500 so the request still
+//     completes. sentryLabel (inside auth, outside gzip) fills the route and
+//     key-id tags the recovery point cannot see.
+//   - reportServerError — the 5xx report hook the writeError choke point
+//     calls: one place, every error.
+//
+// Tag discipline (PRD #112): events carry the validated key ID and the
+// matched route pattern — bearer material NEVER (same rule as the metrics
+// key_id label); scrubEvent strips request auth material at the BeforeSend
+// choke point as belt-and-braces.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/spf13/viper"
+)
+
+// sentryTransport overrides the SDK's default HTTP transport. Always nil in
+// production; swapped only by tests so the full SetupSentry path is
+// exercisable without network (same seam idiom as write.go's marshalJSON).
+var sentryTransport sentry.Transport
+
+// SetupSentry initialises Sentry error capture (errors only, no tracing) when
+// SENTRY_DSN is present in the environment — the same gate as Phase 0's
+// servers.setupSentry, which this replaces at cutover (#134). Without a DSN
+// nothing is initialised — no client, no capture, local/dev unaffected; the
+// only side effect is one Info line making the disabled state visible at
+// boot. Returns whether capture was enabled.
+//
+// release is the build-time version (the -X servers.version injection today;
+// the cutover slice passes it through) — it stamps every event's Release tag.
+func SetupSentry(release string) bool {
+	dsn := viper.GetString("SENTRY_DSN")
+	if dsn == "" {
+		Info.Println("Sentry disabled — SENTRY_DSN not set")
+		return false
+	}
+
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn: dsn,
+		// Release tagging from the build-time version (PRD #112).
+		Release: release,
+		// Errors only — no tracing (PRD #112).
+		EnableTracing: false,
+		// Explicit zero: the SDK normalises 0 to its default of 1.0, so
+		// every error event is sent (confirmed convention in #113).
+		SampleRate: 0,
+		// String panics (panic("msg")) become message events; without this
+		// they would arrive with no stack trace at all.
+		AttachStacktrace: true,
+		// Env-gated SDK diagnostics (SENTRY_DEBUG) — delivery failures are
+		// otherwise invisible without a rebuild.
+		Debug: sentryDebugEnabled(),
+		// SDK debug lines land on the Warn logger's underlying writer with
+		// the SDK's own "[Sentry] " prefix — NOT the app's "WARNING: "
+		// prefix. Log scrapers keyed on our prefixes will not match them.
+		DebugWriter: Warn.Writer(),
+		// Belt-and-braces scrubbing at the choke point — see scrubEvent for
+		// the exact (request-material-only) scope of the guarantee.
+		BeforeSend: scrubEvent,
+		// nil in production — tests swap the seam for a capture mock.
+		Transport: sentryTransport,
+	})
+	if err != nil {
+		// Telemetry must never take the API down: log and run without it.
+		Warn.Printf("sentry init failed — continuing without error capture: %v", err)
+		return false
+	}
+
+	Info.Println("Sentry error capture enabled (errors only), release:", release)
+	return true
+}
+
+// sentryDebugEnabled reads SENTRY_DEBUG strictly (mirrors Phase 0, which this
+// file replaces at cutover). viper.GetBool silently maps unparseable values
+// ("yes", "on", typos) to false — a mid-incident operator trap: debug looks
+// enabled but nothing logs. Unset stays silently off; a set but unparseable
+// value warns and is treated as off.
+func sentryDebugEnabled() bool {
+	raw := viper.GetString("SENTRY_DEBUG")
+	if raw == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		Warn.Printf("SENTRY_DEBUG=%q is not a boolean (use \"true\" or \"false\") — treating as off", raw)
+		return false
+	}
+	return enabled
+}
+
+// sentryLabels is the mutable per-request holder the sentry middleware shares
+// with sentryLabel — the same channel-through-the-context mechanism as
+// metricLabels (#130), and for the same reason: the recovery point is the
+// OUTERMOST layer, where the request never carries the matched pattern (the
+// mux sets it on auth's inner clone) or the validated key (attached to the
+// inner context). It also carries the panic de-dup flag the writeError choke
+// point consults: the recovery's own contract-500 write must not turn one
+// panic into a second (message) event.
+type sentryLabels struct {
+	hub      *sentry.Hub
+	route    string // mux pattern, e.g. "GET /api/v1/milpacs/ranks"; "" if never routed
+	keyID    string // decimal key id, e.g. "7"; "" if no key validated
+	panicked bool   // a panic event was already captured for this request
+}
+
+// sentryLabelsContextKey is the private context key for *sentryLabels.
+type sentryLabelsContextKey struct{}
+
+// sentryLabelsFromContext returns the request's holder, or nil when the
+// sentry middleware is a pass-through (no SENTRY_DSN — every consumer below
+// then no-ops, the complete-no-op guarantee).
+func sentryLabelsFromContext(ctx context.Context) *sentryLabels {
+	v, _ := ctx.Value(sentryLabelsContextKey{}).(*sentryLabels)
+	return v
+}
+
+// sentryMiddleware is the panic-recovery layer at the FRONT of the chain (PRD
+// order: sentry → metrics → auth → gzip → mux). It sits OUTSIDE metrics by
+// ruling: the metrics middleware meters a panic as status="500" (unwritten
+// case) and RE-RAISES — this layer catches that re-panic with metering
+// already done, reports the event (tagged via the sentryLabels holder
+// sentryLabel filled on the way out), and writes the contract 500 error shape
+// so the request still completes.
+//
+// Without an initialised client (no SENTRY_DSN) it is a complete no-op:
+// requests flow unchanged and panics propagate exactly as they do today
+// (net/http recovers them per-connection) — Phase 0 parity.
+//
+// A response already committed when the panic arrives (a handler that wrote
+// before panicking, or any gzipped request — the gzip layer's deferred Close
+// emits stream bytes during unwind) cannot be turned into a 500: the event is
+// still captured, then the panic re-raises so net/http aborts the connection
+// and the client sees the truncation instead of trusting a half response.
+func sentryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if sentry.CurrentHub().Client() == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		hub := sentry.CurrentHub().Clone()
+		hub.Scope().SetTag("transport", "http") // Phase 0 dashboard continuity
+		labels := &sentryLabels{hub: hub}
+		r = r.WithContext(context.WithValue(r.Context(), sentryLabelsContextKey{}, labels))
+		cw := &commitWriter{ResponseWriter: w}
+
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			labels.panicked = true
+			scope := hub.Scope()
+			if labels.route != "" {
+				scope.SetTag("route", labels.route)
+			}
+			if labels.keyID != "" {
+				scope.SetTag("key_id", labels.keyID)
+			}
+			hub.RecoverWithContext(r.Context(), rec) // event queued; ID unused — async transport
+			// The recovery swallows what net/http would have logged — keep
+			// panics visible in process logs even when Sentry delivery fails.
+			Error.Printf("panic serving %s %s: %v\n%s", r.Method, r.URL.Path, rec, debug.Stack())
+			if cw.committed {
+				panic(rec) // status already on the wire — see the doc comment
+			}
+			writeError(cw, r, codeInternal, "Internal Server Error")
+		}()
+
+		next.ServeHTTP(cw, r)
+	})
+}
+
+// sentryLabel fills the sentryLabels holder with the matched route pattern
+// and the validated key id — the recovery point's only channel to them. It
+// mounts INSIDE auth (the key is on this request's context) and OUTSIDE the
+// mux, deliberately on the same *http.Request pointer the mux dispatches:
+// ServeMux assigns r.Pattern in place before calling the handler, so the
+// DEFERRED read observes it even while a handler panic unwinds — exactly the
+// path the recovery layer needs it on. The companion of routeLabel (#130),
+// which fills the metrics holder the same way one layer further in.
+func sentryLabel(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labels := sentryLabelsFromContext(r.Context())
+		if labels == nil { // sentry disabled — complete no-op
+			next.ServeHTTP(w, r)
+			return
+		}
+		defer func() {
+			labels.route = r.Pattern
+			if key := KeyFromContext(r.Context()); key != nil {
+				// The id, never the bearer token (same rule as metrics).
+				labels.keyID = strconv.FormatUint(uint64(key.KeyId), 10)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// reportServerError is the 5xx report hook the writeStatusJSON choke point
+// calls for every status ≥ 500 — one place, every error (#132). r is the
+// request the FAILING LAYER holds: inside the mux it carries the matched
+// pattern and the validated key (both tagged; the id, never the bearer
+// token); on the pre-routing tiers (auth's datastore-outage 503) both are
+// absent and the tags are simply omitted — same semantics as the empty
+// metrics labels.
+//
+// No-op when the request never passed an enabled sentry middleware: no
+// SENTRY_DSN (the complete-no-op guarantee), or a chain that does not mount
+// it (the legacy gateway reuses AuthMiddleware — and so this choke point —
+// until cutover; its own Phase 0 sentry layer reports those). Also a no-op
+// for the recovery layer's own contract-500 write after a panic: that event
+// is already captured, and one failure must not become two issues.
+func reportServerError(r *http.Request, status int) {
+	labels := sentryLabelsFromContext(r.Context())
+	if labels == nil || labels.panicked {
+		return
+	}
+	labels.hub.WithScope(func(scope *sentry.Scope) {
+		if r.Pattern != "" {
+			scope.SetTag("route", r.Pattern)
+		}
+		if key := KeyFromContext(r.Context()); key != nil {
+			scope.SetTag("key_id", strconv.FormatUint(uint64(key.KeyId), 10))
+		}
+		scope.SetTag("http_status", strconv.Itoa(status))
+		scope.SetLevel(sentry.LevelError)
+		// Group by method+status, not path (Phase 0 idiom, kept verbatim so
+		// Sentry issues survive the cutover): parameterized paths must not
+		// fan one failure into N issues. The pattern stays on the route tag.
+		scope.SetFingerprint([]string{"http-5xx", r.Method, strconv.Itoa(status)})
+		labels.hub.CaptureMessage(fmt.Sprintf("HTTP %d %s %s", status, r.Method, r.URL.Path)) // event queued; ID unused — async transport
+	})
+}
+
+// commitWriter tracks whether anything reached the wire, so the panic
+// recovery knows whether the contract 500 can still be written. Outermost
+// wrapper in the chain — Unwrap keeps http.ResponseController tunnelling
+// through it (same obligation as the metrics statusWriter it wraps).
+type commitWriter struct {
+	http.ResponseWriter
+	committed bool
+}
+
+func (w *commitWriter) WriteHeader(code int) {
+	w.committed = true
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *commitWriter) Write(b []byte) (int, error) {
+	w.committed = true
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *commitWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// scrubEvent is the BeforeSend hook closing the request-material vector: it
+// strips authorization / proxy-authorization / cookie headers
+// (case-insensitive), the cookie jar, and the raw query string from every
+// outgoing error event (mirrors Phase 0's servers.scrubEvent, which this file
+// replaces at cutover). It does NOT scan exception text, breadcrumbs or
+// extras — never put key material in error strings. If tracing is ever
+// enabled, transactions bypass BeforeSend and need an equivalent
+// BeforeSendTransaction hook.
+func scrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+	if event.Request == nil {
+		return event
+	}
+	event.Request.Cookies = ""
+	event.Request.QueryString = ""
+	for name := range event.Request.Headers {
+		switch strings.ToLower(name) {
+		case "authorization", "cookie", "proxy-authorization":
+			delete(event.Request.Headers, name)
+		}
+	}
+	return event
+}

--- a/rest/sentry.go
+++ b/rest/sentry.go
@@ -170,6 +170,13 @@ func sentryMiddleware(next http.Handler) http.Handler {
 			if rec == nil {
 				return
 			}
+			if rec == http.ErrAbortHandler { // raw comparison — net/http's own idiom
+				// The stdlib's DELIBERATE-abort sentinel (net/http suppresses
+				// its stack; httputil.ReverseProxy — the cutover docs proxy —
+				// panics with it on client disconnects): not an error, no
+				// event, no 500 rewrite. Re-raise for net/http to honour.
+				panic(rec)
+			}
 			labels.panicked = true
 			scope := hub.Scope()
 			if labels.route != "" {

--- a/rest/sentry.go
+++ b/rest/sentry.go
@@ -15,8 +15,19 @@ package rest
 //     re-panic, reports it, and writes the contract 500 so the request still
 //     completes. sentryLabel (inside auth, outside gzip) fills the route and
 //     key-id tags the recovery point cannot see.
-//   - reportServerError — the 5xx report hook the writeError choke point
-//     calls: one place, every error.
+//   - reportServerError — the 5xx report hook the writeStatusJSON choke
+//     point calls (the error-writer behind writeError; methodNotAllowed
+//     reaches it without writeError): one place, every error.
+//
+// What this file deliberately does NOT reproduce — servers/sentry.go's three
+// boot-lifecycle pieces, which the cutover slice (#134) must port before
+// deleting that file: sentryDialCheck (warn-only TCP reachability check of
+// the DSN ingest host at boot), sentryStartupProbe (one canary event flushed
+// through the real transport before any listener opens), and
+// flushSentryOnShutdown (the SIGTERM/interrupt flush handler servers.Start
+// installs after setupSentry). Dropping them silently would make a
+// Sentry-down misconfig invisible at boot and lose every still-buffered
+// event on SIGTERM.
 //
 // Tag discipline (PRD #112): events carry the validated key ID and the
 // matched route pattern — bearer material NEVER (same rule as the metrics
@@ -38,6 +49,9 @@ import (
 // sentryTransport overrides the SDK's default HTTP transport. Always nil in
 // production; swapped only by tests so the full SetupSentry path is
 // exercisable without network (same seam idiom as write.go's marshalJSON).
+// Caveat: a non-nil Transport puts the SDK on its legacy direct-send path,
+// not production's async telemetry-processor pipeline — tests do not observe
+// production queueing/drop semantics.
 var sentryTransport sentry.Transport
 
 // SetupSentry initialises Sentry error capture (errors only, no tracing) when
@@ -114,9 +128,9 @@ func sentryDebugEnabled() bool {
 // metricLabels (#130), and for the same reason: the recovery point is the
 // OUTERMOST layer, where the request never carries the matched pattern (the
 // mux sets it on auth's inner clone) or the validated key (attached to the
-// inner context). It also carries the panic de-dup flag the writeError choke
-// point consults: the recovery's own contract-500 write must not turn one
-// panic into a second (message) event.
+// inner context). It also carries the panic de-dup flag the writeStatusJSON
+// choke point consults: the recovery's own contract-500 write must not turn
+// one panic into a second (message) event.
 type sentryLabels struct {
 	hub      *sentry.Hub
 	route    string // mux pattern, e.g. "GET /api/v1/milpacs/ranks"; "" if never routed
@@ -172,11 +186,17 @@ func sentryMiddleware(next http.Handler) http.Handler {
 			}
 			if rec == http.ErrAbortHandler { // raw comparison — net/http's own idiom
 				// The stdlib's DELIBERATE-abort sentinel (net/http suppresses
-				// its stack; httputil.ReverseProxy — the cutover docs proxy —
-				// panics with it on client disconnects): not an error, no
-				// event, no 500 rewrite. Re-raise for net/http to honour.
+				// its stack; e.g. httputil.ReverseProxy panics with it on
+				// client disconnects): not an error, no event, no 500
+				// rewrite. Re-raise for net/http to honour.
 				panic(rec)
 			}
+			// Log FIRST — the recovery swallows what net/http would have
+			// logged, and the SDK capture below runs synchronously (stack
+			// symbolisation reads source files, BeforeSend runs) and could
+			// itself fail or panic: the original panic and stack must already
+			// be in the process logs before any of that runs.
+			Error.Printf("panic serving %s %s: %v\n%s", r.Method, r.URL.Path, rec, debug.Stack())
 			labels.panicked = true
 			scope := hub.Scope()
 			if labels.route != "" {
@@ -186,11 +206,10 @@ func sentryMiddleware(next http.Handler) http.Handler {
 				scope.SetTag("key_id", labels.keyID)
 			}
 			hub.RecoverWithContext(r.Context(), rec) // event queued; ID unused — async transport
-			// The recovery swallows what net/http would have logged — keep
-			// panics visible in process logs even when Sentry delivery fails.
-			Error.Printf("panic serving %s %s: %v\n%s", r.Method, r.URL.Path, rec, debug.Stack())
 			if cw.committed {
-				panic(rec) // status already on the wire — see the doc comment
+				// Status already on the wire — see the doc comment. net/http
+				// logs this re-raise a second time: accepted duplication.
+				panic(rec)
 			}
 			writeError(cw, r, codeInternal, "Internal Server Error")
 		}()
@@ -235,8 +254,11 @@ func sentryLabel(next http.Handler) http.Handler {
 //
 // No-op when the request never passed an enabled sentry middleware: no
 // SENTRY_DSN (the complete-no-op guarantee), or a chain that does not mount
-// it (the legacy gateway reuses AuthMiddleware — and so this choke point —
-// until cutover; its own Phase 0 sentry layer reports those). Also a no-op
+// it — the legacy gateway reuses AuthMiddleware (and so this choke point)
+// until cutover, but its Phase 0 sentry layer sits INSIDE auth, so on that
+// chain auth's 503s stay unreported until cutover (accepted Phase 0 gap,
+// documented in servers/gateway/gateway.go); the new stack is what closes
+// it. Also a no-op
 // for the recovery layer's own contract-500 write after a panic: that event
 // is already captured, and one failure must not become two issues.
 func reportServerError(r *http.Request, status int) {
@@ -262,9 +284,15 @@ func reportServerError(r *http.Request, status int) {
 }
 
 // commitWriter tracks whether anything reached the wire, so the panic
-// recovery knows whether the contract 500 can still be written. Outermost
-// wrapper in the chain — Unwrap keeps http.ResponseController tunnelling
-// through it (same obligation as the metrics statusWriter it wraps).
+// recovery knows whether the contract 500 can still be written. Created by
+// the OUTERMOST middleware but the INNERMOST wrapper in write delegation —
+// writes run gzipWriter → statusWriter → commitWriter → the server's writer
+// (metrics builds its statusWriter around this one). Unwrap keeps
+// http.ResponseController tunnelling through it (same obligation as the
+// metrics statusWriter that wraps it). FlushError closes the tunnel's blind
+// spot: without it ResponseController.Flush would reach the base writer via
+// Unwrap WITHOUT setting committed, and a flush-then-panic would write a
+// contract 500 over a 200 already on the wire.
 type commitWriter struct {
 	http.ResponseWriter
 	committed bool
@@ -278,6 +306,15 @@ func (w *commitWriter) WriteHeader(code int) {
 func (w *commitWriter) Write(b []byte) (int, error) {
 	w.committed = true
 	return w.ResponseWriter.Write(b)
+}
+
+// FlushError marks the response committed before delegating the flush — see
+// the type doc for the blind spot this closes. Delegating through a fresh
+// ResponseController keeps the downstream search semantics identical
+// (http.ErrNotSupported surfaces naturally when nothing below can flush).
+func (w *commitWriter) FlushError() error {
+	w.committed = true
+	return http.NewResponseController(w.ResponseWriter).Flush()
 }
 
 func (w *commitWriter) Unwrap() http.ResponseWriter {

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -1,0 +1,197 @@
+package rest
+
+// Behavioral tests for the new stack's first-class Sentry wiring (#132):
+// env-gating, panic recovery at the front of the chain, choke-point 5xx
+// reports, tag discipline (key id and route pattern, never bearer material),
+// and release tagging. Internal package tests (like auth_test.go) so they can
+// swap the sentryTransport seam and drive the production SetupSentry path —
+// no real network is ever touched.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/proto"
+	"github.com/7cav/api/referencecache"
+	"github.com/getsentry/sentry-go"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sentryFakeDatastore embeds the Datastore interface so it satisfies the type
+// without implementing every method (same pattern as fakeAuthDatastore); any
+// unstubbed call panics loudly. One key: cav7_sentry_read → key id 7, scope
+// "read" — the id (never the token) is what events must carry.
+type sentryFakeDatastore struct {
+	datastores.Datastore
+	findAllRanks   func() ([]*proto.RankExpanded, error)
+	validateApiKey func(string) (*datastores.ApiKeyResult, error)
+}
+
+func (f *sentryFakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
+	if f.validateApiKey != nil {
+		return f.validateApiKey(rawKey)
+	}
+	if rawKey == "cav7_sentry_read" {
+		return &datastores.ApiKeyResult{KeyId: 7, UserId: 3, Scopes: map[string]struct{}{"read": {}}}, nil
+	}
+	return nil, nil
+}
+
+func (f *sentryFakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error) {
+	return f.findAllRanks()
+}
+
+// sentryStubCache is the no-op TicketReferenceCache the sentry tests mount —
+// New refuses nil, and no sentry test reaches the tickets routes.
+type sentryStubCache struct{}
+
+func (*sentryStubCache) StatusName(uint32) string                       { return "" }
+func (*sentryStubCache) PriorityName(uint32) string                     { return "" }
+func (*sentryStubCache) PrefixName(uint32) string                      { return "" }
+func (*sentryStubCache) Category(uint32) *referencecache.CategoryRecord { return nil }
+func (*sentryStubCache) CategoryAncestors(uint32) []uint32              { return nil }
+func (*sentryStubCache) CategoryTree() []*referencecache.CategoryRecord { return nil }
+func (*sentryStubCache) ExpandSubtree(ids []uint32) []uint32            { return ids }
+
+// doRanks drives one authenticated GET /api/v1/milpacs/ranks through the
+// public chain h.
+func doRanks(h http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_sentry_read")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+// transportMock captures every event the client would have sent to Sentry.
+// Events arrive post-BeforeSend, so the production scrub is observable.
+type transportMock struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *transportMock) Configure(sentry.ClientOptions) {}
+func (t *transportMock) SendEvent(e *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, e)
+}
+func (t *transportMock) Flush(time.Duration) bool             { return true }
+func (t *transportMock) FlushWithContext(context.Context) bool { return true }
+func (t *transportMock) Close()                                {}
+func (t *transportMock) Events() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]*sentry.Event(nil), t.events...)
+}
+
+// testRelease is the build-time version stand-in tests pass to SetupSentry.
+const testRelease = "v-test-132"
+
+// errOutageSentry is the injected datastore failure driving the handler-500
+// tier (its text leaks into the response body — frozen handler behavior).
+var errOutageSentry = errors.New("simulated datastore outage")
+
+// enableSentry drives the PRODUCTION init path (SetupSentry) with the
+// transport seam swapped for a capture mock, and restores the disabled state
+// afterwards so the rest of the package's tests keep running with no client.
+func enableSentry(t *testing.T) *transportMock {
+	t.Helper()
+	tr := &transportMock{}
+	sentryTransport = tr
+	viper.Set("SENTRY_DSN", "https://public@sentry.example.invalid/1")
+	t.Cleanup(func() {
+		sentry.CurrentHub().BindClient(nil)
+		sentryTransport = nil
+		viper.Set("SENTRY_DSN", "")
+	})
+	require.True(t, SetupSentry(testRelease), "SetupSentry must enable capture when SENTRY_DSN is set")
+	return tr
+}
+
+// No DSN → complete no-op: nothing is initialised, exactly as in Phase 0 —
+// no client, so every capture point in the package stays a pass-through.
+func TestSetupSentry_NoDSNInitialisesNothing(t *testing.T) {
+	viper.Set("SENTRY_DSN", "")
+	assert.False(t, SetupSentry(testRelease), "no DSN must report capture disabled")
+	assert.Nil(t, sentry.CurrentHub().Client(), "no DSN must bind no client")
+}
+
+// With a DSN the client is initialised and release-tagged from the build-time
+// version the caller passes — every event carries it.
+func TestSetupSentry_DSNEnablesClientWithRelease(t *testing.T) {
+	tr := enableSentry(t)
+	require.NotNil(t, sentry.CurrentHub().Client(), "a DSN must bind a client")
+
+	sentry.CaptureMessage("wiring probe")
+	events := tr.Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, testRelease, events[0].Release, "events must carry the build-time release")
+}
+
+// The headline acceptance (#132): a panicking handler produces ONE event —
+// tagged with the release, the validated key id, and the matched route
+// pattern — and the request still completes as a 500 in the contract error
+// shape instead of net/http killing the connection. One event, not two: the
+// recovery's own 500 write passes the choke point, which must not
+// double-report a panic it already captured.
+func TestSentry_PanicCompletesAs500AndReportsTaggedEvent(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t) // panic + 5xx logging stays server-side, not in test output
+	h := New(&sentryFakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		panic("ranks exploded")
+	}}, &sentryStubCache{})
+
+	var rr *httptest.ResponseRecorder
+	require.NotPanics(t, func() { rr = doRanks(h) },
+		"the sentry layer must recover the metrics layer's re-panic")
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"code":13,"message":"Internal Server Error","details":[]}`, rr.Body.String(),
+		"the panic 500 must keep the contract error shape")
+
+	events := tr.Events()
+	require.Len(t, events, 1, "one panic = one event; the choke-point 5xx report must not double-report")
+	ev := events[0]
+	assert.Equal(t, testRelease, ev.Release, "release tagging from the build-time version")
+	assert.Equal(t, "GET /api/v1/milpacs/ranks", ev.Tags["route"], "route tag is the matched mux pattern")
+	assert.Equal(t, "7", ev.Tags["key_id"], "key_id tag is the validated key's id")
+	assert.Equal(t, sentry.LevelFatal, ev.Level)
+	assert.Equal(t, "ranks exploded", ev.Message, "string panics arrive as message events (Phase 0 convention)")
+}
+
+// A handler 500 written through the writeError choke point produces one
+// message event — tagged route/key_id/http_status, release-stamped, grouped
+// by the Phase 0 method+status fingerprint so Sentry issues survive the
+// cutover.
+func TestSentry_Handler500ThroughChokePointReportsEvent(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t)
+	h := New(&sentryFakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		return nil, errOutageSentry
+	}}, &sentryStubCache{})
+
+	rr := doRanks(h)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	events := tr.Events()
+	require.Len(t, events, 1, "one 5xx response = one event from the choke point")
+	ev := events[0]
+	assert.Equal(t, "HTTP 500 GET /api/v1/milpacs/ranks", ev.Message, "Phase 0 message format")
+	assert.Equal(t, sentry.LevelError, ev.Level)
+	assert.Equal(t, testRelease, ev.Release)
+	assert.Equal(t, "GET /api/v1/milpacs/ranks", ev.Tags["route"], "route tag is the matched mux pattern")
+	assert.Equal(t, "7", ev.Tags["key_id"])
+	assert.Equal(t, "500", ev.Tags["http_status"])
+	assert.Equal(t, []string{"http-5xx", "GET", "500"}, ev.Fingerprint,
+		"grouping by method+status (Phase 0 idiom): parameterized routes must not fan one failure into N issues")
+}

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/7cav/api/proto"
 	"github.com/7cav/api/referencecache"
 	"github.com/getsentry/sentry-go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,8 +35,9 @@ import (
 // "read" — the id (never the token) is what events must carry.
 type sentryFakeDatastore struct {
 	datastores.Datastore
-	findAllRanks   func() ([]*proto.RankExpanded, error)
-	validateApiKey func(string) (*datastores.ApiKeyResult, error)
+	findAllRanks     func() ([]*proto.RankExpanded, error)
+	findProfilesById func(...uint64) ([]*proto.Profile, error)
+	validateApiKey   func(string) (*datastores.ApiKeyResult, error)
 }
 
 func (f *sentryFakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyResult, error) {
@@ -50,6 +52,10 @@ func (f *sentryFakeDatastore) ValidateApiKey(rawKey string) (*datastores.ApiKeyR
 
 func (f *sentryFakeDatastore) FindAllRanks() ([]*proto.RankExpanded, error) {
 	return f.findAllRanks()
+}
+
+func (f *sentryFakeDatastore) FindProfilesById(ids ...uint64) ([]*proto.Profile, error) {
+	return f.findProfilesById(ids...)
 }
 
 // sentryStubCache is the no-op TicketReferenceCache the sentry tests mount —
@@ -128,6 +134,21 @@ func TestSetupSentry_NoDSNInitialisesNothing(t *testing.T) {
 	assert.Nil(t, sentry.CurrentHub().Client(), "no DSN must bind no client")
 }
 
+// A malformed DSN must fail SAFE — telemetry must never take the API down
+// (the init-failure branch in SetupSentry): Init errors, capture reports
+// disabled, no client binds, and nothing panics. The API then runs exactly as
+// in the no-DSN case.
+func TestSetupSentry_InvalidDSNFailsSafeWithoutClient(t *testing.T) {
+	viper.Set("SENTRY_DSN", "not-a-dsn")
+	t.Cleanup(func() { viper.Set("SENTRY_DSN", "") })
+
+	var enabled bool
+	require.NotPanics(t, func() { enabled = SetupSentry(testRelease) },
+		"a bad DSN must never panic the boot path")
+	assert.False(t, enabled, "a failed init must report capture disabled")
+	assert.Nil(t, sentry.CurrentHub().Client(), "a failed init must bind no client")
+}
+
 // With a DSN the client is initialised and release-tagged from the build-time
 // version the caller passes — every event carries it.
 func TestSetupSentry_DSNEnablesClientWithRelease(t *testing.T) {
@@ -145,7 +166,10 @@ func TestSetupSentry_DSNEnablesClientWithRelease(t *testing.T) {
 // pattern — and the request still completes as a 500 in the contract error
 // shape instead of net/http killing the connection. One event, not two: the
 // recovery's own 500 write passes the choke point, which must not
-// double-report a panic it already captured.
+// double-report a panic it already captured. The metrics half of the
+// recovery-outside-metrics ruling is pinned alongside: exactly one counter
+// increment, status="500", under the route — metering already done when the
+// re-panic reaches this layer.
 func TestSentry_PanicCompletesAs500AndReportsTaggedEvent(t *testing.T) {
 	tr := enableSentry(t)
 	captureErrorLog(t) // panic + 5xx logging stays server-side, not in test output
@@ -153,9 +177,15 @@ func TestSentry_PanicCompletesAs500AndReportsTaggedEvent(t *testing.T) {
 		panic("ranks exploded")
 	}}, &sentryStubCache{})
 
+	panicCounter := requestsTotal.WithLabelValues("GET /api/v1/milpacs/ranks", "GET", "500", "7")
+	before := testutil.ToFloat64(panicCounter)
+
 	var rr *httptest.ResponseRecorder
 	require.NotPanics(t, func() { rr = doRanks(h) },
 		"the sentry layer must recover the metrics layer's re-panic")
+
+	assert.Equal(t, before+1, testutil.ToFloat64(panicCounter),
+		`exactly one status="500" increment under the route — recovery outside metrics must not skip or double metering`)
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
@@ -425,9 +455,76 @@ func TestSentry_GzippedPanicReportsAndRepanics(t *testing.T) {
 	assert.Equal(t, "7", events[0].Tags["key_id"])
 }
 
+// Two simultaneously in-flight failing requests must keep ISOLATED tags:
+// each event carries its own request's key_id and route, never the other's.
+// This is what the per-request hub.Clone() in sentryMiddleware buys — a
+// future "simplification" to the global hub would make concurrent requests
+// race on one shared scope. Channel-gated (a WaitGroup both handlers block
+// on) so both requests are inside the chain at the same time; CI runs plain
+// `go test`, so the -race run of this test is the only realistic guard.
+func TestSentry_ConcurrentRequestsKeepIsolatedTags(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t)
+
+	var inside sync.WaitGroup
+	inside.Add(2)
+	gate := func() {
+		inside.Done()
+		inside.Wait() // releases only once BOTH requests are inside the chain
+	}
+	h := New(&sentryFakeDatastore{
+		validateApiKey: func(raw string) (*datastores.ApiKeyResult, error) {
+			switch raw {
+			case "cav7_key_a":
+				return &datastores.ApiKeyResult{KeyId: 11, UserId: 3, Scopes: map[string]struct{}{"read": {}}}, nil
+			case "cav7_key_b":
+				return &datastores.ApiKeyResult{KeyId: 22, UserId: 4, Scopes: map[string]struct{}{"read": {}}}, nil
+			}
+			return nil, nil
+		},
+		findAllRanks: func() ([]*proto.RankExpanded, error) {
+			gate()
+			return nil, errOutageSentry
+		},
+		findProfilesById: func(...uint64) ([]*proto.Profile, error) {
+			gate()
+			return nil, errOutageSentry
+		},
+	}, &sentryStubCache{})
+
+	send := func(path, bearer string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer "+bearer)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		return rr
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var rrA, rrB *httptest.ResponseRecorder
+	go func() { defer wg.Done(); rrA = send("/api/v1/milpacs/ranks", "cav7_key_a") }()
+	go func() { defer wg.Done(); rrB = send("/api/v1/milpacs/profile/id/5", "cav7_key_b") }()
+	wg.Wait()
+
+	require.Equal(t, http.StatusInternalServerError, rrA.Code)
+	require.Equal(t, http.StatusInternalServerError, rrB.Code)
+
+	events := tr.Events()
+	require.Len(t, events, 2, "two failing requests = two events")
+	routeByKey := map[string]string{}
+	for _, ev := range events {
+		routeByKey[ev.Tags["key_id"]] = ev.Tags["route"]
+	}
+	assert.Equal(t, map[string]string{
+		"11": "GET /api/v1/milpacs/ranks",
+		"22": "GET /api/v1/milpacs/profile/id/{user_id}",
+	}, routeByKey, "each event must carry its OWN request's key_id and route — per-request hub.Clone() isolation")
+}
+
 // http.ErrAbortHandler is the stdlib's sentinel for a DELIBERATE abort —
-// net/http suppresses its stack trace, and httputil.ReverseProxy (the docs
-// proxy the cutover slice mounts) panics with it on client disconnects. The
+// net/http suppresses its stack trace, and stdlib handlers panic with it on
+// purpose (e.g. httputil.ReverseProxy on client disconnects). The
 // recovery layer must re-raise it unreported: not an error, no event, no 500
 // rewrite — aborting means the connection dies, exactly as the handler asked.
 func TestSentry_ErrAbortHandlerRepanicsUnreported(t *testing.T) {
@@ -451,10 +548,11 @@ func TestSentry_ErrAbortHandlerRepanicsUnreported(t *testing.T) {
 	assert.Empty(t, tr.Events(), "a deliberate abort is not an error — no event")
 }
 
-// commitWriter is the outermost wrapper when sentry is enabled, so it must
-// expose Unwrap for http.ResponseController — otherwise Flusher/Hijacker/
-// deadline control silently vanish for every inner layer (same obligation the
-// metrics statusWriter pins one layer in).
+// commitWriter sits in the write-delegation chain when sentry is enabled, so
+// it must keep http.ResponseController working — Flush via its own FlushError
+// (which marks the response committed), Hijacker/deadline control via Unwrap
+// — otherwise that control silently vanishes for every inner layer (same
+// obligation the metrics statusWriter carries).
 func TestSentry_ResponseControllerTunnelsThroughCommitWriter(t *testing.T) {
 	enableSentry(t)
 
@@ -470,5 +568,33 @@ func TestSentry_ResponseControllerTunnelsThroughCommitWriter(t *testing.T) {
 	require.NoError(t, err)
 	res.Body.Close()
 	require.NoError(t, <-flushErr,
-		"ResponseController.Flush must reach the underlying writer via commitWriter.Unwrap")
+		"ResponseController.Flush must reach the underlying writer through commitWriter")
+}
+
+// Flush-then-panic: FlushError marks the response committed, so a panic after
+// an explicit flush re-raises (connection abort) instead of writing a
+// contract 500 over the response already flushed to the wire — the blind spot
+// Unwrap-only tunnelling had (Flush used to bypass the committed flag
+// entirely).
+func TestSentry_PanicAfterFlushRepanicsInsteadOfRewriting(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t)
+
+	h := sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, http.NewResponseController(w).Flush(),
+			"the recorder is a Flusher — FlushError must delegate to it")
+		panic("exploded after the flush")
+	}))
+
+	rr := httptest.NewRecorder()
+	panicked := func() (p any) {
+		defer func() { p = recover() }()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/flush-boom", nil))
+		return nil
+	}()
+	require.Equal(t, "exploded after the flush", panicked,
+		"a flushed (committed) response must re-raise — no honest 500 is possible any more")
+	assert.True(t, rr.Flushed, "the flush must have reached the base writer")
+	assert.Zero(t, rr.Body.Len(), "no contract 500 body behind the flushed response")
+	require.Len(t, tr.Events(), 1, "the panic is still captured even when the response cannot be rewritten")
 }

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -9,9 +9,12 @@ package rest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -55,7 +58,7 @@ type sentryStubCache struct{}
 
 func (*sentryStubCache) StatusName(uint32) string                       { return "" }
 func (*sentryStubCache) PriorityName(uint32) string                     { return "" }
-func (*sentryStubCache) PrefixName(uint32) string                      { return "" }
+func (*sentryStubCache) PrefixName(uint32) string                       { return "" }
 func (*sentryStubCache) Category(uint32) *referencecache.CategoryRecord { return nil }
 func (*sentryStubCache) CategoryAncestors(uint32) []uint32              { return nil }
 func (*sentryStubCache) CategoryTree() []*referencecache.CategoryRecord { return nil }
@@ -84,7 +87,7 @@ func (t *transportMock) SendEvent(e *sentry.Event) {
 	defer t.mu.Unlock()
 	t.events = append(t.events, e)
 }
-func (t *transportMock) Flush(time.Duration) bool             { return true }
+func (t *transportMock) Flush(time.Duration) bool              { return true }
 func (t *transportMock) FlushWithContext(context.Context) bool { return true }
 func (t *transportMock) Close()                                {}
 func (t *transportMock) Events() []*sentry.Event {
@@ -194,4 +197,252 @@ func TestSentry_Handler500ThroughChokePointReportsEvent(t *testing.T) {
 	assert.Equal(t, "500", ev.Tags["http_status"])
 	assert.Equal(t, []string{"http-5xx", "GET", "500"}, ev.Fingerprint,
 		"grouping by method+status (Phase 0 idiom): parameterized routes must not fan one failure into N issues")
+}
+
+// 4xx responses are expected behavior, not errors worth an event: drive every
+// client-error tier through the choke point (and the bypassing 401 tier) and
+// assert silence.
+func TestSentry_4xxProducesNoEvents(t *testing.T) {
+	tr := enableSentry(t)
+	h := New(&sentryFakeDatastore{}, &sentryStubCache{})
+
+	for _, tc := range []struct {
+		name, method, path, bearer string
+		wantCode                   int
+	}{
+		{"401 missing credentials", http.MethodGet, "/api/v1/milpacs/ranks", "", http.StatusUnauthorized},
+		{"401 unknown key", http.MethodGet, "/api/v1/milpacs/ranks", "cav7_unknown", http.StatusUnauthorized},
+		{"403 wrong scope", http.MethodGet, "/api/v1/tickets", "cav7_sentry_read", http.StatusForbidden},
+		{"404 unknown path", http.MethodGet, "/api/v1/does/not/exist", "cav7_sentry_read", http.StatusNotFound},
+		{"400 binding error", http.MethodGet, "/api/v1/milpacs/profile/id/notanumber", "cav7_sentry_read", http.StatusBadRequest},
+		{"405 wrong method", http.MethodPost, "/api/v1/milpacs/ranks", "cav7_sentry_read", http.StatusMethodNotAllowed},
+	} {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		if tc.bearer != "" {
+			req.Header.Set("Authorization", "Bearer "+tc.bearer)
+		}
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		require.Equal(t, tc.wantCode, rr.Code, tc.name)
+	}
+
+	assert.Empty(t, tr.Events(), "client errors must not produce Sentry events")
+}
+
+// The auth-tier 503 (ValidateApiKey failing mid-outage) writes through the
+// same choke point BEFORE routing and before any key validates: the event is
+// emitted with the route and key_id tags simply omitted — same semantics as
+// the empty metrics labels on that tier.
+func TestSentry_AuthOutage503ReportsWithoutRouteOrKeyTags(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t)
+	h := New(&sentryFakeDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
+		return nil, errOutageSentry
+	}}, &sentryStubCache{})
+
+	rr := doRanks(h)
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+
+	events := tr.Events()
+	require.Len(t, events, 1, "the pre-routing 503 tier must still report")
+	ev := events[0]
+	assert.Equal(t, "HTTP 503 GET /api/v1/milpacs/ranks", ev.Message)
+	assert.Equal(t, "503", ev.Tags["http_status"])
+	assert.NotContains(t, ev.Tags, "route", "no route matched — the tag must be omitted, not empty")
+	assert.NotContains(t, ev.Tags, "key_id", "no key validated — the tag must be omitted, not empty")
+}
+
+// Bearer material must NEVER appear in any event payload. Drive every
+// reporting tier that handles the key (panic, handler 500, auth-outage 503)
+// with its real token — plus a query-string token, the other place a caller
+// might put one — then serialize every captured event in full and sweep for
+// the token. The token is assembled at runtime: AttachStacktrace embeds ±5
+// SOURCE lines around in-stack frames (ContextifyFrames), so a token literal
+// in this test's body would trip the sweep as source-context noise — source
+// can only ever leak source, never a runtime token value, which is exactly
+// what this test must stay sensitive to.
+func TestSentry_BearerMaterialAbsentFromEventPayloads(t *testing.T) {
+	token := fmt.Sprintf("cav%d_%s", 7, "sweeptoken")
+	acceptAny := func(string) (*datastores.ApiKeyResult, error) {
+		return &datastores.ApiKeyResult{KeyId: 7, UserId: 3, Scopes: map[string]struct{}{"read": {}}}, nil
+	}
+
+	tr := enableSentry(t)
+	captureErrorLog(t)
+
+	panicStack := New(&sentryFakeDatastore{validateApiKey: acceptAny, findAllRanks: func() ([]*proto.RankExpanded, error) {
+		panic("boom")
+	}}, &sentryStubCache{})
+	errorStack := New(&sentryFakeDatastore{validateApiKey: acceptAny, findAllRanks: func() ([]*proto.RankExpanded, error) {
+		return nil, errOutageSentry
+	}}, &sentryStubCache{})
+	outageStack := New(&sentryFakeDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
+		return nil, errOutageSentry
+	}}, &sentryStubCache{})
+
+	for _, h := range []http.Handler{panicStack, errorStack, outageStack} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks?key="+token, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Cookie", "session="+token)
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	events := tr.Events()
+	require.Len(t, events, 3, "every tier must have reported")
+	sawKeyID := false
+	for _, ev := range events {
+		raw, err := json.Marshal(ev)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), token,
+			"bearer material leaked into an event payload: %s", raw)
+		if ev.Tags["key_id"] == "7" {
+			sawKeyID = true
+		}
+	}
+	assert.True(t, sawKeyID, "the validated key id (not the token) is how events are attributed")
+}
+
+// The production BeforeSend scrub (wired by SetupSentry) strips request auth
+// material from any event that does carry request data — belt-and-braces for
+// capture points that attach the request to the scope.
+func TestSentry_BeforeSendScrubsRequestAuthMaterial(t *testing.T) {
+	tr := enableSentry(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks?key=cav7_secret", nil)
+	req.Header.Set("Authorization", "Bearer cav7_secret")
+	req.Header.Set("authorization", "Bearer cav7_secret") // case-insensitive strip
+	req.Header.Set("Proxy-Authorization", "Basic cav7_secret")
+	req.Header.Set("Cookie", "session=cav7_secret")
+	req.Header.Set("User-Agent", "sweep-test")
+
+	hub := sentry.CurrentHub().Clone()
+	hub.Scope().SetRequest(req)
+	hub.CaptureMessage("request-bearing event")
+
+	events := tr.Events()
+	require.Len(t, events, 1)
+	ev := events[0]
+	require.NotNil(t, ev.Request, "request data itself survives — only auth material is stripped")
+	assert.Empty(t, ev.Request.Cookies)
+	assert.Empty(t, ev.Request.QueryString)
+	for name := range ev.Request.Headers {
+		assert.NotContains(t, []string{"authorization", "cookie", "proxy-authorization"},
+			strings.ToLower(name), "auth header %q must be scrubbed", name)
+	}
+	assert.Equal(t, "sweep-test", ev.Request.Headers["User-Agent"], "non-auth headers survive")
+}
+
+// No DSN → complete no-op (Phase 0 parity): with no client bound the sentry
+// layer is a pass-through — panics propagate exactly as they do today
+// (net/http recovers them per-connection; here, to the test) with nothing
+// written, and 5xx responses flow through the choke point unchanged with no
+// capture machinery in the path.
+func TestSentry_NoDSNIsCompletePassThrough(t *testing.T) {
+	require.Nil(t, sentry.CurrentHub().Client(), "precondition: no client bound")
+	captureErrorLog(t)
+
+	h := New(&sentryFakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		panic("ranks exploded")
+	}}, &sentryStubCache{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_sentry_read")
+	rr := httptest.NewRecorder()
+	panicked := func() (p any) {
+		defer func() { p = recover() }()
+		h.ServeHTTP(rr, req)
+		return nil
+	}()
+	require.Equal(t, "ranks exploded", panicked,
+		"without a DSN the panic must propagate unchanged — no recovery, no rewriting of crash semantics")
+	assert.Zero(t, rr.Body.Len(), "no recovery layer means nothing is written for the panicked request")
+
+	h500 := New(&sentryFakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		return nil, errOutageSentry
+	}}, &sentryStubCache{})
+	rr = doRanks(h500)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code, "the 5xx path itself is untouched")
+}
+
+// A panic AFTER the response committed cannot become a contract 500 — the
+// status is on the wire. The event is still captured, then the panic
+// re-raises so net/http aborts the connection and the client sees the
+// truncation instead of trusting a half response. (Composition mirrors New;
+// mini-chain because no real handler writes before panicking.)
+func TestSentry_PanicAfterCommittedResponseReportsAndRepanics(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /boom", sentryLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial body before the panic"))
+		panic("exploded after the 200")
+	})))
+	h := sentryMiddleware(metricsMiddleware(mux))
+
+	rr := httptest.NewRecorder()
+	panicked := func() (p any) {
+		defer func() { p = recover() }()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/boom", nil))
+		return nil
+	}()
+	require.Equal(t, "exploded after the 200", panicked,
+		"a committed response must re-raise — net/http's connection abort is the only honest signal left")
+	assert.Equal(t, http.StatusOK, rr.Code, "the committed status stays untouched")
+	assert.Equal(t, "partial body before the panic", rr.Body.String(), "no 500 body appended behind a committed 200")
+
+	events := tr.Events()
+	require.Len(t, events, 1, "the event is captured even when the response cannot be rewritten")
+	assert.Equal(t, "GET /boom", events[0].Tags["route"])
+}
+
+// The gzip layer commits bytes during panic unwind (its deferred Close emits
+// the stream header even when nothing was written), so a gzipped panic takes
+// the committed path: event captured, panic re-raised — same connection-abort
+// semantics the old stack had for every panic.
+func TestSentry_GzippedPanicReportsAndRepanics(t *testing.T) {
+	tr := enableSentry(t)
+	captureErrorLog(t)
+	h := New(&sentryFakeDatastore{findAllRanks: func() ([]*proto.RankExpanded, error) {
+		panic("ranks exploded")
+	}}, &sentryStubCache{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_sentry_read")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	panicked := func() (p any) {
+		defer func() { p = recover() }()
+		h.ServeHTTP(rr, req)
+		return nil
+	}()
+	require.Equal(t, "ranks exploded", panicked)
+
+	events := tr.Events()
+	require.Len(t, events, 1)
+	assert.Equal(t, "GET /api/v1/milpacs/ranks", events[0].Tags["route"])
+	assert.Equal(t, "7", events[0].Tags["key_id"])
+}
+
+// commitWriter is the outermost wrapper when sentry is enabled, so it must
+// expose Unwrap for http.ResponseController — otherwise Flusher/Hijacker/
+// deadline control silently vanish for every inner layer (same obligation the
+// metrics statusWriter pins one layer in).
+func TestSentry_ResponseControllerTunnelsThroughCommitWriter(t *testing.T) {
+	enableSentry(t)
+
+	flushErr := make(chan error, 1) // handler runs on the server goroutine
+	h := sentryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flushErr <- http.NewResponseController(w).Flush()
+	}))
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	res, err := srv.Client().Get(srv.URL + "/")
+	require.NoError(t, err)
+	res.Body.Close()
+	require.NoError(t, <-flushErr,
+		"ResponseController.Flush must reach the underlying writer via commitWriter.Unwrap")
 }

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -425,6 +425,32 @@ func TestSentry_GzippedPanicReportsAndRepanics(t *testing.T) {
 	assert.Equal(t, "7", events[0].Tags["key_id"])
 }
 
+// http.ErrAbortHandler is the stdlib's sentinel for a DELIBERATE abort —
+// net/http suppresses its stack trace, and httputil.ReverseProxy (the docs
+// proxy the cutover slice mounts) panics with it on client disconnects. The
+// recovery layer must re-raise it unreported: not an error, no event, no 500
+// rewrite — aborting means the connection dies, exactly as the handler asked.
+func TestSentry_ErrAbortHandlerRepanicsUnreported(t *testing.T) {
+	tr := enableSentry(t)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /abort", sentryLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	})))
+	h := sentryMiddleware(metricsMiddleware(mux))
+
+	rr := httptest.NewRecorder()
+	panicked := func() (p any) {
+		defer func() { p = recover() }()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/abort", nil))
+		return nil
+	}()
+	require.Equal(t, http.ErrAbortHandler, panicked,
+		"the abort sentinel must propagate for net/http to honour")
+	assert.Zero(t, rr.Body.Len(), "an abort must not be rewritten into a contract 500")
+	assert.Empty(t, tr.Events(), "a deliberate abort is not an error — no event")
+}
+
 // commitWriter is the outermost wrapper when sentry is enabled, so it must
 // expose Unwrap for http.ResponseController — otherwise Flusher/Hijacker/
 // deadline control silently vanish for every inner layer (same obligation the

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -466,8 +466,9 @@ func TestSentry_ConcurrentRequestsKeepIsolatedTags(t *testing.T) {
 	tr := enableSentry(t)
 	captureErrorLog(t)
 
-	var inside sync.WaitGroup
-	inside.Add(2)
+	// inside is swapped per round; the swap is sequenced by wg.Wait, so the
+	// fakes' reads never race the assignment.
+	var inside *sync.WaitGroup
 	gate := func() {
 		inside.Done()
 		inside.Wait() // releases only once BOTH requests are inside the chain
@@ -500,26 +501,45 @@ func TestSentry_ConcurrentRequestsKeepIsolatedTags(t *testing.T) {
 		return rr
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	var rrA, rrB *httptest.ResponseRecorder
-	go func() { defer wg.Done(); rrA = send("/api/v1/milpacs/ranks", "cav7_key_a") }()
-	go func() { defer wg.Done(); rrB = send("/api/v1/milpacs/profile/id/5", "cav7_key_b") }()
-	wg.Wait()
+	// One interleaved pair is a weak witness: with a shared global hub the
+	// two reports can still serialize into the right tags by scheduling
+	// luck (red-validation caught the CurrentHub()-no-Clone mutation only
+	// at -count=20). Repeating the gated pair raises a single plain run to
+	// ~80% red under that mutation (measured: 4/5 at 300 rounds — the two
+	// reports usually serialize even with both requests gated into the
+	// chain, so per-round contamination odds are low); under -race the
+	// mutation is a straight data race on the shared scope and fails
+	// deterministically. CI runs plain `go test ./...` — the branch gate's
+	// -race pass is the reliable guard until CI grows one.
+	const rounds = 300
+	for i := 0; i < rounds; i++ {
+		inside = &sync.WaitGroup{}
+		inside.Add(2)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var rrA, rrB *httptest.ResponseRecorder
+		go func() { defer wg.Done(); rrA = send("/api/v1/milpacs/ranks", "cav7_key_a") }()
+		go func() { defer wg.Done(); rrB = send("/api/v1/milpacs/profile/id/5", "cav7_key_b") }()
+		wg.Wait()
 
-	require.Equal(t, http.StatusInternalServerError, rrA.Code)
-	require.Equal(t, http.StatusInternalServerError, rrB.Code)
+		require.Equal(t, http.StatusInternalServerError, rrA.Code)
+		require.Equal(t, http.StatusInternalServerError, rrB.Code)
+	}
 
 	events := tr.Events()
-	require.Len(t, events, 2, "two failing requests = two events")
-	routeByKey := map[string]string{}
-	for _, ev := range events {
-		routeByKey[ev.Tags["key_id"]] = ev.Tags["route"]
-	}
-	assert.Equal(t, map[string]string{
+	require.Len(t, events, 2*rounds, "every failing request = one event")
+	want := map[string]string{
 		"11": "GET /api/v1/milpacs/ranks",
 		"22": "GET /api/v1/milpacs/profile/id/{user_id}",
-	}, routeByKey, "each event must carry its OWN request's key_id and route — per-request hub.Clone() isolation")
+	}
+	seen := map[string]int{}
+	for _, ev := range events {
+		require.Equal(t, want[ev.Tags["key_id"]], ev.Tags["route"],
+			"each event must carry its OWN request's key_id and route — per-request hub.Clone() isolation")
+		seen[ev.Tags["key_id"]]++
+	}
+	assert.Equal(t, map[string]int{"11": rounds, "22": rounds}, seen,
+		"event count per key must match the rounds — no dropped or doubled reports")
 }
 
 // http.ErrAbortHandler is the stdlib's sentinel for a DELIBERATE abort —

--- a/rest/write.go
+++ b/rest/write.go
@@ -91,12 +91,15 @@ type statusBody struct {
 // the guard would otherwise be unreachable dead weight. Swapped only by tests.
 var marshalJSON = json.Marshal
 
-// writeError is the single error choke point of the new stack: every non-401
-// error response is written here — one place to keep the wire shape, the
-// code→HTTP mapping, the ≥500 server-side logging, and the 5xx Sentry
-// reports (#132, reportServerError). The plain-text 401 tier deliberately bypasses
-// it: the auth middleware writes those itself (two-tier behavior golden-pinned
-// by #106). r supplies the method/path request context for the log lines.
+// writeError is the error choke point's main entrance: every non-401 error
+// response is written here or through writeStatusJSON below (the
+// status-decoupled form methodNotAllowed reaches directly) — one place to
+// keep the wire shape and the code→HTTP mapping; the ≥500 server-side
+// logging and the 5xx Sentry reports (#132, reportServerError) live in
+// writeStatusJSON so both entrances share them. The plain-text 401 tier
+// deliberately bypasses it: the auth middleware writes those itself (two-tier
+// behavior golden-pinned by #106). r supplies the method/path request context
+// for the log lines.
 //
 // Handler-specific message strings are frozen behavior (including the ones
 // that leak wrapped error text) — callers format them verbatim.
@@ -129,6 +132,12 @@ func writeStatusJSON(w http.ResponseWriter, r *http.Request, status int, c code,
 		// message, or the real error vanishes behind the generic body.
 		Error.Printf("%s %s: marshaling error body failed (original code %d, message %q): %v",
 			r.Method, r.URL.Path, c, msg, err)
+		if status < 500 {
+			// The wire status just became a 500 even though the original was
+			// 4xx — report it like every other server error (the choke-point
+			// rule; the ≥500 branch above already reported the rest).
+			reportServerError(r, http.StatusInternalServerError)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		if _, werr := w.Write([]byte(`{"code":13,"message":"failed to encode error","details":[]}`)); werr != nil {

--- a/rest/write.go
+++ b/rest/write.go
@@ -93,8 +93,8 @@ var marshalJSON = json.Marshal
 
 // writeError is the single error choke point of the new stack: every non-401
 // error response is written here — one place to keep the wire shape, the
-// code→HTTP mapping, the ≥500 server-side logging, and (extension point,
-// #132) the 5xx Sentry reports. The plain-text 401 tier deliberately bypasses
+// code→HTTP mapping, the ≥500 server-side logging, and the 5xx Sentry
+// reports (#132, reportServerError). The plain-text 401 tier deliberately bypasses
 // it: the auth middleware writes those itself (two-tier behavior golden-pinned
 // by #106). r supplies the method/path request context for the log lines.
 //
@@ -111,9 +111,10 @@ func writeError(w http.ResponseWriter, r *http.Request, c code, format string, a
 func writeStatusJSON(w http.ResponseWriter, r *http.Request, status int, c code, format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	if status >= 500 {
-		// Cheap insurance: production 5xx outages stay visible server-side
-		// even if cutover (#134) lands before the Sentry slice (#132).
+		// The log line keeps 5xx outages visible server-side even without a
+		// SENTRY_DSN (local/dev — the report below is then a no-op).
 		Error.Printf("%s %s: %d (code %d): %s", r.Method, r.URL.Path, status, c, msg)
+		reportServerError(r, status)
 	}
 	body, err := marshalJSON(statusBody{
 		Code:    c,

--- a/rest/write_test.go
+++ b/rest/write_test.go
@@ -112,8 +112,9 @@ func TestWriteJSON_MarshalFailureBecomesInternalError(t *testing.T) {
 }
 
 // Every ≥500 response is Error-logged at the choke point with code, message,
-// method, and path — cheap insurance that a production outage is visible
-// server-side even if cutover (#134) lands before the Sentry slice (#132).
+// method, and path — the log line keeps outages visible server-side even
+// without a SENTRY_DSN (local/dev), where the choke point's Sentry report
+// (#132) is a no-op.
 func TestWriteError_500sAreLoggedWithRequestContext(t *testing.T) {
 	buf := captureErrorLog(t)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
Closes #132. Part of #112 Phase 3 (wave 2). Independent of the #157/#158 stack — mergeable in any order (expect a trivial `rest/rest.go` chain-comment conflict with #128's `cleanPathRedirect` if it lands first; single-merge resolves).

## What
`rest/sentry.go`: `SetupSentry(release)` env-gated by `SENTRY_DSN` exactly as Phase 0 (no DSN → complete no-op incl. panic propagation); recovery middleware at the front of the chain — **outside metrics per the ratified ruling** (metrics meters the panic as 500-unwritten and re-panics; sentry catches the re-panic, reports tagged event, writes the contract 500); 5xx reports from the single `writeStatusJSON` choke point; tags = key id + matched route pattern + release; bearer material never sent (runtime-assembled-token sweep across all three reporting tiers); committed-response and gzip-stream panics re-raise (honest truncation); `ErrAbortHandler` re-raised unreported.

## Review trail
4 review agents + fixer round + red-validation: 3 doc-Criticals fixed (false Phase-0-gateway-coverage claim, inverted commitWriter wrap direction, invented #134 ReverseProxy); log-before-capture reorder (panic stack survives SDK-path failure); `commitWriter.FlushError` closes the ResponseController-flush blind spot; #134 hand-off obligation documented in-file **and** on the issue (dial check / startup probe / shutdown flush — see #134 comment). New pins mutation-verified: global-hub regression (300-round gated pairs, ~80% red plain / deterministic under -race), bad-DSN boot safety, panic-metered-exactly-once, flush-then-panic.

## Gate
gofmt/vet/build clean; `go test ./...` + `go test -race ./rest/` green; `make test-integration` green. Re-verified independently by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)