### PR TITLE
openapi: document position-search empty-result semantics (#137 ruled expected)

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -313,10 +313,17 @@ paths:
     get:
       operationId: MilpacService_SearchByPosition
       summary: Search for profiles by position title
+      # Empty-result semantics ruled expected at #137: the matcher was
+      # verified correct against the mirror; {} is data-truthful when the
+      # phrase occurs in no current position title.
       description: >-
-        Search for profiles by position title substring (SQL LIKE '%query%'
-        against primary and secondary-capable position titles); returns lite
-        profiles. The live route is a multi-segment glob
+        Search for profiles by position title substring (SQL LIKE '%query%',
+        case-insensitive, unanchored, against primary and secondary-capable
+        position titles); returns lite profiles. An empty profiles map means
+        no current position title contains the query — terms must follow the
+        unit's own billet vocabulary (line leadership is "Section Leader" /
+        "Platoon Leader"; there is no "Squad Leader" billet, so that query
+        returns {}). The live route is a multi-segment glob
         ({position_query=**}, proto/milpacs.proto): slashes inside the query
         and the bare trailing-slash form also reach the handler — forms an
         OpenAPI path template cannot express; this document records the


### PR DESCRIPTION
## Summary

Resolves the #137 verdict question: **expected behavior, not a bug.** The spec description for `MilpacService_SearchByPosition` now states case-insensitivity and what an empty profiles map means.

## Diagnosis (mirror DB, exact query shape — join + secondary filter)

| Query | Matches |
|---|---|
| `squad leader` | 0 |
| `section leader` | 125 |
| `SECTION LEADER` | 125 |
| `platoon leader` | 22 |

The matcher (escaped substring `LIKE`, case-insensitive via collation) is correct. The org's billet vocabulary has **Section Leader / Assistant Section Leader / Platoon Leader** (357 rows); the only "Squad"-titled positions are staff roles. `{"profiles":{}}` for "squad leader" is data-truthful.

No behavior change — prose-only spec edit; `go test -count=1 ./openapi/... ./contract/...` green.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)