### PR TITLE
rest: pin the %2F-as-segment-data family (deliberate break, PRD #112)

### DIFF
--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -1264,3 +1264,44 @@ func TestNewStack_EmptyRanksIsEmptyArray(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, `{"ranks":[]}`, strings.TrimSpace(rr.Body.String()))
 }
+
+// --- Encoded path separators (deliberate break, PRD #112, ruled 2026-06-06) -
+//
+// The old gateway percent-decoded paths BEFORE routing, so %2F was
+// routing-equivalent to a literal slash; ServeMux matches the escaped path,
+// so %2F stays data within a single segment and binds into the path value —
+// the non-wildcard sibling of the #128 search-segment break. Pinned
+// new-stack-only: the corpus replays the old stack, which produces the
+// pre-break behavior (roster generic 404, username generic 404, tickets
+// messages 200 via decode-before-route, ticket_id parse stopping at "ref").
+// The unknown-path case rides along as the family's no-divergence member —
+// the fallback 404 is identical on both stacks.
+func TestNewStack_EncodedSlashStaysSegmentData(t *testing.T) {
+	h := newStack(t)
+
+	cases := []struct {
+		path, key  string
+		wantStatus int
+		wantBody   string
+	}{
+		{"/api/v1/roster/combat%2Ffoo", "cav7_readkey", http.StatusBadRequest,
+			`{"code":3,"message":"type mismatch, parameter: roster, error: combat/foo is not valid","details":[]}`},
+		{"/api/v1/milpacs/profile/username/john%2Fdoe", "cav7_readkey", http.StatusNotFound,
+			`{"code":5,"message":"no profile found for username: john/doe","details":[]}`},
+		{"/api/v1/tickets/1%2Fmessages", "cav7_ticketskey", http.StatusBadRequest,
+			`{"code":3,"message":"type mismatch, parameter: ticket_id, error: strconv.ParseUint: parsing \"1/messages\": invalid syntax","details":[]}`},
+		{"/api/v1/tickets/ref%2Fmessages", "cav7_ticketskey", http.StatusBadRequest,
+			`{"code":3,"message":"type mismatch, parameter: ticket_id, error: strconv.ParseUint: parsing \"ref/messages\": invalid syntax","details":[]}`},
+		{"/api/v1/foo%2Fbar", "cav7_readkey", http.StatusNotFound,
+			`{"code":5,"message":"Not Found","details":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			rr := positionsGet(t, h, tc.path, tc.key)
+
+			require.Equal(t, tc.wantStatus, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, tc.wantBody, rr.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
> *This was generated by AI during triage.*

Executes the %2F family ruling (2026-06-06, pre-#131 triage): pins all five probed shapes of the encoded-path-separator deliberate break, new-stack-only (`TestNewStack_EncodedSlashStaysSegmentData`, rest/rest_test.go). The corpus replays the old stack, which produces the pre-break behavior — same pinning mechanism as the 405 and 307 precedents.

Shapes pinned (verbatim from the dual-stack probe):

- `roster/combat%2Ffoo` → 400 type-mismatch on the bound roster value (was generic 404)
- `milpacs/profile/username/john%2Fdoe` → 404 with bound-value message (was generic 404)
- `tickets/1%2Fmessages` → 400 ticket_id parse (was **200** via the old gateway's decode-before-route; sole `read:tickets` holder ruled it breakable by ownership)
- `tickets/ref%2Fmessages` → 400, parse text now binds the whole segment
- `foo%2Fbar` → unchanged JSON 404, the family's no-divergence member

The full enumerated entry with probe-table values is recorded in PRD #112's deliberate-breaks list (body, after the 307 entry).

Mutation-verified: the roster pin goes red on a one-word mutation of `types/rostertype_parse.go`'s parse text (first attempt was a no-op sed against the wrong file — caught and redone against the real string).

Gate: gofmt clean, vet clean, build green, full `go test ./...` green.

Ref #112. Clears the %2F gate; #131 is then gated solely on #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
