### PR TITLE
rest: handleRaw + route="" sweep — mechanical never-routed guard (#173)

### DIFF
--- a/rest/export_test.go
+++ b/rest/export_test.go
@@ -7,17 +7,16 @@ import (
 )
 
 // RoutesForTest builds the bare route mux (no middleware) and returns it
-// together with every pattern registered through handle() — the scope-gated
-// registration table. The scope-loop completeness guard (#128 round 3,
-// ruling 2; positions_test.go) derives its expected route set from this table
-// and probes the mux for what its path list actually witnesses, so the guard
-// cannot rot into a second hand-maintained list.
-//
-// Deliberately ABSENT from the table: the direct mux.Handle registrations —
-// the refMessagesParity shim (scope-independent by ruling), the
-// {ticket_id}/{sub} dispatcher (scope gate applied inside, see
-// ticketSubResource) and the catch-all. They are not handle()-gated and carry
-// their own pinned coverage.
+// together with the COMPLETE registration table: every pattern registered
+// through handle() AND the direct handleRaw registrations handle() cannot
+// express — the refMessagesParity shim, the {ticket_id}/{sub} dispatcher,
+// the catch-all (#173; before that the table deliberately excluded them, so
+// the completeness machinery never saw a direct registration). Guards derive
+// their expected route sets from this table instead of a second
+// hand-maintained list that could rot alongside the first: the scope-loop
+// completeness guard (#128 round 3, ruling 2; positions_test.go) filters it
+// to the position/awol family, and the route="" sweep (#173;
+// metrics_test.go) drives traffic at every pattern in it.
 func RoutesForTest(ds datastores.Datastore, rc datastores.TicketReferenceCache) (*http.ServeMux, []string) {
 	var patterns []string
 	onHandle = func(pattern string) { patterns = append(patterns, pattern) }

--- a/rest/informational_internal_test.go
+++ b/rest/informational_internal_test.go
@@ -54,9 +54,13 @@ func TestWriterWrappers_Informational1xxDoesNotLatch(t *testing.T) {
 	// Event accessor the sentry row shares between build and assert.
 	var sentryEvents func() []*sentry.Event
 	meter := func(status string) float64 {
-		// Route is "" (no routeLabel in this chain), method clamps to GET,
-		// no key validated — the deferred recording's exact label set.
-		return testutil.ToFloat64(requestsTotal.WithLabelValues("", http.MethodGet, status, ""))
+		// Route is the probe's route-labeled pattern (mounted like every
+		// registration in the assembled stack — an unlabeled probe would
+		// violate the registry's never-routed contract, route="" ⇒ auth tiers
+		// or pre-routing panic, swept post-run by TestMain, #173), method
+		// clamps to GET, no key validated — the deferred recording's exact
+		// label set.
+		return testutil.ToFloat64(requestsTotal.WithLabelValues("GET /", http.MethodGet, status, ""))
 	}
 
 	cases := []struct {
@@ -73,7 +77,9 @@ func TestWriterWrappers_Informational1xxDoesNotLatch(t *testing.T) {
 			build: func(t *testing.T, next http.Handler) http.Handler {
 				meter200Before = meter("200")
 				meter103Before = meter("103")
-				return metricsMiddleware(next)
+				mux := http.NewServeMux()
+				mux.Handle("GET /", routeLabel(next))
+				return metricsMiddleware(mux)
 			},
 			finish: func(w http.ResponseWriter) {
 				w.WriteHeader(http.StatusOK)
@@ -195,7 +201,8 @@ func TestWriterWrappers_101Latches(t *testing.T) {
 	var meter101Before, meter500Before float64
 	var sentryEvents func() []*sentry.Event
 	meter := func(status string) float64 {
-		return testutil.ToFloat64(requestsTotal.WithLabelValues("", http.MethodGet, status, ""))
+		// Route-labeled probe, same rationale as the table above (#173).
+		return testutil.ToFloat64(requestsTotal.WithLabelValues("GET /", http.MethodGet, status, ""))
 	}
 
 	cases := []struct {
@@ -230,7 +237,9 @@ func TestWriterWrappers_101Latches(t *testing.T) {
 			build: func(t *testing.T, next http.Handler) http.Handler {
 				meter101Before = meter("101")
 				meter500Before = meter("500")
-				return metricsMiddleware(next)
+				mux := http.NewServeMux()
+				mux.Handle("GET /", routeLabel(next))
+				return metricsMiddleware(mux)
 			},
 			finish: func(_ *testing.T, w http.ResponseWriter) {
 				panic("exploded after the 101")

--- a/rest/metrics.go
+++ b/rest/metrics.go
@@ -105,7 +105,7 @@ type metricLabels struct {
 	// route is the matched mux pattern, e.g. "GET /api/v1/milpacs/ranks".
 	// "" means exactly one thing: the request never reached routing (the
 	// auth 401/503 tiers, or a pre-routing panic) — EVERY registration fills
-	// the slot, including the direct mux.Handle ones outside handle() (#166).
+	// the slot: handleRaw applies routeLabel structurally (#166, #173).
 	route string
 	keyID string // decimal key id, e.g. "101"; "" if no key validated
 }

--- a/rest/metrics_internal_test.go
+++ b/rest/metrics_internal_test.go
@@ -17,9 +17,15 @@ import (
 // mask the gap).
 func TestStatusWriter_ResponseControllerTunnelsThroughMetrics(t *testing.T) {
 	flushErr := make(chan error, 1) // handler runs on the server goroutine
-	h := metricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// The probe mounts route-labeled, like every registration in the
+	// assembled stack: the process-global registry's never-routed contract
+	// (route="" ⇒ the auth tiers or a pre-routing panic, #173) is swept
+	// post-run by TestMain, and an unlabeled probe would mint route="" 200.
+	mux := http.NewServeMux()
+	mux.Handle("GET /", routeLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		flushErr <- http.NewResponseController(w).Flush()
-	}))
+	})))
+	h := metricsMiddleware(mux)
 
 	srv := httptest.NewServer(h)
 	defer srv.Close()

--- a/rest/metrics_test.go
+++ b/rest/metrics_test.go
@@ -1,9 +1,13 @@
 package rest_test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
 	"sync"
 	"testing"
 
@@ -23,18 +27,30 @@ import (
 func scrapeMetrics(t *testing.T) map[string]*dto.MetricFamily {
 	t.Helper()
 
+	families, err := gatherFamilies()
+	require.NoError(t, err, "exposition must scrape and parse as Prometheus text format")
+	return families
+}
+
+// gatherFamilies is scrapeMetrics without the *testing.T: one real scrape of
+// the internal-only mount, parsed into families. Separate so the post-run
+// route="" sweep in TestMain — which has no *testing.T — shares the exact
+// same wire-faithful observation path.
+func gatherFamilies() (map[string]*dto.MetricFamily, error) {
 	srv := httptest.NewServer(rest.MetricsHandler())
 	defer srv.Close()
 
 	res, err := srv.Client().Get(srv.URL + "/metrics")
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	defer res.Body.Close()
-	require.Equal(t, http.StatusOK, res.StatusCode)
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("metrics scrape: status %d", res.StatusCode)
+	}
 
 	parser := expfmt.NewTextParser(model.LegacyValidation)
-	families, err := parser.TextToMetricFamilies(res.Body)
-	require.NoError(t, err, "exposition must parse as Prometheus text format")
-	return families
+	return parser.TextToMetricFamilies(res.Body)
 }
 
 // counterValue returns the current value of the named counter child whose
@@ -649,6 +665,150 @@ func TestMetrics_BearerMaterialAbsentFromExposition(t *testing.T) {
 		"bearer material leaked into the exposition — key_id is the only permitted key-derived value")
 	assert.Contains(t, string(raw), `key_id="101"`,
 		"the validated key id (not the token) is how consumers are attributed")
+}
+
+// muxWildcard matches one mux pattern wildcard — "{name}" or "{name...}".
+var muxWildcard = regexp.MustCompile(`\{[^}]+\}`)
+
+// pathForPattern synthesizes a concrete request path from a registration
+// pattern: drop the method qualifier, substitute "x" for every wildcard. The
+// response tier does not matter to the sweep (a 400/404 routed exactly like a
+// 200 — it meters under the matched pattern either way); what matters is that
+// every registered pattern sees authenticated traffic.
+func pathForPattern(pattern string) string {
+	p := pattern
+	if _, after, ok := strings.Cut(p, " "); ok {
+		p = after
+	}
+	return muxWildcard.ReplaceAllString(p, "x")
+}
+
+// emptyRouteWithValidatedKeyChildren returns every request-counter child that
+// pairs route="" with a non-empty key_id — the combination the exposition
+// must never contain: route="" means the request never reached routing, but a
+// validated key means auth passed, and routing follows auth.
+func emptyRouteWithValidatedKeyChildren(families map[string]*dto.MetricFamily) []string {
+	mf, ok := families["api_http_requests_total"]
+	if !ok {
+		return nil
+	}
+	var violations []string
+	for _, m := range mf.GetMetric() {
+		var route, keyID string
+		for _, lp := range m.GetLabel() {
+			switch lp.GetName() {
+			case "route":
+				route = lp.GetValue()
+			case "key_id":
+				keyID = lp.GetValue()
+			}
+		}
+		if route == "" && keyID != "" {
+			violations = append(violations, m.String())
+		}
+	}
+	return violations
+}
+
+// The route="" ⇔ never-routed sweep (#173, ruling: option 1). #166 pinned the
+// direct registrations point-wise; this guard is mechanical: drive
+// authenticated traffic at a synthesized path for EVERY pattern in the real
+// registration table (handle() and handleRaw registrations alike — zero
+// per-route bookkeeping, the derive-from-reality philosophy of the scope-loop
+// guard, #128 ruling 2), then assert no exposition child pairs route="" with
+// a non-empty key_id. A registration missing its routeLabel wrap — a bare
+// mux.Handle, or routeLabel dropped from the helpers — meters its
+// authenticated traffic under route="" and goes red here. TestMain re-runs
+// the same assertion AFTER the whole package, so a registration that bypasses
+// the table too is caught the moment any test drives its traffic.
+func TestMetrics_SweepNoChildPairsEmptyRouteWithValidatedKey(t *testing.T) {
+	// One key with every scope, so the sweep reaches past each scope gate
+	// into the handlers (a 403 would still meter under its route — this just
+	// exercises more of each chain).
+	ds := &fakeDatastore{validateApiKey: func(string) (*datastores.ApiKeyResult, error) {
+		return &datastores.ApiKeyResult{
+			KeyId:  104,
+			UserId: 3,
+			Scopes: map[string]struct{}{"read": {}, "read:tickets": {}},
+		}, nil
+	}}
+	h := rest.New(ds, &stubReferenceCache{})
+
+	_, patterns := rest.RoutesForTest(ds, &stubReferenceCache{})
+	// Non-vacuousness: the catch-all proves the direct registrations feed the
+	// table — without them this sweep would silently cover only the
+	// handle()-gated routes.
+	require.Contains(t, patterns, "/",
+		"registration table is missing the direct registrations — the sweep cannot witness them")
+
+	for _, pattern := range patterns {
+		do(h, http.MethodGet, pathForPattern(pattern), "cav7_sweepkey")
+	}
+
+	families := scrapeMetrics(t)
+
+	assert.Empty(t, emptyRouteWithValidatedKeyChildren(families),
+		`exposition child pairs route="" with a validated key — a registration is missing its routeLabel wrap (bare mux.Handle instead of handleRaw?)`)
+
+	// Non-vacuousness: the sweep's own traffic must have metered under a
+	// route label (the "/" registration's synthesized path is the
+	// authenticated 404) — otherwise a rotted driver passes the sweep with
+	// zero witnesses.
+	assert.GreaterOrEqual(t,
+		counterValue(t, families, "api_http_requests_total",
+			map[string]string{"route": "/", "method": "GET", "status": "404", "key_id": "104"}),
+		1.0, "sweep traffic never metered under its route label — the driver (or routeLabel itself) rotted")
+}
+
+// TestMain re-asserts the sweep's invariant AFTER every test in the package
+// has run, over the same process-global exposition. This is the
+// order-guaranteed half of the #173 guard: a future direct mux.Handle that
+// bypasses handleRaw never enters the registration table, so the sweep test
+// cannot drive its traffic — but the new route's own tests will, and their
+// authenticated requests meter under route="" the moment routeLabel is
+// missing. Running after m.Run() sees that traffic no matter where in the
+// package those tests live.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if code == 0 {
+		if err := sweepExpositionForEmptyRouteWithValidatedKey(); err != nil {
+			fmt.Fprintf(os.Stderr, "post-run route=\"\" sweep (#173): %v\n", err)
+			code = 1
+		}
+	}
+	os.Exit(code)
+}
+
+func sweepExpositionForEmptyRouteWithValidatedKey() error {
+	families, err := gatherFamilies()
+	if err != nil {
+		return fmt.Errorf("scraping exposition: %w", err)
+	}
+	if v := emptyRouteWithValidatedKeyChildren(families); len(v) > 0 {
+		return fmt.Errorf(`exposition children pair route="" with a validated key — a registration is missing its routeLabel wrap (bare mux.Handle instead of handleRaw?): %s`,
+			strings.Join(v, "; "))
+	}
+	return nil
+}
+
+// The registration-completeness seam sees EVERY registration (#173): the
+// direct registrations handle() cannot express — the ref/messages parity
+// shim, the {ticket_id}/{sub} dispatcher, and the catch-all — flow through
+// the same table as the scope-gated routes. Before #173 the table
+// deliberately excluded them, so a future direct registration added without
+// routeLabel was invisible to every guard that derives its expectations from
+// the table (the route="" sweep below included).
+func TestRoutesForTest_TableIncludesDirectRegistrations(t *testing.T) {
+	_, patterns := rest.RoutesForTest(&fakeDatastore{}, &stubReferenceCache{})
+
+	for _, direct := range []string{
+		"GET /api/v1/tickets/ref/messages",
+		"GET /api/v1/tickets/{ticket_id}/{sub}",
+		"/",
+	} {
+		assert.Contains(t, patterns, direct,
+			"direct registration %q missing from the registration table — register it through handleRaw, not bare mux.Handle", direct)
+	}
 }
 
 // The exposition is served on its OWN listener only (#130: a port the

--- a/rest/metrics_test.go
+++ b/rest/metrics_test.go
@@ -465,12 +465,12 @@ func TestMetrics_TicketUnknownSub404MetersUnderSubResourcePattern(t *testing.T) 
 	assert.Equal(t, before+1, after, "unknown-sub 404s must meter under the sub-resource registration pattern")
 }
 
-// The other direct mux.Handle registration #166 wrapped — the scope-independent
-// /tickets/ref/messages parity shim — is route-labeled too: its frozen 400
-// meters under its literal pattern (a bounded label), never route="". With
-// both #166 registrations wrapped (the catch-all was already labeled),
-// route="" means exactly one thing across the whole table: the request never
-// reached routing.
+// The other direct mux.Handle registration #166 wrapped (since #173 a
+// handleRaw call site) — the scope-independent /tickets/ref/messages parity
+// shim — is route-labeled too: its frozen 400 meters under its literal
+// pattern (a bounded label), never route="". With both #166 registrations
+// wrapped (the catch-all was already labeled), route="" means exactly one
+// thing across the whole table: the request never reached routing.
 func TestMetrics_TicketsRefMessagesFrozen400MetersUnderItsPattern(t *testing.T) {
 	h := newStack(t)
 	labels := map[string]string{
@@ -710,17 +710,55 @@ func emptyRouteWithValidatedKeyChildren(families map[string]*dto.MetricFamily) [
 	return violations
 }
 
-// The route="" ⇔ never-routed sweep (#173, ruling: option 1). #166 pinned the
-// direct registrations point-wise; this guard is mechanical: drive
-// authenticated traffic at a synthesized path for EVERY pattern in the real
-// registration table (handle() and handleRaw registrations alike — zero
-// per-route bookkeeping, the derive-from-reality philosophy of the scope-loop
-// guard, #128 ruling 2), then assert no exposition child pairs route="" with
-// a non-empty key_id. A registration missing its routeLabel wrap — a bare
-// mux.Handle, or routeLabel dropped from the helpers — meters its
-// authenticated traffic under route="" and goes red here. TestMain re-runs
-// the same assertion AFTER the whole package, so a registration that bypasses
-// the table too is caught the moment any test drives its traffic.
+// neverRoutedStatusViolations returns every request-counter child whose
+// route="" status falls outside the enumerated never-routed outcomes: the
+// auth 401/503 tiers and the pre-routing-panic 500 (the counter help text's
+// exhaustive list). The pair-predicate above cannot see an UNAUTHENTICATED
+// unlabeled mount — key_id stays empty, exactly the #134 docs-UI shape
+// (handlers mounted outside auth) — but this derived contract can: such a
+// mount's 200s mint route="" with a status no never-routed request produces.
+func neverRoutedStatusViolations(families map[string]*dto.MetricFamily) []string {
+	mf, ok := families["api_http_requests_total"]
+	if !ok {
+		return nil
+	}
+	allowed := map[string]bool{"401": true, "500": true, "503": true}
+	var violations []string
+	for _, m := range mf.GetMetric() {
+		var route, status string
+		for _, lp := range m.GetLabel() {
+			switch lp.GetName() {
+			case "route":
+				route = lp.GetValue()
+			case "status":
+				status = lp.GetValue()
+			}
+		}
+		if route == "" && !allowed[status] {
+			violations = append(violations, m.String())
+		}
+	}
+	return violations
+}
+
+// The route="" ⇔ never-routed sweep (#173, ruling: do both — this sweep is
+// the option-1 half; handleRaw is option 2). #166 pinned the direct
+// registrations point-wise; this guard is mechanical: drive authenticated
+// traffic at a synthesized path for EVERY pattern in the real registration
+// table (handle() and handleRaw registrations alike — zero per-route
+// bookkeeping, the derive-from-reality philosophy of the scope-loop guard,
+// #128 ruling 2), then assert the never-routed contract over the exposition:
+// no child pairs route="" with a non-empty key_id, and every route="" child
+// carries a status the never-routed tiers can actually produce (401/503 from
+// auth, 500 from a pre-routing panic — the counter help text's enumerated
+// outcomes). routeLabel dropped from the helpers meters the sweep's own
+// authenticated traffic under route="" and goes red here; a bare mux.Handle
+// never enters the registration table, so this sweep cannot drive its
+// traffic — that escape belongs to the TestMain half below, the status
+// predicate, and the source-scan guard (TestMuxHandle_OnlyCallSiteIsHandleRaw).
+// TestMain re-runs the same assertions AFTER the whole package, so a
+// registration that bypasses the table too is caught the moment any test
+// drives its traffic.
 func TestMetrics_SweepNoChildPairsEmptyRouteWithValidatedKey(t *testing.T) {
 	// One key with every scope, so the sweep reaches past each scope gate
 	// into the handlers (a 403 would still meter under its route — this just
@@ -750,6 +788,9 @@ func TestMetrics_SweepNoChildPairsEmptyRouteWithValidatedKey(t *testing.T) {
 	assert.Empty(t, emptyRouteWithValidatedKeyChildren(families),
 		`exposition child pairs route="" with a validated key — a registration is missing its routeLabel wrap (bare mux.Handle instead of handleRaw?)`)
 
+	assert.Empty(t, neverRoutedStatusViolations(families),
+		`exposition child pairs route="" with a status outside the never-routed set {401, 500, 503} — an unlabeled mount is serving traffic outside routing (a handler mounted outside auth, the #134 docs-UI shape?)`)
+
 	// Non-vacuousness: the sweep's own traffic must have metered under a
 	// route label (the "/" registration's synthesized path is the
 	// authenticated 404) — otherwise a rotted driver passes the sweep with
@@ -760,18 +801,21 @@ func TestMetrics_SweepNoChildPairsEmptyRouteWithValidatedKey(t *testing.T) {
 		1.0, "sweep traffic never metered under its route label — the driver (or routeLabel itself) rotted")
 }
 
-// TestMain re-asserts the sweep's invariant AFTER every test in the package
+// TestMain re-asserts the sweep's invariants AFTER every test in the package
 // has run, over the same process-global exposition. This is the
 // order-guaranteed half of the #173 guard: a future direct mux.Handle that
 // bypasses handleRaw never enters the registration table, so the sweep test
 // cannot drive its traffic — but the new route's own tests will, and their
 // authenticated requests meter under route="" the moment routeLabel is
 // missing. Running after m.Run() sees that traffic no matter where in the
-// package those tests live.
+// package those tests live. Reach limit: this sweep sees ONE test binary's
+// traffic — #134's cutover package is a second binary whose requests never
+// touch this process's exposition, so the cutover slice must re-assert the
+// contract there (or this package exports the sweep helper then).
 func TestMain(m *testing.M) {
 	code := m.Run()
 	if code == 0 {
-		if err := sweepExpositionForEmptyRouteWithValidatedKey(); err != nil {
+		if err := sweepExpositionForNeverRoutedContract(); err != nil {
 			fmt.Fprintf(os.Stderr, "post-run route=\"\" sweep (#173): %v\n", err)
 			code = 1
 		}
@@ -779,13 +823,17 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func sweepExpositionForEmptyRouteWithValidatedKey() error {
+func sweepExpositionForNeverRoutedContract() error {
 	families, err := gatherFamilies()
 	if err != nil {
 		return fmt.Errorf("scraping exposition: %w", err)
 	}
 	if v := emptyRouteWithValidatedKeyChildren(families); len(v) > 0 {
 		return fmt.Errorf(`exposition children pair route="" with a validated key — a registration is missing its routeLabel wrap (bare mux.Handle instead of handleRaw?): %s`,
+			strings.Join(v, "; "))
+	}
+	if v := neverRoutedStatusViolations(families); len(v) > 0 {
+		return fmt.Errorf(`exposition children pair route="" with a status outside the never-routed set {401, 500, 503} — an unlabeled mount is serving traffic outside routing (a handler mounted outside auth, the #134 docs-UI shape?): %s`,
 			strings.Join(v, "; "))
 	}
 	return nil
@@ -797,7 +845,7 @@ func sweepExpositionForEmptyRouteWithValidatedKey() error {
 // the same table as the scope-gated routes. Before #173 the table
 // deliberately excluded them, so a future direct registration added without
 // routeLabel was invisible to every guard that derives its expectations from
-// the table (the route="" sweep below included).
+// the table (the route="" sweep in this file included).
 func TestRoutesForTest_TableIncludesDirectRegistrations(t *testing.T) {
 	_, patterns := rest.RoutesForTest(&fakeDatastore{}, &stubReferenceCache{})
 
@@ -809,6 +857,54 @@ func TestRoutesForTest_TableIncludesDirectRegistrations(t *testing.T) {
 		assert.Contains(t, patterns, direct,
 			"direct registration %q missing from the registration table — register it through handleRaw, not bare mux.Handle", direct)
 	}
+}
+
+// handleRaw's "ONLY way a handler reaches the mux" claim, mechanically
+// enforced (#173). The dynamic guards have a demonstrated escape: a bare
+// mux.Handle on a route with no tests driving authenticated traffic passes
+// the entire suite — it never enters the registration table (invisible to the
+// sweep), and with no traffic the TestMain re-assertion sees nothing either.
+// Close it at the source level: the rest package's non-test sources must
+// contain exactly one mux.Handle call — the one inside handleRaw (rest.go).
+// mux.Handler (the fallback's 405 probe) is a lookup, not a registration, and
+// does not match the scanned token.
+func TestMuxHandle_OnlyCallSiteIsHandleRaw(t *testing.T) {
+	entries, err := os.ReadDir(".") // the test binary runs in the package dir
+	require.NoError(t, err)
+
+	var hits []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		require.NoError(t, err)
+		for i, line := range strings.Split(string(src), "\n") {
+			if strings.Contains(line, "mux.Handle(") {
+				hits = append(hits, fmt.Sprintf("%s:%d: %s", name, i+1, strings.TrimSpace(line)))
+			}
+		}
+	}
+
+	require.Len(t, hits, 1,
+		"exactly one mux.Handle call site is allowed in the rest package — handleRaw's. Register routes through handle()/handleRaw, never bare mux.Handle. Found: %s",
+		strings.Join(hits, "; "))
+	assert.True(t, strings.HasPrefix(hits[0], "rest.go:"),
+		"the single mux.Handle call site moved out of rest.go: %s", hits[0])
+
+	// The one call must sit inside handleRaw itself — the function whose doc
+	// claims to be the only path to the mux.
+	src, err := os.ReadFile("rest.go")
+	require.NoError(t, err)
+	fnStart := strings.Index(string(src), "\nfunc handleRaw(")
+	require.GreaterOrEqual(t, fnStart, 0, "func handleRaw not found in rest.go")
+	body := string(src)[fnStart+1:]
+	if end := strings.Index(body, "\nfunc "); end >= 0 {
+		body = body[:end]
+	}
+	assert.Contains(t, body, "mux.Handle(",
+		"the single mux.Handle call site is not inside handleRaw")
 }
 
 // The exposition is served on its OWN listener only (#130: a port the

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -161,18 +161,19 @@ func routes(ds datastores.Datastore, rc datastores.TicketReferenceCache) *http.S
 	// lookup. Deliberately NOT scope-gated: the old 400 fired in the gateway
 	// before the RPC, so RequireScope never ran. No cacheControl wrap either:
 	// the shim answers nothing but the frozen 400, and only 200s carry the
-	// freshness signal. routeLabel DOES wrap it: the frozen 400 routed, so it
-	// meters under this literal pattern, never route="" (#166).
-	mux.Handle("GET /api/v1/tickets/ref/messages", routeLabel(refMessagesParity()))
-	// routeLabel OUTSIDE the dispatcher, mirroring handle()'s wrap order:
-	// everything the {ticket_id}/{sub} registration answers — the messages
-	// 200s, the scope 403s, the unknown-sub 404s — meters under its pattern.
-	mux.Handle(ticketSubPattern, routeLabel(ticketSubResource(ds)))
+	// freshness signal. handleRaw applies routeLabel: the frozen 400 routed,
+	// so it meters under this literal pattern, never route="" (#166).
+	handleRaw(mux, "GET /api/v1/tickets/ref/messages", refMessagesParity())
+	// handleRaw puts routeLabel OUTSIDE the dispatcher, mirroring handle()'s
+	// wrap order: everything the {ticket_id}/{sub} registration answers — the
+	// messages 200s, the scope 403s, the unknown-sub 404s — meters under its
+	// pattern.
+	handleRaw(mux, ticketSubPattern, ticketSubResource(ds))
 
 	// The catch-all is route-labeled like every registered pattern: 404s and
 	// 405s meter under its "/" pattern — bounded, and distinct from "" (a
 	// request that never reached routing).
-	mux.Handle("/", routeLabel(fallback(mux)))
+	handleRaw(mux, "/", fallback(mux))
 
 	return mux
 }
@@ -196,8 +197,9 @@ const ticketSubPattern = "GET /api/v1/tickets/{ticket_id}/{sub}"
 //
 //   - sub == "messages" → the scope-gated, freshness-signaled messages
 //     handler (requireScope AND cacheControl applied HERE because handle()
-//     cannot register this route — the per-route wraps stay explicit at the
-//     registration site);
+//     cannot register this route — those two wraps stay explicit at the
+//     registration site; the third per-route wrap, routeLabel, comes from
+//     handleRaw at the registration in routes(), same as every route);
 //   - anything else → the JSON 404, scope-INDEPENDENT, exactly like the mux
 //     fallback for paths no route pattern matches (the old stack 404s these
 //     without consulting scopes either).
@@ -205,8 +207,8 @@ func ticketSubResource(ds datastores.Datastore) http.Handler {
 	// requireScope and cacheControl applied HERE because handle() cannot
 	// register this route — the two wraps stay explicit at the registration
 	// site. handle()'s third wrap, routeLabel, wraps this dispatcher at its
-	// mux.Handle call in routes() — OUTSIDE the scope gate, the same order
-	// handle() applies, so even a 403 meters under this route (#166).
+	// handleRaw registration in routes() — OUTSIDE the scope gate, the same
+	// order handle() applies, so even a 403 meters under this route (#166).
 	messages := requireScope("read:tickets", cacheControl(maxAgeTickets, listTicketMessages(ds)))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !knownTicketSub(r.PathValue("sub")) {
@@ -235,17 +237,41 @@ func knownTicketSub(sub string) bool { return sub == "messages" }
 // stamps 200s only, so the order is semantics-neutral — this one just reads
 // truest).
 func handle(mux *http.ServeMux, pattern, scope string, maxAgeSeconds int, h http.Handler) {
+	handleRaw(mux, pattern, requireScope(scope, cacheControl(maxAgeSeconds, h)))
+}
+
+// handleRaw is the ONLY way a handler reaches the mux — handle() funnels
+// through it, and the registrations handle() cannot express (the ref/messages
+// parity shim, the {ticket_id}/{sub} dispatcher, the catch-all) call it
+// directly. It carries the two invariants EVERY registration must carry,
+// scope-gated or not:
+//
+//   - routeLabel, so route="" keeps meaning exactly one thing — the request
+//     never reached routing (#166). A bare mux.Handle would regress that
+//     silently: traffic meters under the empty label and no test that uses a
+//     labeled route child notices.
+//   - the onHandle feed, so the registration table the completeness guards
+//     derive from (RoutesForTest) sees every registration — including the
+//     route="" sweep in metrics_test.go, which drives traffic at every table
+//     pattern (#173).
+//
+// Adding a route? Use handle(). Only a route whose scope gate cannot be
+// expressed as one requireScope wrap belongs here — and then the per-route
+// wraps it skips (scope, cache-control) must be applied explicitly inside the
+// handler, the way ticketSubResource does.
+func handleRaw(mux *http.ServeMux, pattern string, h http.Handler) {
 	if onHandle != nil {
 		onHandle(pattern)
 	}
-	mux.Handle(pattern, routeLabel(requireScope(scope, cacheControl(maxAgeSeconds, h))))
+	mux.Handle(pattern, routeLabel(h))
 }
 
-// onHandle observes each handle() registration. Nil in production; swapped
-// only by tests (RoutesForTest, export_test.go) so registration-completeness
-// guards — e.g. the scope-403 loop coverage guard (#128 round 3, ruling 2) —
-// derive their expected route sets from the REAL registration table instead
-// of a second hand-maintained list that could rot alongside the first.
+// onHandle observes each registration (every handle() and handleRaw call).
+// Nil in production; swapped only by tests (RoutesForTest, export_test.go) so
+// registration-completeness guards — e.g. the scope-403 loop coverage guard
+// (#128 round 3, ruling 2) and the route="" sweep (#173) — derive their
+// expected route sets from the REAL registration table instead of a second
+// hand-maintained list that could rot alongside the first.
 var onHandle func(pattern string)
 
 // fallback serves every request no route pattern matched, splitting two

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -117,10 +117,12 @@ func New(ds datastores.Datastore, rc datastores.TicketReferenceCache) http.Handl
 							routes(ds, rc)))))))
 }
 
-// routes builds the pattern-routing mux: one handle call per public route,
-// each gated on its scope. Everything no route pattern matches falls through
-// to fallback (the JSON 404, or the 405+Allow for a known path under an
-// unsupported method).
+// routes builds the pattern-routing mux. Every route registers through
+// handle() — scope-gated, cache-controlled — except the three handleRaw call
+// sites: the ref/messages parity shim and the catch-all (ungated by ruling)
+// and the {ticket_id}/{sub} dispatcher (gates inside itself). Everything no
+// route pattern matches falls through to fallback (the JSON 404, or the
+// 405+Allow for a known path under an unsupported method).
 func routes(ds datastores.Datastore, rc datastores.TicketReferenceCache) *http.ServeMux {
 	mux := http.NewServeMux()
 
@@ -206,9 +208,9 @@ const ticketSubPattern = "GET /api/v1/tickets/{ticket_id}/{sub}"
 func ticketSubResource(ds datastores.Datastore) http.Handler {
 	// requireScope and cacheControl applied HERE because handle() cannot
 	// register this route — the two wraps stay explicit at the registration
-	// site. handle()'s third wrap, routeLabel, wraps this dispatcher at its
-	// handleRaw registration in routes() — OUTSIDE the scope gate, the same
-	// order handle() applies, so even a 403 meters under this route (#166).
+	// site. handleRaw's wrap, routeLabel, wraps this dispatcher at its
+	// registration in routes() — OUTSIDE the scope gate, the same order
+	// handle() applies, so even a 403 meters under this route (#166).
 	messages := requireScope("read:tickets", cacheControl(maxAgeTickets, listTicketMessages(ds)))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !knownTicketSub(r.PathValue("sub")) {
@@ -258,7 +260,9 @@ func handle(mux *http.ServeMux, pattern, scope string, maxAgeSeconds int, h http
 // Adding a route? Use handle(). Only a route whose scope gate cannot be
 // expressed as one requireScope wrap belongs here — and then the per-route
 // wraps it skips (scope, cache-control) must be applied explicitly inside the
-// handler, the way ticketSubResource does.
+// handler where they apply (the way ticketSubResource does), or their absence
+// ruled and documented (the parity shim and the catch-all carry neither, by
+// ruling).
 func handleRaw(mux *http.ServeMux, pattern string, h http.Handler) {
 	if onHandle != nil {
 		onHandle(pattern)

--- a/rest/sentry_test.go
+++ b/rest/sentry_test.go
@@ -407,11 +407,15 @@ func TestSentry_PanicAfterCommittedResponseReportsAndRepanics(t *testing.T) {
 	captureErrorLog(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /boom", sentryLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// routeLabel: the committed 200 meters under the route, keeping the
+	// registry's never-routed contract (route="" ⇒ auth tiers or pre-routing
+	// panic, swept post-run by TestMain, #173) — an unlabeled probe would
+	// mint route="" 200.
+	mux.Handle("GET /boom", routeLabel(sentryLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("partial body before the panic"))
 		panic("exploded after the 200")
-	})))
+	}))))
 	h := sentryMiddleware(metricsMiddleware(mux))
 
 	rr := httptest.NewRecorder()
@@ -554,9 +558,12 @@ func TestSentry_ErrAbortHandlerRepanicsUnreported(t *testing.T) {
 	tr := enableSentry(t)
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /abort", sentryLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// routeLabel: keeps the probe inside the registry's never-routed
+	// contract (#173) — unlabeled, its relabeled 500 would meter as
+	// route="", conflating this routed abort with a pre-routing panic.
+	mux.Handle("GET /abort", routeLabel(sentryLabel(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		panic(http.ErrAbortHandler)
-	})))
+	}))))
 	h := sentryMiddleware(metricsMiddleware(mux))
 
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
Closes #173. Implements the maintainer ruling (do both: structural helper + derive-from-reality sweep).

**`handleRaw(mux, pattern, h)`** is now the only path to the mux — `handle()` funnels through it, and the three registrations `handle()` can't express (ref/messages shim, `{ticket_id}/{sub}` dispatcher, catch-all) call it directly. It carries the two invariants every registration needs: `routeLabel` (so `route=""` keeps meaning exactly "never routed", #166) and the `onHandle` feed (so the completeness guards see every registration). A `TestMuxHandle_OnlyCallSiteIsHandleRaw` source scan makes the "only way" claim mechanically enforced.

**Sweep:** drives authenticated traffic at every registered pattern and asserts no exposition child pairs `route=""` with a non-empty `key_id`, plus the derived contract `route=="" ⇒ status ∈ {401,500,503}` (closes the unauthenticated-mount blind spot — the #134 docs-UI shape). Re-asserted in `TestMain` after the whole package so a helper-bypassing registration is caught the moment any test drives its traffic.

Also folds in the `ticketSubResource` doc nit (all three per-route wraps now enumerated) and route-labels the internal middleware probes (they were minting `route=""` 101/103/200 against the new contract).

Reviewed (code/test/comment) + fixups + mutation-verified both layers trip. Sequenced before #134 so the cutover's new mounts use `handleRaw` from day one. Gate green incl. `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)