### PR TITLE
rest: pin cacheControlWriter.FlushError errors.Is discriminator (#172)

### DIFF
--- a/rest/cachecontrol_internal_test.go
+++ b/rest/cachecontrol_internal_test.go
@@ -1,6 +1,9 @@
 package rest
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -114,6 +117,48 @@ func TestCacheControlWriter_CommitDecision(t *testing.T) {
 		assert.Empty(t, rr.Result().Header.Get("Cache-Control"),
 			"a 404 after a failed flush must not carry the freshness signal")
 	})
+
+	// The errors.Is discriminator on the rollback above (#172; mirror of the
+	// #164 pin TestSentry_PanicAfterGenuineFlushErrorKeepsRepanicSemantics):
+	// ONLY the delegate's refusal (http.ErrNotSupported — nothing sent) may
+	// roll the stamp back. A first flush failing with a genuine I/O error is
+	// the opposite world: by then net/http has already snapshotted the headers
+	// onto the wire, so the commit — and the stamp riding it — really
+	// happened, and both must KEEP. Broadening the discriminator to any
+	// non-nil error would delete from the live map a stamp the wire already
+	// carries and reopen with committed=false a decision the wire already
+	// took. The delegate (flushErrorWriter, sentry_test.go) fails the flush
+	// with the injected error, never the refusal sentinel; the trailing 404
+	// is the handler-reacts-to-the-failed-flush move from the rollback pin
+	// above — here it must NOT reopen the commit (on a real server that 404
+	// is superfluous; the stamped implied 200 already went out).
+	errConnReset := errors.New("conn reset")
+	for _, tc := range []struct {
+		name     string
+		flushErr error // what the delegate's FlushError returns
+		want     error // the sentinel that must surface through the chain
+	}{
+		{name: "genuine flush error keeps the stamp (plain)", flushErr: errConnReset, want: errConnReset},
+		{name: "genuine flush error keeps the stamp (wrapped)", flushErr: fmt.Errorf("flush tcp conn: %w", io.ErrClosedPipe), want: io.ErrClosedPipe},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			w := &cacheControlWriter{ResponseWriter: &flushErrorWriter{rr: rr, err: tc.flushErr}, value: "max-age=600"}
+
+			err := http.NewResponseController(w).Flush()
+			require.ErrorIs(t, err, tc.want,
+				"the delegate's genuine flush error must surface to the caller")
+			require.NotErrorIs(t, err, http.ErrNotSupported,
+				"premise: a real flush failure, not the delegate's refusal")
+
+			assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
+				"a genuinely failed flush really committed — the stamp must keep")
+
+			w.WriteHeader(http.StatusNotFound)
+			assert.Equal(t, "max-age=600", rr.Result().Header.Get("Cache-Control"),
+				"the commit decision stays latched — a later error status cannot reopen it")
+		})
+	}
 }
 
 // noFlushWriter hides the recorder's Flusher — the shape gzipResponseWriter

--- a/rest/cachecontrol_internal_test.go
+++ b/rest/cachecontrol_internal_test.go
@@ -21,7 +21,11 @@ import (
 // at WriteHeader (a flush implies one), so a stamp set after delegating
 // would be wire-invisible and must fail here. Stamp-ABSENCE assertions read
 // the live rr.Header() map, the stronger check there: not even a
-// post-snapshot late stamp is tolerated.
+// post-snapshot late stamp is tolerated. Exception (#172 battery): when the
+// delegate intercepts the flush without committing to the recorder (no
+// WriteHeader reached it), there is no snapshot yet — the live map is the
+// only valid pre-404 observation. rr.Result() also memoizes, so calling it
+// early would blind a later snapshot read to the cached pre-404 state.
 func TestCacheControlWriter_CommitDecision(t *testing.T) {
 	wrap := func() (*cacheControlWriter, *httptest.ResponseRecorder) {
 		rr := httptest.NewRecorder()
@@ -151,6 +155,11 @@ func TestCacheControlWriter_CommitDecision(t *testing.T) {
 			require.NotErrorIs(t, err, http.ErrNotSupported,
 				"premise: a real flush failure, not the delegate's refusal")
 
+			// LIVE map here (not the Result snapshot): flushErrorWriter
+			// intercepts the flush before any WriteHeader reaches the recorder,
+			// so no snapshot exists yet — and rr.Result() memoizes, so reading
+			// it now would blind the post-404 snapshot check below to the
+			// cached pre-404 state, making the cannot-reopen pin vacuous.
 			assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"),
 				"a genuinely failed flush really committed — the stamp must keep")
 


### PR DESCRIPTION
Closes #172.

Test-only pin closing a surviving mutant in `cacheControlWriter.FlushError`: the stamp-rollback discriminator `errors.Is(err, http.ErrNotSupported)` had no test witnessing the genuine-error direction — broadening it to `err != nil` passed the whole suite. Two new subtests assert a genuine (plain and wrapped) flush error KEEPS the Cache-Control stamp and the commit latch holds against a later WriteHeader. Mirrors the #164 sentry pin, reuses its `flushErrorWriter` fake.

Second commit annotates the live-map observation exception (a delegate-intercepted flush reaches no recorder WriteHeader, so the live map is the only valid pre-404 read — `rr.Result()` would memoize and blind the latch check).

Reviewed (code/test/comment agents) + mutation-verified: the `err != nil` broadening dies at both assertion sites. Gate green (`build`/`vet`/`test`/`-race`).

Follow-up #178 filed for two adjacent unwitnessed mutants in the same rollback block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)