### PR TITLE
Phase 3: Cache-Control headers on read endpoints (#131)

### DIFF
--- a/contract/golden.go
+++ b/contract/golden.go
@@ -87,6 +87,12 @@ type Case struct {
 //     no challenge header. RunCase skips empty headers, so goldens carry no
 //     WWW-Authenticate key; a rewrite whose auth middleware adds one shows
 //     up in CompareGolden as ""-vs-set — a red diff.
+//
+// Cache-Control (#131) must stay OFF this list: it is a deliberate
+// new-stack-only addition (the old stack sends none), so recording it would
+// pin its ABSENCE the same way WWW-Authenticate's is — poisoning the new
+// stack's replay. Its pins live in rest/cachecontrol_test.go and the spec
+// coupling in rest/spec_test.go instead.
 var contractHeaders = []string{"Content-Type", "X-Content-Type-Options", "WWW-Authenticate"}
 
 // Golden is the recorded contract for one case: status, allowlisted headers,

--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -736,9 +736,9 @@ func TestSpec_MutationCanary(t *testing.T) {
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -838,9 +838,10 @@ func TestSpec_MutationCanary(t *testing.T) {
 // TestSpec_Every200DeclaresCacheControl pins the Cache-Control freshness
 // signal (#131) at the spec layer, both directions:
 //
-//   - every operation's explicitly declared 2xx response MUST carry a
-//     required Cache-Control header whose schema is a string const of the
-//     form "max-age=N" — the spec is where the per-route-group values are
+//   - every operation's explicitly declared 2xx response MUST declare a
+//     Cache-Control header (deliberately optional — see the required-header
+//     note in the body) whose schema is a string const of the form
+//     "max-age=N" — the spec is where the per-route-group values are
 //     recorded for consumers, and a new operation cannot land without
 //     declaring its freshness bound;
 //   - no non-2xx response (operation-declared, default, or shared

--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -853,10 +853,10 @@ func TestSpec_MutationCanary(t *testing.T) {
 // corpus deliberately records no Cache-Control (the old stack sends none —
 // a recorded key would pin the header's absence), which is why this is a
 // structural net plus a live coupling test, not a golden field.
-var cacheControlConst = regexp.MustCompile(`^max-age=[0-9]+$`)
-
 func TestSpec_Every200DeclaresCacheControl(t *testing.T) {
 	_, model := loadSpec(t)
+
+	cacheControlConst := regexp.MustCompile(`^max-age=[0-9]+$`)
 
 	checkResponse := func(where, code string, r *v3.Response) {
 		if r == nil {

--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -733,6 +733,15 @@ func mutateSpec(t *testing.T, find, replace string) (libopenapi.Document, *v3.Do
 func TestSpec_MutationCanary(t *testing.T) {
 	const ranks200Block = `        "200":
           description: Rank reference list.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -824,6 +833,94 @@ func TestSpec_MutationCanary(t *testing.T) {
 			assert.Contains(t, joined, m.wantOp, "failure must name the operation")
 		})
 	}
+}
+
+// TestSpec_Every200DeclaresCacheControl pins the Cache-Control freshness
+// signal (#131) at the spec layer, both directions:
+//
+//   - every operation's explicitly declared 2xx response MUST carry a
+//     required Cache-Control header whose schema is a string const of the
+//     form "max-age=N" — the spec is where the per-route-group values are
+//     recorded for consumers, and a new operation cannot land without
+//     declaring its freshness bound;
+//   - no non-2xx response (operation-declared, default, or shared
+//     components.responses) may declare one — errors are always served
+//     live, exactly as the retired response cache (200s-only) behaved.
+//
+// The VALUES the new stack actually sends are asserted against these
+// declarations in rest/spec_test.go (observed-equals-declared), so the spec
+// and the registration table cannot drift apart silently. The frozen golden
+// corpus deliberately records no Cache-Control (the old stack sends none —
+// a recorded key would pin the header's absence), which is why this is a
+// structural net plus a live coupling test, not a golden field.
+var cacheControlConst = regexp.MustCompile(`^max-age=[0-9]+$`)
+
+func TestSpec_Every200DeclaresCacheControl(t *testing.T) {
+	_, model := loadSpec(t)
+
+	checkResponse := func(where, code string, r *v3.Response) {
+		if r == nil {
+			return
+		}
+		var hdr *v3.Header
+		if r.Headers != nil {
+			hdr = r.Headers.GetOrZero("Cache-Control")
+		}
+		if !strings.HasPrefix(code, "2") {
+			assert.Nil(t, hdr,
+				"%s: response %s declares Cache-Control — errors are served live, only 2xx carries the freshness signal", where, code)
+			return
+		}
+		require.NotNil(t, hdr,
+			"%s: 2xx response declares no Cache-Control header — every read endpoint records its freshness bound in the spec (#131)", where)
+		// Deliberately NOT required: the validator enforces required response
+		// headers, and the frozen golden corpus (recorded from the old stack,
+		// which sends none — and allowlist-filtered besides) replays against
+		// this document, so required: true breaks TestSpec_GoldenReplay
+		// permanently. The new stack's always-sent-on-200 guarantee is pinned
+		// live instead (rest/cachecontrol_test.go and the observed-equals-
+		// declared coupling in rest/spec_test.go).
+		assert.False(t, hdr.Required,
+			"%s: Cache-Control must stay optional — required: true fails the frozen-corpus replay (goldens record no Cache-Control)", where)
+		require.NotNil(t, hdr.Schema, "%s: Cache-Control header declares no schema", where)
+		s := hdr.Schema.Schema()
+		require.NotNil(t, s, "%s: Cache-Control header schema does not build", where)
+		assert.Equal(t, []string{"string"}, s.Type, "%s: Cache-Control schema must be a string", where)
+		require.NotNil(t, s.Const,
+			"%s: Cache-Control schema must pin its exact value with const — the declaration IS the recorded per-route-group value", where)
+		assert.Regexp(t, cacheControlConst, s.Const.Value,
+			"%s: Cache-Control const must be of the form max-age=N", where)
+	}
+
+	if model.Components != nil {
+		for pair := orderedmap.First(model.Components.Responses); pair != nil; pair = pair.Next() {
+			// Shared components.responses are the error tier (Unauthorized,
+			// Error) — never 2xx, so they must declare no Cache-Control.
+			checkResponse("components.responses."+pair.Key(), "default", pair.Value())
+		}
+	}
+
+	two00s := 0
+	for pair := orderedmap.First(model.Paths.PathItems); pair != nil; pair = pair.Next() {
+		route := pair.Key()
+		for method, op := range pair.Value().GetOperations().FromOldest() {
+			opPath := strings.ToUpper(method) + " " + route
+			if op.Responses == nil {
+				continue // absence of responses is the replay loop's failure to report
+			}
+			for rp := orderedmap.First(op.Responses.Codes); rp != nil; rp = rp.Next() {
+				if strings.HasPrefix(rp.Key(), "2") {
+					two00s++
+				}
+				checkResponse(opPath+".responses."+rp.Key(), rp.Key(), rp.Value())
+			}
+			checkResponse(opPath+".responses.default", "default", op.Responses.Default)
+		}
+	}
+	// Non-vacuousness: the surface declares a 2xx on every operation
+	// (TestSpec_EveryOperationHasGolden demands a 2xx golden per operation,
+	// and the replay loop demands the status be declared).
+	assert.GreaterOrEqual(t, two00s, 16, "expected a 2xx declaration per public operation, saw %d", two00s)
 }
 
 // TestSpec_EveryOperationHasGolden is coverage direction A: every operation

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -534,8 +534,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal: never cached by the retired response
-                cache; always served live (stale immediately).
+                Freshness signal: always served live — responses are
+                stale immediately; do not cache.
               schema:
                 type: string
                 const: max-age=0
@@ -574,8 +574,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal: never cached by the retired response
-                cache; always served live (stale immediately).
+                Freshness signal: always served live — responses are
+                stale immediately; do not cache.
               schema:
                 type: string
                 const: max-age=0
@@ -612,8 +612,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal: never cached by the retired response
-                cache; always served live (stale immediately).
+                Freshness signal: always served live — responses are
+                stale immediately; do not cache.
               schema:
                 type: string
                 const: max-age=0
@@ -669,8 +669,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal: never cached by the retired response
-                cache; always served live (stale immediately).
+                Freshness signal: always served live — responses are
+                stale immediately; do not cache.
               schema:
                 type: string
                 const: max-age=0
@@ -699,8 +699,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal: never cached by the retired response
-                cache; always served live (stale immediately).
+                Freshness signal: always served live — responses are
+                stale immediately; do not cache.
               schema:
                 type: string
                 const: max-age=0

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -74,9 +74,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -121,9 +121,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -156,9 +156,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -191,9 +191,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -222,9 +222,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -257,9 +257,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -290,9 +290,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -336,9 +336,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -365,9 +365,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -394,9 +394,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -421,9 +421,9 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): consumers may treat this data as
-                fresh for 10 minutes — parity with the retired response
-                cache's update_time poller (ADR 0003).
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
               schema:
                 type: string
                 const: max-age=600
@@ -534,8 +534,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): per-user data, never cached —
-                always served live (max-age=0, stale immediately).
+                Freshness signal: never cached by the retired response
+                cache; always served live (stale immediately).
               schema:
                 type: string
                 const: max-age=0
@@ -574,8 +574,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): per-user data, never cached —
-                always served live (max-age=0, stale immediately).
+                Freshness signal: never cached by the retired response
+                cache; always served live (stale immediately).
               schema:
                 type: string
                 const: max-age=0
@@ -612,8 +612,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): per-user data, never cached —
-                always served live (max-age=0, stale immediately).
+                Freshness signal: never cached by the retired response
+                cache; always served live (stale immediately).
               schema:
                 type: string
                 const: max-age=0
@@ -669,8 +669,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): per-user data, never cached —
-                always served live (max-age=0, stale immediately).
+                Freshness signal: never cached by the retired response
+                cache; always served live (stale immediately).
               schema:
                 type: string
                 const: max-age=0
@@ -699,8 +699,8 @@ paths:
           headers:
             Cache-Control:
               description: >-
-                Freshness signal (#131): per-user data, never cached —
-                always served live (max-age=0, stale immediately).
+                Freshness signal: never cached by the retired response
+                cache; always served live (stale immediately).
               schema:
                 type: string
                 const: max-age=0

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -71,6 +71,15 @@ paths:
       responses:
         "200":
           description: The full milpac profile.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -109,6 +118,15 @@ paths:
       responses:
         "200":
           description: The full milpac profile.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -135,6 +153,15 @@ paths:
       responses:
         "200":
           description: The full milpac profile.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -161,6 +188,15 @@ paths:
       responses:
         "200":
           description: The full milpac profile.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -183,6 +219,15 @@ paths:
       responses:
         "200":
           description: Profiles keyed by milpac relation id.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -209,6 +254,15 @@ paths:
       responses:
         "200":
           description: Lite profiles keyed by milpac relation id.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -233,6 +287,15 @@ paths:
       responses:
         "200":
           description: S1 uniforms profiles keyed by milpac relation id.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -270,6 +333,15 @@ paths:
           description: >-
             Matching lite profiles keyed by milpac relation id; {} when
             nothing matches (200, never 404).
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -290,6 +362,15 @@ paths:
       responses:
         "200":
           description: Rank reference list.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -310,6 +391,15 @@ paths:
       responses:
         "200":
           description: Position group reference tree.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -328,6 +418,15 @@ paths:
       responses:
         "200":
           description: AWOL list.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): consumers may treat this data as
+                fresh for 10 minutes — parity with the retired response
+                cache's update_time poller (ADR 0003).
+              schema:
+                type: string
+                const: max-age=600
           content:
             application/json:
               schema:
@@ -432,6 +531,14 @@ paths:
       responses:
         "200":
           description: One page of tickets.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): per-user data, never cached —
+                always served live (max-age=0, stale immediately).
+              schema:
+                type: string
+                const: max-age=0
           content:
             application/json:
               schema:
@@ -464,6 +571,14 @@ paths:
       responses:
         "200":
           description: The ticket with its first messages.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): per-user data, never cached —
+                always served live (max-age=0, stale immediately).
+              schema:
+                type: string
+                const: max-age=0
           content:
             application/json:
               schema:
@@ -494,6 +609,14 @@ paths:
       responses:
         "200":
           description: The ticket with its first messages.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): per-user data, never cached —
+                always served live (max-age=0, stale immediately).
+              schema:
+                type: string
+                const: max-age=0
           content:
             application/json:
               schema:
@@ -543,6 +666,14 @@ paths:
       responses:
         "200":
           description: One page of the message thread.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): per-user data, never cached —
+                always served live (max-age=0, stale immediately).
+              schema:
+                type: string
+                const: max-age=0
           content:
             application/json:
               schema:
@@ -565,6 +696,14 @@ paths:
       responses:
         "200":
           description: Category reference tree.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal (#131): per-user data, never cached —
+                always served live (max-age=0, stale immediately).
+              schema:
+                type: string
+                const: max-age=0
           content:
             application/json:
               schema:

--- a/rest/cachecontrol.go
+++ b/rest/cachecontrol.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -95,16 +96,32 @@ func (w *cacheControlWriter) Write(b []byte) (int, error) {
 // flush — a flush before the first write commits the response, so without
 // this the header would miss the wire and the later Write would stamp a dead
 // map. Delegating through a fresh ResponseController keeps the downstream
-// search semantics identical (http.ErrNotSupported surfaces naturally when
-// nothing below can flush).
+// search semantics identical.
+//
+// If the delegated flush reports http.ErrNotSupported, no layer below could
+// flush — nothing reached the wire, so nothing committed — and the stamp
+// this call made is rolled back. Leaving it would poison the live header map
+// and lie committed=true: a handler reacting to the failed flush by writing
+// an error would commit a non-200 carrying max-age, the exact leak class the
+// type doc forbids. Worst on the gzip chain, where gzipResponseWriter
+// supports no flush at all, so the delegated flush ALWAYS fails this way. A
+// genuine I/O error keeps the state: by then net/http has already
+// snapshotted the headers onto the wire, so the commit really happened.
 func (w *cacheControlWriter) FlushError() error {
+	stamped := false
 	if !w.committed {
 		// A flush without an explicit WriteHeader commits the net/http
 		// implied 200 — same decision as the Write path above.
 		w.committed = true
 		w.Header().Set("Cache-Control", w.value)
+		stamped = true
 	}
-	return http.NewResponseController(w.ResponseWriter).Flush()
+	err := http.NewResponseController(w.ResponseWriter).Flush()
+	if stamped && errors.Is(err, http.ErrNotSupported) {
+		w.Header().Del("Cache-Control")
+		w.committed = false
+	}
+	return err
 }
 
 // Unwrap exposes the underlying writer to http.ResponseController so inner

--- a/rest/cachecontrol.go
+++ b/rest/cachecontrol.go
@@ -21,18 +21,21 @@ import (
 //     information_schema.tables.update_time over its 9 monitored tables
 //     every 10 minutes and flushed on any change, so consumers already
 //     tolerated up-to-10-minute staleness on every roster-family route.
-//   - maxAgeTickets (0): the old cache was keyed by path only, so the
-//     per-user tickets surface was NEVER cached — always served live.
-//     max-age=0 (stale immediately) is the honest signal for per-user data;
-//     anything larger would invent a freshness bound that never existed.
+//   - maxAgeTickets (0): also parity, not a judgment about the data. Tickets
+//     are a query-variant surface (filters, cursors) that the retired
+//     cache's path-only key could not cache, so its middleware bypassed the
+//     entire /api/v1/tickets prefix wholesale (middleware/cache.go @
+//     92afba5^) — every tickets response was served live. max-age=0 (stale
+//     immediately) is the honest signal for that; anything larger would
+//     invent a freshness bound that never existed.
 //
 // The header goes on 200s ONLY — also parity: the retired cache stored 200s
-// and nothing else ("Non-200 response: not caching"), so error responses
-// were always recomputed live on both surfaces. A cacheable 500 or 404
-// would be a regression the old stack never had.
+// and nothing else ("[CACHE] Non-200 response: %d, not caching"), so error
+// responses were always recomputed live on both surfaces. A cacheable 500
+// or 404 would be a regression the old stack never had.
 const (
 	maxAgeRosterFamily = 600 // seconds; scope "read" — the surface the old cache covered
-	maxAgeTickets      = 0   // seconds; scope "read:tickets" — never cached, per-user data
+	maxAgeTickets      = 0   // seconds; scope "read:tickets" — the surface the old cache bypassed
 )
 
 // cacheControl wraps a route handler, stamping the route group's
@@ -41,6 +44,11 @@ const (
 // required argument of handle() — like the scope gate, a wrapping convention
 // is how a route silently loses its freshness signal.
 func cacheControl(maxAgeSeconds int, next http.Handler) http.Handler {
+	if maxAgeSeconds < 0 {
+		// Registration-time constant — a negative max-age is invalid on the
+		// wire and always a programming error, so fail at startup.
+		panic(fmt.Sprintf("cacheControl: negative max-age %d", maxAgeSeconds))
+	}
 	value := fmt.Sprintf("max-age=%d", maxAgeSeconds)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(&cacheControlWriter{ResponseWriter: w, value: value}, r)
@@ -48,10 +56,15 @@ func cacheControl(maxAgeSeconds int, next http.Handler) http.Handler {
 }
 
 // cacheControlWriter injects the Cache-Control header at commit time — the
-// first WriteHeader or Write call — and only when the response is a 200.
+// first WriteHeader, Write, or flush — and only when the response is a 200.
 // Commit time is the only safe moment: setting the header eagerly would leak
 // it onto error responses written later (writeError never clears headers),
 // and onto the contract 500 the sentry layer writes after a handler panic.
+// On a 200 the Set is unconditional: a handler-set Cache-Control is
+// discarded — the registration table is the single source of truth for
+// freshness bounds. The stamped surface is exactly 200, not 2xx (the
+// structural spec test covers every declared 2xx): a non-200 2xx route
+// needs a deliberate extension of both this wrapper and that test.
 type cacheControlWriter struct {
 	http.ResponseWriter
 	value     string
@@ -78,9 +91,27 @@ func (w *cacheControlWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
+// FlushError stamps the header on the implied 200 before delegating the
+// flush — a flush before the first write commits the response, so without
+// this the header would miss the wire and the later Write would stamp a dead
+// map. Delegating through a fresh ResponseController keeps the downstream
+// search semantics identical (http.ErrNotSupported surfaces naturally when
+// nothing below can flush).
+func (w *cacheControlWriter) FlushError() error {
+	if !w.committed {
+		// A flush without an explicit WriteHeader commits the net/http
+		// implied 200 — same decision as the Write path above.
+		w.committed = true
+		w.Header().Set("Cache-Control", w.value)
+	}
+	return http.NewResponseController(w.ResponseWriter).Flush()
+}
+
 // Unwrap exposes the underlying writer to http.ResponseController so inner
-// layers keep Flusher/Hijacker/deadline access through this wrapper (same
-// rule as statusWriter in metrics.go).
+// layers keep Flusher/Hijacker/deadline access through this wrapper. The
+// model is commitWriter in sentry.go, not statusWriter: this wrapper has
+// commit-time semantics, so Unwrap alone would open the tunnel's blind spot
+// — FlushError above closes it.
 func (w *cacheControlWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }

--- a/rest/cachecontrol.go
+++ b/rest/cachecontrol.go
@@ -1,0 +1,86 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Cache-Control freshness signal (#131): every read route's 200 responses
+// carry `Cache-Control: max-age=…` — the cooperative signal that replaces
+// what the retired response cache's existence used to imply (PRD #112;
+// Phase 2 deleted the cache). With the cache gone this is how respectful
+// consumers learn how fresh the data is and how often to poll, instead of
+// guessing. ETag/conditional requests and rate limiting are explicitly
+// deferred (the update_time-polling trick the old cache used is the natural
+// backend for the ETag work when it comes).
+//
+// Per-route-group values, reviewed at PR time:
+//
+//   - maxAgeRosterFamily (600): parity reproduction, not a guess. The
+//     retired response cache (cache/manager.go @ 92afba5^, ADR 0003) polled
+//     information_schema.tables.update_time over its 9 monitored tables
+//     every 10 minutes and flushed on any change, so consumers already
+//     tolerated up-to-10-minute staleness on every roster-family route.
+//   - maxAgeTickets (0): the old cache was keyed by path only, so the
+//     per-user tickets surface was NEVER cached — always served live.
+//     max-age=0 (stale immediately) is the honest signal for per-user data;
+//     anything larger would invent a freshness bound that never existed.
+//
+// The header goes on 200s ONLY — also parity: the retired cache stored 200s
+// and nothing else ("Non-200 response: not caching"), so error responses
+// were always recomputed live on both surfaces. A cacheable 500 or 404
+// would be a regression the old stack never had.
+const (
+	maxAgeRosterFamily = 600 // seconds; scope "read" — the surface the old cache covered
+	maxAgeTickets      = 0   // seconds; scope "read:tickets" — never cached, per-user data
+)
+
+// cacheControl wraps a route handler, stamping the route group's
+// `Cache-Control: max-age=…` on its 200 responses. Non-200 responses pass
+// through untouched (see the package constants above for why). It is a
+// required argument of handle() — like the scope gate, a wrapping convention
+// is how a route silently loses its freshness signal.
+func cacheControl(maxAgeSeconds int, next http.Handler) http.Handler {
+	value := fmt.Sprintf("max-age=%d", maxAgeSeconds)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&cacheControlWriter{ResponseWriter: w, value: value}, r)
+	})
+}
+
+// cacheControlWriter injects the Cache-Control header at commit time — the
+// first WriteHeader or Write call — and only when the response is a 200.
+// Commit time is the only safe moment: setting the header eagerly would leak
+// it onto error responses written later (writeError never clears headers),
+// and onto the contract 500 the sentry layer writes after a handler panic.
+type cacheControlWriter struct {
+	http.ResponseWriter
+	value     string
+	committed bool
+}
+
+func (w *cacheControlWriter) WriteHeader(code int) {
+	if !w.committed {
+		w.committed = true
+		if code == http.StatusOK {
+			w.Header().Set("Cache-Control", w.value)
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *cacheControlWriter) Write(b []byte) (int, error) {
+	if !w.committed {
+		// A Write without an explicit WriteHeader is the net/http implied
+		// 200 — the writeJSON path every handler success takes.
+		w.committed = true
+		w.Header().Set("Cache-Control", w.value)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController so inner
+// layers keep Flusher/Hijacker/deadline access through this wrapper (same
+// rule as statusWriter in metrics.go).
+func (w *cacheControlWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/rest/cachecontrol.go
+++ b/rest/cachecontrol.go
@@ -22,13 +22,15 @@ import (
 //     information_schema.tables.update_time over its 9 monitored tables
 //     every 10 minutes and flushed on any change, so consumers already
 //     tolerated up-to-10-minute staleness on every roster-family route.
-//   - maxAgeTickets (0): also parity, not a judgment about the data. Tickets
-//     are a query-variant surface (filters, cursors) that the retired
-//     cache's path-only key could not cache, so its middleware bypassed the
-//     entire /api/v1/tickets prefix wholesale (middleware/cache.go @
-//     92afba5^) — every tickets response was served live. max-age=0 (stale
-//     immediately) is the honest signal for that; anything larger would
-//     invent a freshness bound that never existed.
+//   - maxAgeTickets (0): also parity, not a judgment about the data. The
+//     retired cache's middleware bypassed the entire /api/v1/tickets prefix
+//     wholesale (middleware/cache.go @ 92afba5^) — every tickets response
+//     was served live. The middleware records no rationale for the bypass —
+//     sensible, since tickets are a query-variant surface (filters, cursors)
+//     a path-only key could not have cached correctly — but the bypass
+//     itself is the verifiable fact. max-age=0 (stale immediately) is the
+//     honest signal for never-cached; anything larger would invent a
+//     freshness bound that never existed.
 //
 // The header goes on 200s ONLY — also parity: the retired cache stored 200s
 // and nothing else ("[CACHE] Non-200 response: %d, not caching"), so error

--- a/rest/cachecontrol_internal_test.go
+++ b/rest/cachecontrol_internal_test.go
@@ -13,6 +13,12 @@ import (
 // implied-200 path only (writeJSON never calls WriteHeader(200)), so the
 // explicit-WriteHeader branch needs its own witness — without one, neutering
 // the header-set inside the code==200 branch leaves the whole suite green.
+//
+// Stamp-PRESENCE assertions read rr.Result().Header — the recorder snapshots
+// at WriteHeader (a flush implies one), so a stamp set after delegating
+// would be wire-invisible and must fail here. Stamp-ABSENCE assertions read
+// the live rr.Header() map, the stronger check there: not even a
+// post-snapshot late stamp is tolerated.
 func TestCacheControlWriter_CommitDecision(t *testing.T) {
 	wrap := func() (*cacheControlWriter, *httptest.ResponseRecorder) {
 		rr := httptest.NewRecorder()
@@ -22,7 +28,7 @@ func TestCacheControlWriter_CommitDecision(t *testing.T) {
 	t.Run("explicit WriteHeader 200 stamps", func(t *testing.T) {
 		w, rr := wrap()
 		w.WriteHeader(http.StatusOK)
-		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"))
+		assert.Equal(t, "max-age=600", rr.Result().Header.Get("Cache-Control"))
 	})
 
 	t.Run("WriteHeader 204 does not stamp", func(t *testing.T) {
@@ -48,7 +54,7 @@ func TestCacheControlWriter_CommitDecision(t *testing.T) {
 		w, rr := wrap()
 		_, err := w.Write([]byte("{}"))
 		require.NoError(t, err)
-		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"))
+		assert.Equal(t, "max-age=600", rr.Result().Header.Get("Cache-Control"))
 	})
 
 	// The tunnel blind spot (same shape commitWriter closes in sentry.go): a
@@ -59,7 +65,7 @@ func TestCacheControlWriter_CommitDecision(t *testing.T) {
 	t.Run("FlushError before first write stamps", func(t *testing.T) {
 		w, rr := wrap()
 		require.NoError(t, http.NewResponseController(w).Flush())
-		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
+		assert.Equal(t, "max-age=600", rr.Result().Header.Get("Cache-Control"),
 			"a flush commits the implied 200 — the freshness signal must already be on it")
 	})
 

--- a/rest/cachecontrol_internal_test.go
+++ b/rest/cachecontrol_internal_test.go
@@ -62,7 +62,49 @@ func TestCacheControlWriter_CommitDecision(t *testing.T) {
 		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
 			"a flush commits the implied 200 — the freshness signal must already be on it")
 	})
+
+	// committed==true guard on FlushError: a flush after an explicit non-200
+	// must not stamp — the 500 already decided. Asserted on the LIVE map (not
+	// the Result snapshot): a guard mutant stamps after the recorder's
+	// WriteHeader snapshot, so only the live map can see it.
+	t.Run("FlushError after WriteHeader 500 does not stamp", func(t *testing.T) {
+		w, rr := wrap()
+		w.WriteHeader(http.StatusInternalServerError)
+		require.NoError(t, http.NewResponseController(w).Flush())
+		assert.Empty(t, rr.Header().Get("Cache-Control"))
+	})
+
+	// Regression pin (#163 R1): on a gzip-shaped chain — a plain
+	// ResponseWriter with no FlushError/Flusher/Unwrap, exactly
+	// gzipResponseWriter's shape — the delegated flush ALWAYS returns
+	// http.ErrNotSupported: nothing reached the wire. The stamp and
+	// committed=true must roll back, or a handler reacting to the failed
+	// flush by writing an error commits a non-200 carrying max-age (the leak
+	// class the wrapper's own doc forbids).
+	t.Run("failed flush rolls back stamp before error response", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		w := &cacheControlWriter{ResponseWriter: &noFlushWriter{rr: rr}, value: "max-age=600"}
+
+		err := http.NewResponseController(w).Flush()
+		require.ErrorIs(t, err, http.ErrNotSupported,
+			"a gzip-shaped writer supports no flush — nothing was sent")
+
+		w.WriteHeader(http.StatusNotFound)
+		assert.Empty(t, rr.Result().Header.Get("Cache-Control"),
+			"a 404 after a failed flush must not carry the freshness signal")
+	})
 }
+
+// noFlushWriter hides the recorder's Flusher — gzipResponseWriter's shape
+// (no FlushError, no Flusher, no Unwrap), where a delegated flush always
+// fails with http.ErrNotSupported.
+type noFlushWriter struct {
+	rr *httptest.ResponseRecorder
+}
+
+func (w *noFlushWriter) Header() http.Header         { return w.rr.Header() }
+func (w *noFlushWriter) Write(b []byte) (int, error) { return w.rr.Write(b) }
+func (w *noFlushWriter) WriteHeader(code int)        { w.rr.WriteHeader(code) }
 
 // cacheControl values are registration-time constants; a negative max-age is
 // always a programming error, so it fails at registration, not on the wire.

--- a/rest/cachecontrol_internal_test.go
+++ b/rest/cachecontrol_internal_test.go
@@ -1,0 +1,73 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Direct pins on cacheControlWriter's commit decision: the battery rides the
+// implied-200 path only (writeJSON never calls WriteHeader(200)), so the
+// explicit-WriteHeader branch needs its own witness — without one, neutering
+// the header-set inside the code==200 branch leaves the whole suite green.
+func TestCacheControlWriter_CommitDecision(t *testing.T) {
+	wrap := func() (*cacheControlWriter, *httptest.ResponseRecorder) {
+		rr := httptest.NewRecorder()
+		return &cacheControlWriter{ResponseWriter: rr, value: "max-age=600"}, rr
+	}
+
+	t.Run("explicit WriteHeader 200 stamps", func(t *testing.T) {
+		w, rr := wrap()
+		w.WriteHeader(http.StatusOK)
+		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"))
+	})
+
+	t.Run("WriteHeader 204 does not stamp", func(t *testing.T) {
+		w, rr := wrap()
+		w.WriteHeader(http.StatusNoContent)
+		assert.Empty(t, rr.Header().Get("Cache-Control"))
+	})
+
+	t.Run("WriteHeader 500 does not stamp", func(t *testing.T) {
+		w, rr := wrap()
+		w.WriteHeader(http.StatusInternalServerError)
+		assert.Empty(t, rr.Header().Get("Cache-Control"))
+	})
+
+	t.Run("second WriteHeader cannot change the first decision", func(t *testing.T) {
+		w, rr := wrap()
+		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusOK) // superfluous — the 500 already committed
+		assert.Empty(t, rr.Header().Get("Cache-Control"))
+	})
+
+	t.Run("implied 200 via Write stamps", func(t *testing.T) {
+		w, rr := wrap()
+		_, err := w.Write([]byte("{}"))
+		require.NoError(t, err)
+		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"))
+	})
+
+	// The tunnel blind spot (same shape commitWriter closes in sentry.go): a
+	// ResponseController flush before the first write commits the implied 200
+	// on the wire, so the header must be stamped by then — without FlushError
+	// the flush reaches the recorder via Unwrap and the later Write stamps a
+	// dead map.
+	t.Run("FlushError before first write stamps", func(t *testing.T) {
+		w, rr := wrap()
+		require.NoError(t, http.NewResponseController(w).Flush())
+		assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
+			"a flush commits the implied 200 — the freshness signal must already be on it")
+	})
+}
+
+// cacheControl values are registration-time constants; a negative max-age is
+// always a programming error, so it fails at registration, not on the wire.
+func TestCacheControl_NegativeMaxAgePanics(t *testing.T) {
+	assert.Panics(t, func() {
+		cacheControl(-5, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	})
+}

--- a/rest/cachecontrol_test.go
+++ b/rest/cachecontrol_test.go
@@ -1,0 +1,117 @@
+package rest_test
+
+// Cache-Control freshness signal (#131): every read endpoint's 200 responses
+// carry `Cache-Control: max-age=…` — the cooperative signal that replaces
+// what the retired response cache's existence used to imply (PRD #112,
+// Phase 2 deleted it). Values per route group (reviewed at PR time):
+//
+//   - roster-family routes (everything under scope "read"): max-age=600 —
+//     parity with the retired cache's consumer-visible freshness bound: its
+//     10-minute update_time poller (cache/manager.go @ 92afba5^, ADR 0003)
+//     meant consumers already tolerated up-to-10-minute staleness there.
+//   - tickets routes: max-age=0 — the old cache was keyed by path only, so
+//     the per-user tickets surface was NEVER cached; always served live.
+//     max-age=0 is the honest signal for that (stale immediately).
+//
+// ERROR responses carry NO Cache-Control — also parity: the retired cache
+// stored 200s only ("Non-200 response: not caching"), so errors were always
+// recomputed live on both surfaces.
+//
+// These pins are deliberately NEW-STACK-ONLY (same precedent as the 405 and
+// %2F families): the golden corpus replays against the old stack too, and
+// the old stack sends no Cache-Control — a recorded header would poison the
+// old-stack suite (or, worse, pin the header's ABSENCE).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/7cav/api/contract"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHeader wraps a stack so battery replays can observe response headers
+// the contract harness deliberately filters out: contract.RunCase records only
+// the contractHeaders allowlist (Cache-Control must stay OFF that list — the
+// goldens replay against the old stack, which sends none). After each request
+// *last holds the full header map of the response just served.
+func captureHeader(h http.Handler, last *http.Header) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+		*last = w.Header().Clone()
+	})
+}
+
+// wantCacheControl is the expected freshness signal for one observed
+// response: the route group's max-age on 200s, nothing anywhere else. The
+// tickets predicate is verbatim the retired cache middleware's bypass
+// (middleware/cache.go @ 92afba5^) — the exact line that made tickets
+// never-cached is the line that now classifies them as always-live.
+func wantCacheControl(status int, path string) string {
+	if status != http.StatusOK {
+		return ""
+	}
+	if path == "/api/v1/tickets" || strings.HasPrefix(path, "/api/v1/tickets/") {
+		return "max-age=0"
+	}
+	return "max-age=600"
+}
+
+// TestNewStack_CacheControlAcrossBattery rides the full implemented battery
+// (the golden layer's request set) and asserts the freshness signal on every
+// observed response: 200s carry their route group's max-age, everything else
+// — the 401 tiers, scope 403s, binding 400s, not-found 404s, injected-outage
+// 500s — carries NO Cache-Control at all. Because the loop derives from
+// implementedCases, a future route's battery cases are covered the moment
+// they are implemented; no second hand-maintained list.
+func TestNewStack_CacheControlAcrossBattery(t *testing.T) {
+	var last http.Header
+	h := captureHeader(newStack(t), &last)
+
+	known := map[string]contract.Case{}
+	for _, c := range contract.Cases() {
+		known[c.Name] = c
+	}
+
+	sawGroup := map[string]bool{}
+	for _, name := range implementedCases {
+		c, ok := known[name]
+		require.True(t, ok, "implementedCases entry %q names no battery case", name)
+		t.Run(name, func(t *testing.T) {
+			g, _, err := contract.RunCase(h, c)
+			require.NoError(t, err)
+
+			path := c.Path
+			if i := strings.IndexByte(path, '?'); i >= 0 {
+				path = path[:i]
+			}
+			want := wantCacheControl(g.Status, path)
+			assert.Equal(t, want, last.Get("Cache-Control"),
+				"status %d on %s", g.Status, c.Path)
+			if g.Status == http.StatusOK {
+				sawGroup[want] = true
+			}
+		})
+	}
+
+	// Non-vacuousness: the battery must witness a 200 in BOTH route groups —
+	// otherwise the tickets value (or the roster one) passes by absence.
+	assert.True(t, sawGroup["max-age=600"], "no roster-family 200 witnessed the 600 bound")
+	assert.True(t, sawGroup["max-age=0"], "no tickets 200 witnessed the always-live signal")
+}
+
+func TestNewStack_RanksCarriesRosterFamilyCacheControl(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
+		"roster-family 200s carry the retired cache's 10-minute freshness bound (ADR 0003 parity)")
+}

--- a/rest/cachecontrol_test.go
+++ b/rest/cachecontrol_test.go
@@ -115,3 +115,69 @@ func TestNewStack_RanksCarriesRosterFamilyCacheControl(t *testing.T) {
 	assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
 		"roster-family 200s carry the retired cache's 10-minute freshness bound (ADR 0003 parity)")
 }
+
+// HEAD rides every GET pattern (read surface), and its 200 carries the same
+// freshness signal — net/http suppresses the body, not the headers. Observed
+// through a live httptest.Server like the HEAD body-suppression pin.
+func TestNewStack_HEADCarriesCacheControl(t *testing.T) {
+	srv := httptest.NewServer(newStack(t))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL+"/api/v1/milpacs/ranks", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	res, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "max-age=600", res.Header.Get("Cache-Control"))
+}
+
+// A gzipped 200 keeps the freshness signal: the cacheControl writer sits
+// inside the gzip layer and stamps the shared header map before the first
+// body byte commits the response.
+func TestNewStack_GzippedResponseKeepsCacheControl(t *testing.T) {
+	h := newStack(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/milpacs/ranks", nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "gzip", rr.Result().Header.Get("Content-Encoding"))
+	assert.Equal(t, "max-age=600", rr.Result().Header.Get("Cache-Control"))
+}
+
+// The non-route surfaces stay unsignaled — they are not read endpoints, and
+// none of them is a 200: the clean-path 307 (answered in front of the mux),
+// the wrong-method 405, and the {ticket_id}/{sub} dispatcher's 404 for an
+// unknown sub-resource.
+func TestNewStack_NonRouteSurfacesCarryNoCacheControl(t *testing.T) {
+	h := newStack(t)
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		key        string
+		wantStatus int
+	}{
+		{"clean_path_307", http.MethodGet, "/api/v1/milpacs/position/search/A//B", "cav7_readkey", http.StatusTemporaryRedirect},
+		{"wrong_method_405", http.MethodPost, "/api/v1/milpacs/ranks", "cav7_readkey", http.StatusMethodNotAllowed},
+		{"unknown_ticket_sub_404", http.MethodGet, "/api/v1/tickets/42/bogus", "cav7_ticketskey", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+tc.key)
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.wantStatus, rr.Code)
+			assert.Empty(t, rr.Header().Get("Cache-Control"))
+		})
+	}
+}

--- a/rest/cachecontrol_test.go
+++ b/rest/cachecontrol_test.go
@@ -9,13 +9,15 @@ package rest_test
 //     parity with the retired cache's consumer-visible freshness bound: its
 //     10-minute update_time poller (cache/manager.go @ 92afba5^, ADR 0003)
 //     meant consumers already tolerated up-to-10-minute staleness there.
-//   - tickets routes: max-age=0 — the old cache was keyed by path only, so
-//     the per-user tickets surface was NEVER cached; always served live.
-//     max-age=0 is the honest signal for that (stale immediately).
+//   - tickets routes: max-age=0 — tickets are a query-variant surface the
+//     retired cache's path-only key could not cache, so its middleware
+//     bypassed the entire /api/v1/tickets prefix wholesale; tickets were
+//     NEVER cached, always served live. max-age=0 is the honest signal for
+//     that (stale immediately).
 //
 // ERROR responses carry NO Cache-Control — also parity: the retired cache
-// stored 200s only ("Non-200 response: not caching"), so errors were always
-// recomputed live on both surfaces.
+// stored 200s only ("[CACHE] Non-200 response: %d, not caching"), so errors
+// were always recomputed live on both surfaces.
 //
 // These pins are deliberately NEW-STACK-ONLY (same precedent as the 405 and
 // %2F families): the golden corpus replays against the old stack too, and
@@ -37,12 +39,47 @@ import (
 // the contract harness deliberately filters out: contract.RunCase records only
 // the contractHeaders allowlist (Cache-Control must stay OFF that list — the
 // goldens replay against the old stack, which sends none). After each request
-// *last holds the full header map of the response just served.
+// *last holds the header map AS OF COMMIT TIME — a recorder's live map keeps
+// accepting writes after commit, but a real server drops a header stamped
+// after the first body byte, so cloning the live map after ServeHTTP would
+// pass a wire-invisible late stamp. commitSnapshot is the wire-faithful
+// observer.
 func captureHeader(h http.Handler, last *http.Header) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h.ServeHTTP(w, r)
-		*last = w.Header().Clone()
+		*last = nil
+		h.ServeHTTP(&commitSnapshot{ResponseWriter: w, last: last}, r)
 	})
+}
+
+// commitSnapshot clones the header map at commit time — the first
+// WriteHeader, Write, or flush (FlushError, for symmetry with the production
+// writers) — which is exactly when a real server snapshots headers onto the
+// wire. Anything set afterwards is invisible to clients and must stay
+// invisible to the battery.
+type commitSnapshot struct {
+	http.ResponseWriter
+	last *http.Header
+}
+
+func (w *commitSnapshot) snap() {
+	if *w.last == nil {
+		*w.last = w.Header().Clone()
+	}
+}
+
+func (w *commitSnapshot) WriteHeader(code int) {
+	w.snap()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *commitSnapshot) Write(b []byte) (int, error) {
+	w.snap()
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *commitSnapshot) FlushError() error {
+	w.snap()
+	return http.NewResponseController(w.ResponseWriter).Flush()
 }
 
 // wantCacheControl is the expected freshness signal for one observed
@@ -66,7 +103,9 @@ func wantCacheControl(status int, path string) string {
 // — the 401 tiers, scope 403s, binding 400s, not-found 404s, injected-outage
 // 500s — carries NO Cache-Control at all. Because the loop derives from
 // implementedCases, a future route's battery cases are covered the moment
-// they are implemented; no second hand-maintained list.
+// they are implemented; no second hand-maintained CASE list (the group split
+// in wantCacheControl is the one hand-maintained predicate, deliberately
+// verbatim from the retired bypass).
 func TestNewStack_CacheControlAcrossBattery(t *testing.T) {
 	var last http.Header
 	h := captureHeader(newStack(t), &last)
@@ -118,20 +157,32 @@ func TestNewStack_RanksCarriesRosterFamilyCacheControl(t *testing.T) {
 
 // HEAD rides every GET pattern (read surface), and its 200 carries the same
 // freshness signal — net/http suppresses the body, not the headers. Observed
-// through a live httptest.Server like the HEAD body-suppression pin.
+// through a live httptest.Server like the HEAD body-suppression pin. One
+// witness per route group: the mechanism is route-agnostic, but the witness
+// is cheap and the groups carry different values.
 func TestNewStack_HEADCarriesCacheControl(t *testing.T) {
 	srv := httptest.NewServer(newStack(t))
 	defer srv.Close()
 
-	req, err := http.NewRequest(http.MethodHead, srv.URL+"/api/v1/milpacs/ranks", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer cav7_readkey")
-	res, err := srv.Client().Do(req)
-	require.NoError(t, err)
-	defer res.Body.Close()
+	cases := []struct {
+		name, path, key, want string
+	}{
+		{"roster_family", "/api/v1/milpacs/ranks", "cav7_readkey", "max-age=600"},
+		{"tickets", "/api/v1/tickets/categories", "cav7_ticketskey", "max-age=0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodHead, srv.URL+tc.path, nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+tc.key)
+			res, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
 
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, "max-age=600", res.Header.Get("Cache-Control"))
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			assert.Equal(t, tc.want, res.Header.Get("Cache-Control"))
+		})
+	}
 }
 
 // A gzipped 200 keeps the freshness signal: the cacheControl writer sits

--- a/rest/cachecontrol_test.go
+++ b/rest/cachecontrol_test.go
@@ -44,6 +44,9 @@ import (
 // after the first body byte, so cloning the live map after ServeHTTP would
 // pass a wire-invisible late stamp. commitSnapshot is the wire-faithful
 // observer.
+//
+// The shared *http.Header pointer makes t.Parallel a silent cross-case
+// bleed — replay loops over a captureHeader stack must stay sequential.
 func captureHeader(h http.Handler, last *http.Header) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		*last = nil
@@ -151,7 +154,7 @@ func TestNewStack_RanksCarriesRosterFamilyCacheControl(t *testing.T) {
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
+	assert.Equal(t, "max-age=600", rr.Result().Header.Get("Cache-Control"),
 		"roster-family 200s carry the retired cache's 10-minute freshness bound (ADR 0003 parity)")
 }
 

--- a/rest/cachecontrol_test.go
+++ b/rest/cachecontrol_test.go
@@ -9,11 +9,12 @@ package rest_test
 //     parity with the retired cache's consumer-visible freshness bound: its
 //     10-minute update_time poller (cache/manager.go @ 92afba5^, ADR 0003)
 //     meant consumers already tolerated up-to-10-minute staleness there.
-//   - tickets routes: max-age=0 — tickets are a query-variant surface the
-//     retired cache's path-only key could not cache, so its middleware
-//     bypassed the entire /api/v1/tickets prefix wholesale; tickets were
-//     NEVER cached, always served live. max-age=0 is the honest signal for
-//     that (stale immediately).
+//   - tickets routes: max-age=0 — the retired cache's middleware bypassed
+//     the entire /api/v1/tickets prefix wholesale (middleware/cache.go @
+//     92afba5^) — sensible, since tickets are a query-variant surface
+//     (filters, cursors) a path-only key could not have cached correctly —
+//     so tickets were NEVER cached, always served live. max-age=0 is the
+//     honest signal for that (stale immediately).
 //
 // ERROR responses carry NO Cache-Control — also parity: the retired cache
 // stored 200s only ("[CACHE] Non-200 response: %d, not caching"), so errors

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -55,11 +55,16 @@
 //     req.ParseForm() parse strictly via bindListQuery instead of
 //     r.URL.Query().
 //  3. Register in routes(): handle(mux, "GET /api/v1/...", "<scope>",
-//     handler) — the scope gate is a required argument, not a wrapping
-//     convention. Path parameters via r.PathValue. Wrong-method and unknown
-//     paths are already covered by the mux fallback (405+Allow / JSON 404).
+//     <max-age>, handler) — the scope gate and the route group's
+//     Cache-Control max-age (#131, cachecontrol.go) are required arguments,
+//     not wrapping conventions. Path parameters via r.PathValue.
+//     Wrong-method and unknown paths are already covered by the mux fallback
+//     (405+Allow / JSON 404).
 //  4. Spec operation block in openapi/openapi.yaml (CI-enforced two-way
-//     coverage, contract/spec_test.go).
+//     coverage, contract/spec_test.go) — its 200 response must declare the
+//     Cache-Control const matching the registered max-age (structural guard
+//     in contract/spec_test.go, observed-equals-declared in
+//     rest/spec_test.go).
 //  5. Goldens green: add the route's battery case names to implementedCases
 //     in rest_test.go — the replay harness does the rest.
 //  6. Classify every new case's request path in specRoutes

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -149,7 +149,7 @@ func routes(ds datastores.Datastore, rc datastores.TicketReferenceCache) *http.S
 	handle(mux, "GET /api/v1/roster/{roster}/lite", "read", maxAgeRosterFamily, getLiteRoster(ds))
 	handle(mux, "GET /api/v1/s1/uniforms/{roster}", "read", maxAgeRosterFamily, getS1UniformsRoster(ds))
 
-	// --- tickets (scope: read:tickets, max-age 0 — per-user, always live) --
+	// --- tickets (scope: read:tickets, max-age 0 — never cached, live) -----
 	// The literal /categories segment wins over {ticket_id} (mux precedence,
 	// golden-pinned by tickets/categories).
 	handle(mux, "GET /api/v1/tickets", "read:tickets", maxAgeTickets, listTickets(ds, rc))
@@ -190,16 +190,18 @@ const ticketSubPattern = "GET /api/v1/tickets/{ticket_id}/{sub}"
 // in routes() restores that). This dispatcher then narrows the wildcard
 // itself:
 //
-//   - sub == "messages" → the scope-gated messages handler (requireScope
-//     applied HERE because handle() cannot register this route — the scope
-//     gate stays explicit at the registration site);
+//   - sub == "messages" → the scope-gated, freshness-signaled messages
+//     handler (requireScope AND cacheControl applied HERE because handle()
+//     cannot register this route — the per-route wraps stay explicit at the
+//     registration site);
 //   - anything else → the JSON 404, scope-INDEPENDENT, exactly like the mux
 //     fallback for paths no route pattern matches (the old stack 404s these
 //     without consulting scopes either).
 func ticketSubResource(ds datastores.Datastore) http.Handler {
-	// requireScope AND cacheControl applied HERE because handle() cannot
-	// register this route — both per-route wraps stay explicit at the
-	// registration site.
+	// requireScope and cacheControl applied HERE because handle() cannot
+	// register this route — the two wraps stay explicit at the registration
+	// site. handle()'s third wrap, routeLabel, is absent (known pre-existing
+	// gap: messages meters under route="").
 	messages := requireScope("read:tickets", cacheControl(maxAgeTickets, listTicketMessages(ds)))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !knownTicketSub(r.PathValue("sub")) {

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -119,42 +119,44 @@ func New(ds datastores.Datastore, rc datastores.TicketReferenceCache) http.Handl
 func routes(ds datastores.Datastore, rc datastores.TicketReferenceCache) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	// --- milpacs (scope: read) -------------------------------------------
-	handle(mux, "GET /api/v1/milpacs/ranks", "read", getAllRanks(ds))
-	handle(mux, "GET /api/v1/milpacs/position/groups", "read", getPositionGroups(ds))
-	handle(mux, "GET /api/v1/milpacs/awol", "read", getAwol(ds))
+	// --- milpacs (scope: read, max-age 600) --------------------------------
+	handle(mux, "GET /api/v1/milpacs/ranks", "read", maxAgeRosterFamily, getAllRanks(ds))
+	handle(mux, "GET /api/v1/milpacs/position/groups", "read", maxAgeRosterFamily, getPositionGroups(ds))
+	handle(mux, "GET /api/v1/milpacs/awol", "read", maxAgeRosterFamily, getAwol(ds))
 	// The "..." wildcard is the legacy gateway's {position_query=**} glob:
 	// multi-segment queries and the bare trailing-slash form (empty query,
 	// handler 400) both route here.
-	handle(mux, "GET /api/v1/milpacs/position/search/{position_query...}", "read", searchByPosition(ds))
+	handle(mux, "GET /api/v1/milpacs/position/search/{position_query...}", "read", maxAgeRosterFamily, searchByPosition(ds))
 	// The slashless form, explicitly: the gateway's ** matched ZERO segments
 	// (httprule OpPushM), so the old stack answered the handler's empty-query
 	// 400 here — without this registration the mux would 307-redirect to the
 	// canonical /search/ instead, a redirect the old stack never sent.
-	handle(mux, "GET /api/v1/milpacs/position/search", "read", searchByPosition(ds))
-	handle(mux, "GET /api/v1/milpacs/profile/id/{user_id}", "read", getProfileByID(ds))
-	handle(mux, "GET /api/v1/milpacs/profile/username/{username}", "read", getProfileByUsername(ds))
+	handle(mux, "GET /api/v1/milpacs/position/search", "read", maxAgeRosterFamily, searchByPosition(ds))
+	handle(mux, "GET /api/v1/milpacs/profile/id/{user_id}", "read", maxAgeRosterFamily, getProfileByID(ds))
+	handle(mux, "GET /api/v1/milpacs/profile/username/{username}", "read", maxAgeRosterFamily, getProfileByUsername(ds))
 	// Historical path prefix: singular "milpac" on the connected-account
 	// lookups, plural "milpacs" everywhere else. Frozen by the corpus.
-	handle(mux, "GET /api/v1/milpac/discord/{discord_id}", "read", getProfileByDiscordID(ds))
-	handle(mux, "GET /api/v1/milpac/gamertag/{gamertag}", "read", getProfileByGamertag(ds))
+	handle(mux, "GET /api/v1/milpac/discord/{discord_id}", "read", maxAgeRosterFamily, getProfileByDiscordID(ds))
+	handle(mux, "GET /api/v1/milpac/gamertag/{gamertag}", "read", maxAgeRosterFamily, getProfileByGamertag(ds))
 	// Roster routes (#127): one member set, three profile shapes. {roster}
 	// binds the RosterType enum by name OR number (see types.ParseRosterType).
-	handle(mux, "GET /api/v1/roster/{roster}", "read", getRoster(ds))
-	handle(mux, "GET /api/v1/roster/{roster}/lite", "read", getLiteRoster(ds))
-	handle(mux, "GET /api/v1/s1/uniforms/{roster}", "read", getS1UniformsRoster(ds))
+	handle(mux, "GET /api/v1/roster/{roster}", "read", maxAgeRosterFamily, getRoster(ds))
+	handle(mux, "GET /api/v1/roster/{roster}/lite", "read", maxAgeRosterFamily, getLiteRoster(ds))
+	handle(mux, "GET /api/v1/s1/uniforms/{roster}", "read", maxAgeRosterFamily, getS1UniformsRoster(ds))
 
-	// --- tickets (scope: read:tickets) -----------------------------------
+	// --- tickets (scope: read:tickets, max-age 0 — per-user, always live) --
 	// The literal /categories segment wins over {ticket_id} (mux precedence,
 	// golden-pinned by tickets/categories).
-	handle(mux, "GET /api/v1/tickets", "read:tickets", listTickets(ds, rc))
-	handle(mux, "GET /api/v1/tickets/categories", "read:tickets", listCategories(ds, rc))
-	handle(mux, "GET /api/v1/tickets/{ticket_id}", "read:tickets", getTicketById(ds, rc))
-	handle(mux, "GET /api/v1/tickets/ref/{ticket_ref}", "read:tickets", getTicketByRef(ds, rc))
+	handle(mux, "GET /api/v1/tickets", "read:tickets", maxAgeTickets, listTickets(ds, rc))
+	handle(mux, "GET /api/v1/tickets/categories", "read:tickets", maxAgeTickets, listCategories(ds, rc))
+	handle(mux, "GET /api/v1/tickets/{ticket_id}", "read:tickets", maxAgeTickets, getTicketById(ds, rc))
+	handle(mux, "GET /api/v1/tickets/ref/{ticket_ref}", "read:tickets", maxAgeTickets, getTicketByRef(ds, rc))
 	// Exact pattern beats ref/{ticket_ref} in ServeMux precedence — see
 	// refMessagesParity for why this path is a frozen 400, not a by-ref
 	// lookup. Deliberately NOT scope-gated: the old 400 fired in the gateway
-	// before the RPC, so RequireScope never ran.
+	// before the RPC, so RequireScope never ran. No cacheControl wrap either:
+	// the shim answers nothing but the frozen 400, and only 200s carry the
+	// freshness signal.
 	mux.Handle("GET /api/v1/tickets/ref/messages", refMessagesParity())
 	mux.Handle(ticketSubPattern, ticketSubResource(ds))
 
@@ -190,7 +192,10 @@ const ticketSubPattern = "GET /api/v1/tickets/{ticket_id}/{sub}"
 //     fallback for paths no route pattern matches (the old stack 404s these
 //     without consulting scopes either).
 func ticketSubResource(ds datastores.Datastore) http.Handler {
-	messages := requireScope("read:tickets", listTicketMessages(ds))
+	// requireScope AND cacheControl applied HERE because handle() cannot
+	// register this route — both per-route wraps stay explicit at the
+	// registration site.
+	messages := requireScope("read:tickets", cacheControl(maxAgeTickets, listTicketMessages(ds)))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !knownTicketSub(r.PathValue("sub")) {
 			notFound(w, r)
@@ -207,16 +212,21 @@ func ticketSubResource(ds datastores.Datastore) http.Handler {
 func knownTicketSub(sub string) bool { return sub == "messages" }
 
 // handle registers one public route: a method-qualified mux pattern, the
-// route's required scope, and its handler. The scope is a required positional
-// argument — gating by wrapping convention is how a scope check gets
+// route's required scope, the route group's Cache-Control max-age (seconds —
+// see cachecontrol.go for the reviewed per-group values), and its handler.
+// Scope and max-age are required positional arguments — gating by wrapping
+// convention is how a scope check (or a route's freshness signal) gets
 // forgotten, and a forgotten check is invisible to every test that uses a
 // fully-scoped key. routeLabel wraps OUTSIDE the scope gate so even a 403
-// meters under the route it was denied on.
-func handle(mux *http.ServeMux, pattern, scope string, h http.Handler) {
+// meters under the route it was denied on; cacheControl wraps INSIDE it so
+// the freshness signal belongs to the route handler's own responses (it
+// stamps 200s only, so the order is semantics-neutral — this one just reads
+// truest).
+func handle(mux *http.ServeMux, pattern, scope string, maxAgeSeconds int, h http.Handler) {
 	if onHandle != nil {
 		onHandle(pattern)
 	}
-	mux.Handle(pattern, routeLabel(requireScope(scope, h)))
+	mux.Handle(pattern, routeLabel(requireScope(scope, cacheControl(maxAgeSeconds, h))))
 }
 
 // onHandle observes each handle() registration. Nil in production; swapped

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -191,6 +191,8 @@ func TestSentry_PanicCompletesAs500AndReportsTaggedEvent(t *testing.T) {
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.JSONEq(t, `{"code":13,"message":"Internal Server Error","details":[]}`, rr.Body.String(),
 		"the panic 500 must keep the contract error shape")
+	assert.Empty(t, rr.Header().Get("Cache-Control"),
+		"the contract 500 after a panic carries no freshness signal — the exact leak cacheControlWriter's commit-time design exists to prevent")
 
 	events := tr.Events()
 	require.Len(t, events, 1, "one panic = one event; the choke-point 5xx report must not double-report")

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -209,6 +209,74 @@ func validateObserved(t *testing.T, model *v3.Document, rv responses.ResponseBod
 	}
 }
 
+// TestNewStack_CacheControlMatchesSpecDeclaration couples the freshness
+// signal's two recording sites (#131): the per-route-group max-age constants
+// the registration table wires (rest/cachecontrol.go) and the per-operation
+// Cache-Control const the spec declares for consumers (openapi/openapi.yaml).
+// Every implemented battery case observing a 200 must carry EXACTLY the
+// value its spec operation declares — change either side alone and this goes
+// red. The closing loop is the per-endpoint completeness direction: every
+// spec operation declaring the header must be witnessed by at least one
+// observed 200, so "every read endpoint sends Cache-Control" cannot rot
+// route by route. (The spec declaration itself is structurally enforced for
+// every 2xx by contract's TestSpec_Every200DeclaresCacheControl; observation
+// happens via captureHeader because the contract harness deliberately
+// filters Cache-Control out of goldens — the corpus replays the old stack,
+// which sends none.)
+func TestNewStack_CacheControlMatchesSpecDeclaration(t *testing.T) {
+	model := loadSpecModel(t)
+	var last http.Header
+	h := captureHeader(newStack(t), &last)
+
+	declaredFor := func(tmpl string) string {
+		pathItem := model.Paths.PathItems.GetOrZero(tmpl)
+		require.NotNil(t, pathItem, "spec is missing path %s", tmpl)
+		op := pathItem.Get
+		require.NotNil(t, op, "spec path %s has no GET operation", tmpl)
+		resp := op.Responses.Codes.GetOrZero("200")
+		require.NotNil(t, resp, "spec path %s declares no 200", tmpl)
+		require.NotNil(t, resp.Headers, "spec path %s: 200 declares no headers", tmpl)
+		hdr := resp.Headers.GetOrZero("Cache-Control")
+		require.NotNil(t, hdr, "spec path %s: 200 declares no Cache-Control header", tmpl)
+		require.NotNil(t, hdr.Schema, "spec path %s: Cache-Control declares no schema", tmpl)
+		s := hdr.Schema.Schema()
+		require.NotNil(t, s, "spec path %s: Cache-Control schema does not build", tmpl)
+		require.NotNil(t, s.Const, "spec path %s: Cache-Control schema pins no const", tmpl)
+		return s.Const.Value
+	}
+
+	known := map[string]contract.Case{}
+	for _, c := range contract.Cases() {
+		known[c.Name] = c
+	}
+
+	witnessed := map[string]bool{}
+	for _, name := range implementedCases {
+		c, ok := known[name]
+		require.True(t, ok, "implementedCases entry %q names no battery case", name)
+		g, _, err := contract.RunCase(h, c)
+		require.NoError(t, err)
+		if g.Status != http.StatusOK {
+			continue // error responses carry no Cache-Control (pinned in cachecontrol_test.go)
+		}
+		base := c.Path
+		if i := strings.IndexByte(base, '?'); i >= 0 {
+			base = base[:i]
+		}
+		tmpl, ok := specRoutes[base]
+		require.True(t, ok, "path %s missing from specRoutes — classify it (recipe step 6)", base)
+		require.NotEmpty(t, tmpl, "case %s observed a 200 on an off-spec path", name)
+		assert.Equal(t, declaredFor(tmpl), last.Get("Cache-Control"),
+			"case %s: observed Cache-Control diverges from the spec's declared const for %s", name, tmpl)
+		witnessed[tmpl] = true
+	}
+
+	for pair := orderedmap.First(model.Paths.PathItems); pair != nil; pair = pair.Next() {
+		assert.True(t, witnessed[pair.Key()],
+			"spec operation GET %s: declared Cache-Control const witnessed by no observed 200 — every read endpoint must demonstrably send its freshness bound", pair.Key())
+	}
+}
+
 // TestNewStack_SpecValidation replays every implemented battery case against
 // the new stack and validates the OBSERVED response against the spec.
 func TestNewStack_SpecValidation(t *testing.T) {


### PR DESCRIPTION
Closes #131. Part of #112 (PRD: Goodbye gRPC), Phase 3.

## Max-age values per route group (the PR-time review decision, recorded)

| Route group | Value | Reasoning |
|---|---|---|
| Roster family (`read` scope: ranks, position groups/search, AWOL, profile lookups ×4, roster/lite/S1) | `max-age=600` | Parity reproduction: the retired response cache (`cache/manager.go` @ `92afba5^`, ADR 0003) polled `update_time` over its 9 monitored tables every 10 min + `FlushAll` — consumers already tolerated up-to-10-minute staleness on exactly this surface. |
| Tickets (`read:tickets` scope incl. messages) | `max-age=0` | Never cached (path-keyed cache, per-user data) — always served live; 0 is the honest "stale immediately" signal, regresses nothing. |
| Errors / non-route surfaces (4xx/5xx, 401 tiers, 405, 307, fallback 404) | no header | Also parity: the retired cache stored 200s only ("Non-200 response: not caching") — errors were always recomputed live. |

## Mechanism

- `cacheControl(maxAge, h)` per-route wrapper (`rest/cachecontrol.go`): commit-time status-conditional ResponseWriter — stamps 200s only, safe vs. `writeError` and the sentry panic-500.
- `handle()` gained a **required** `maxAge` positional arg (same can't-forget rationale as the scope arg). The `{ticket_id}/{sub}` messages dispatcher wraps explicitly; the always-400 `ref/messages` shim documentedly unwrapped.

## Golden/spec-layer assertions (all mutation-verified red)

- `TestNewStack_CacheControlAcrossBattery`: full implemented battery — 200s carry their group value, every non-200 carries none; non-vacuous (both groups must be witnessed). New-stack-only pin; `Cache-Control` deliberately kept OFF `contractHeaders` (recording it would pin its *absence* in the frozen corpus — noted in `contract/golden.go`).
- `openapi.yaml`: all 16 operations' 200s declare `Cache-Control` with `const: max-age=N` (consumer-facing record). Header declared **optional**: libopenapi-validator enforces required response headers, so `required: true` would permanently break the frozen-corpus replay — rationale pinned in the structural guard.
- `TestSpec_Every200DeclaresCacheControl` (`contract/spec_test.go`): every 2xx must declare it; errors/default/components.responses must not.
- `TestNewStack_CacheControlMatchesSpecDeclaration` (`rest/spec_test.go`): observed-equals-declared per 200 + every spec operation witnessed — code constants and spec consts cannot drift.
- Edge pins: HEAD carries it (live server), gzip keeps it, 307/405/unknown-sub-404 carry none.

## Out of scope (explicitly deferred per issue)

ETag/conditional requests; rate limiting. The update-time-polling trick is noted in the issue as the natural ETag backend for later.

## Gate

`go build` ✓ · `go vet` ✓ · `go test ./...` all packages ✓ · `go test -race` ✓ · `make test-integration` (MariaDB harness) ✓ · gofmt clean. Orchestrator independently re-ran the gate in the worktree before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)