### PR TITLE
datastores: fix copy-pasted 'lite' in processProfiles error wrap

### DIFF
--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -644,7 +644,7 @@ func (ds Mysql) processProfiles(profiles []milpacs.Profile) (map[uint64]*proto.P
 	for _, profile := range profiles {
 		protoProfile, err := ds.generateProtoProfile(profile)
 		if err != nil {
-			return nil, fmt.Errorf("error generating lite profile: %w", err)
+			return nil, fmt.Errorf("error generating profile: %w", err)
 		}
 
 		protoProfile.LastForumPostDate = forumPostDates[profile.UserID]


### PR DESCRIPTION
> *This was generated by AI during triage.*

One-word fix for #156, landed as the triage freebie per the 2026-06-06 pre-#131 backlog ruling: `processProfiles` (the FULL-profile path, `datastores/mysql.go:647`) wrapped its error as `"error generating lite profile"` — copy-pasted from `processLiteProfiles` at mysql.go:630.

**One nuance beyond the issue's framing** (which called it a log line): the wrap reaches the wire — it interpolates into the handler's frozen Internal message (`"fetch roster %s: %v"`, rest/rosters.go:65) in 500 bodies during a partial outage on full-profile routes. Checked before landing:

- no golden contains the string (goldens witness no error-path bodies here)
- no pinned test carries it (outage pins use fake-datastore error text)
- envelope, gRPC code (13), and the handler's own message string are unchanged

So this is diagnostic-text-only — exactly the "observability, not shape" category ruled on #154/#155 the same day.

Gate: gofmt clean, `go vet` clean, build green, `go test ./datastores/... ./rest/... ./contract/...` green.

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
