### PR TITLE
docs(phase4): supersede ADRs 0001/0002, refresh CONTEXT.md and README (#136)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,11 +1,15 @@
 # Context
 
-Domain language used by the 7Cav API. The hand-owned OpenAPI 3.1 spec
-(`openapi/openapi.yaml`, validated against the golden corpus) is the
-contract; this document covers the concepts and any nuance that isn't
-obvious from reading the spec. The proto/buf toolchain was retired in
-Phase 4 (#135) — the API is now a plain net/http JSON service with
-hand-written handlers and types.
+Domain language used by the 7Cav API. The contract is a trio that is
+checked in and CI-enforced, not a generated artifact: the **types
+package** (`types/`, the hand-written wire types), the **hand-owned
+OpenAPI 3.1 spec** (`openapi/openapi.yaml`), and the **golden corpus**
+(`contract/goldens/`, one recorded request/response per public route).
+The spec is validated against the corpus, so the three stay in step. This
+document covers the concepts and any nuance that isn't obvious from
+reading them. The proto/buf toolchain was retired in Phase 4 (#135, ADR
+0006); the API is now a plain net/http JSON service with hand-written
+handlers and types.
 
 ## Source data
 
@@ -25,7 +29,7 @@ serves them.
 
 ## Profile shapes
 
-A member's milpac is served in three shapes by different RPCs, each
+A member's milpac is served in three shapes by different routes, each
 tuned to a known consumer:
 
 - **`Profile`** — full view: rank, positions, awards, records, and the
@@ -36,16 +40,15 @@ tuned to a known consumer:
   uniform-relevant fields and omits the rest.
 
 The three are not subsets of one type; they are hand-mapped from the
-same upstream rows into distinct proto messages.
+same upstream rows into distinct wire types in the `types` package.
 
 ## Roster and RosterType
 
 A `Roster` is a collection of members grouped by unit, course, or
 status. `RosterType` is an enum identifying which roster is requested;
 its numeric values are used as the `roster_id` foreign key in the
-upstream tables. The three roster RPCs (`GetRoster`, `GetLiteRoster`,
-`GetS1UniformsRoster`) return the same set of members in the
-corresponding profile shape above.
+upstream tables. The three roster routes return the same set of members
+in the corresponding profile shape above.
 
 ## Rank, Position, PositionGroup
 
@@ -64,7 +67,7 @@ a decoration entry.
 ## AWOL
 
 An entry on the AWOL list — members flagged as absent without leave.
-Served by `GetAwol`, used by status-tracking consumers.
+Served by the AWOL route, used by status-tracking consumers.
 
 ## Connected accounts
 
@@ -74,13 +77,15 @@ integrations:
 
 - **Discord** — Discord user id.
 - **Gamertag** — Xbox / PlayStation handle.
-- **Keycloak** — legacy SSO identifier. The Keycloak auth path has been
-  removed; the lookup RPC is on the chopping block and should not be
-  used in new code.
+- **Keycloak** — legacy SSO identifier. The Keycloak auth path was
+  removed, and the lookup route went with the cutover: the route and the
+  `keycloakId` field are gone from the served surface, and the golden
+  corpus records that removal (`stripKeycloakID` in `contract/canon.go`).
+  Nothing in new code should reference either.
 
 ## Tickets
 
-`TicketsService` exposes the forum's ticket system (powered by the
+The tickets surface exposes the forum's ticket system (powered by the
 `NF Tickets` add-on) as a read-only API.
 
 - **`Ticket`** — a thread: title, status, category, participants,
@@ -108,6 +113,49 @@ service. Each token carries a set of named scopes. Current scopes:
 
 Scope membership is checked per-handler; a token with `read` cannot
 read tickets, and vice versa.
+
+## Wire conventions (house style)
+
+The generated stack produced a particular JSON shape; the rewrite kept it
+and adopted it as house style for every new field. The golden corpus and
+the spec replay enforce it on covered routes, and the tag lint in
+`types/wireconventions_test.go` enforces it at declaration time:
+
+- **JSON names are lowerCamelCase** (e.g. `rankId`, not `rank_id`).
+- **Emit everything**, no `omitempty`. An absent key, `""` and `0` are
+  distinct wire states, so every field is always present. Unset nested
+  messages serialize as `null`; empty collections serialize as `[]` / `{}`
+  (never `null`, so the handlers must allocate empty slices and maps).
+- **64-bit integers serialize as JSON strings** (the `,string` tag);
+  32-bit integers stay JSON numbers. `"3"` and `3` are different on the
+  wire, and the contract differ preserves the distinction.
+- **Enums serialize as their name strings**, with the zero value emitting
+  the `*_UNSPECIFIED` name. Values without a name fall back to the bare
+  number. `RosterType` is the worked example.
+
+## Adding an endpoint
+
+The sequence that used to be one proto edit is now a short hand-written
+checklist. The spec and golden steps are CI-enforced, so a missed step
+fails the build naming the operation or field rather than shipping drift:
+
+1. **Wire types** in `types/`: follow the house style above; the tag
+   lint checks the tags with no registration needed.
+2. **Handler** in `rest/`: map the datastore result to the wire types
+   (allocate empty collections), write JSON on success, and write the
+   frozen error message on failure.
+3. **Route registration** in `rest/`'s `routes()`: register the path
+   with its required scope gate and `Cache-Control` max-age.
+4. **Spec operation** in `openapi/openapi.yaml`: its documented responses
+   feed the two-way coverage check.
+5. **Goldens** in `contract/goldens/`: add the route's cases so the
+   replay harness covers it.
+
+`contract/spec_test.go` asserts coverage in both directions: every spec
+operation needs a witnessing golden (with at least one 2xx), and every
+golden route must resolve to an operation. A new endpoint that skips the
+spec or golden step fails that suite; there is no tribal knowledge to
+forget. See `rest/rest.go` and `types/types.go` for the in-code long form.
 
 ## SQL seam (integration-test harness)
 

--- a/README.md
+++ b/README.md
@@ -2,25 +2,30 @@
 
 # Cav API
 
-A web API using GPRC/protobufs for main communication, but also supplying a more standard HTTP/JSON over grpc-gateway for legacy usage
+An HTTP/JSON API that serves 7Cav community and roster data. It is a read
+layer over the forum's MySQL database, written in Go on the standard
+library `net/http` stack.
 
 ## Clients
 
 ### Authentication
 
-The API is guarded via an OAuth2 bearer token, which you can get via the [7Cav auth service](https://auth.7cav.us/auth/realms/7Cav/account/)
+The API is guarded by a `Bearer` token. Tokens are issued and managed in
+the forum admin UI; each one carries a set of scopes that gate which parts
+of the surface it can read. Send it on every request:
 
-> If you see an empty field for the API Key, go to the 'sessions' tab, and click 'Log out all sessions'. Then, sign in again as usual.
+```
+Authorization: Bearer <your token>
+```
 
 ### HTTP/JSON
 
-We still maintain a simple HTTP API which routes to the underlying gRPC API. The more detailed endpoints are only accessible via the gRPC clients, so only use the HTTP API if you really need to and understand the trade-offs.
+The interactive documentation lives at [api.7cav.us](https://api.7cav.us).
 
-You can view the automatically generated documentation via [api.7cav.us](https://api.7cav.us)
+> To try the API from the docs page, click the `Authorize` button at the
+> top and paste your bearer token.
 
-> If you want to 'try out' the API, ensure you use your bearer token by clicking the 'Authorize' button at the top of the page 
-
-Wrap the requests in whichever flavour of language/HTTP client you wish:
+Wrap the requests in whichever language or HTTP client you prefer.
 
 #### NodeJS
 
@@ -62,7 +67,7 @@ func main() {
         TokenType:   "Bearer",
     }))
 
-    res, err := client.Get("milpacs/profile/id/1")
+    res, err := client.Get("https://api.7cav.us/api/v1/milpacs/profile/id/1")
     if err != nil {
         panic(err)
     }
@@ -70,97 +75,71 @@ func main() {
 }
 ```
 
-### gRPC
+## Architecture
 
-You probably came here for guidance on using the gRPC clients in your code. It depends on which language you're using, and if they are [supported by gRPC](https://grpc.io/docs/languages/).
+The service runs as a single public listener that serves the whole `/api`
+surface plus the documentation UI. There is no second port and no gRPC: an
+earlier version split the process into a gRPC server and a generated
+HTTP/JSON gateway, but that design was retired in [PRD #112][prd]
+("Goodbye gRPC"). See [ADR 0006][adr6] for why.
 
-An example client written in golang can be found in `cmd/example.go` and can be run via `go run main.go example <id>` to get milpac info for a specific user.
+The contract is checked into the repo, not generated:
 
-```go
-package main
+- the **types package** (`types/`) holds the hand-written wire types;
+- the **OpenAPI 3.1 spec** (`openapi/openapi.yaml`) is the reference
+  document served at the docs URL;
+- the **golden corpus** (`contract/goldens/`) records one
+  request/response per public route.
 
-import (
-	"context"
-    "crypto/tls"
-    "fmt"
-    "github.com/7cav/api/proto"
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/credentials"
-    "google.golang.org/grpc/credentials/oauth"
-)
+`contract/spec_test.go` validates the spec against the corpus in both
+directions, so the three stay in step and any drift fails CI naming the
+operation and field. The domain glossary and the add-an-endpoint checklist
+live in [`CONTEXT.md`](CONTEXT.md).
 
-func main() {
-    ctx := context.Background()
-    token := "<token>"
-    
-    rpcCreds := oauth.NewOauthAccess(&oauth2.Token{AccessToken: token})
-
-    // use TLS config to auto detect SSL/TLS cert from Api Host
-    config := &tls.Config{
-        InsecureSkipVerify: false,
-    }
-
-    opts := []grpc.DialOption{
-        grpc.WithTransportCredentials(credentials.NewTLS(config)),
-        grpc.WithPerRPCCredentials(rpcCreds),
-        grpc.WithBlock(),
-    }
-
-    conn, _ := grpc.Dial("api.7cav.us:443", opts...)
-    client := proto.NewMilpacServiceClient(conn)
-    res, err := client.Profile(context.Background(), &proto.ProfileRequest{UserId: 1})
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println(res)
-}
-```
-
-Otherwise, follow the gRPC tutorials on using 'Client Side Code' and use the `proto/milpacs.proto` schema in your own code-bases.
+[prd]: https://github.com/7Cav/api/issues/112
+[adr6]: docs/adr/0006-single-listener-net-http-and-hand-owned-openapi.md
 
 ## Running
 
-In production, we use a customized version of the docker-compose.yml you can see here. The nginx container in front is for handling SSL/TLS termination before we reach the gRPC server.That way internally we don't need to use TLS encryption(needed on client side due to sending bearer tokens)
+In production the API runs behind an nginx that terminates TLS in front of
+the single HTTP listener. The `docker-compose.yaml` in this repo is a
+prod-shaped template; the live compose file is customized and kept out of
+the repo.
 
-The following should get you up and running. However you'll need a copy of the 7cav xenforo database imported into the mysql container!
+You need a copy of the 7Cav XenForo database reachable from the container
+(see the `DB_*` environment variables in `docker-compose.yaml`). Then:
 
 ```shell
-make certs
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Development
 
-So long as you have golang installed, you should be fine to run the following make commands to get setup with the required dependencies:
+With Go installed you can build and run the API directly. There is no code
+generation or tooling install step:
 
 ```shell
-make install
+go build ./...
+go run main.go serve
 ```
 
-This will also install [Cobra](https://github.com/spf13/cobra), which is used for creating the boilerplate for each custom command on the generated binary.
+`go run main.go serve` needs the database environment variables set (see
+`docker-compose.yaml` for the full list).
 
-When making changes to the proto file, be sure to run the relevant make file to regenerate the exported server interfaces:
-
-> You'll need to install the `buf` cli first from [here](https://github.com/bufbuild/buf)
+### Tests
 
 ```shell
-make generate
+go test ./...          # unit + contract suite, no external services
+make test-integration  # adds the dockerized MariaDB harness (testdb/)
 ```
 
-### Windows
+`make lint` runs `go vet`. The contract suite (`contract/`) replays the
+golden corpus against the live stack and validates the OpenAPI spec; run it
+before pushing changes that touch the wire surface.
 
-If you're developing on Windows, we have added a mage file to help you replicate some of the make commands without having access to make.
+### Adding an endpoint
 
-You will need to install [mage](https://magefile.org/) first.
-
-```shell
-mage install
-```
-
-The available commands are:
-`` mage generate ``
-`` mage lint ``
-`` mage install ``
-
-Notably missing is the certs command, which is used to generate self-signed certs for nginx TLS.
-Without this you will not be able to test the API via the swagger page, however you can still test the gateway with curl.
+Wire types → handler → route registration → spec operation → goldens. The
+spec and golden steps are CI-enforced. The full checklist is in
+[`CONTEXT.md`](CONTEXT.md); the in-code long form is in the package docs of
+`rest/rest.go` and `types/types.go`.

--- a/docs/adr/0001-split-process-grpc-and-http-gateway.md
+++ b/docs/adr/0001-split-process-grpc-and-http-gateway.md
@@ -1,5 +1,12 @@
 # ADR 0001: Split-process gRPC server + HTTP/JSON gateway from a single proto
 
+> **Status: Superseded** by ADR 0006 (single-listener net/http service with
+> a hand-owned OpenAPI 3.1 contract), PRD #112 Phase 4. The delete sweep
+> landed in #135 (PR #207). The gRPC listener, the gateway translation
+> layer, the proto files, and the buf/protoc toolchain are gone; the API is
+> now one `net/http` JSON service. This ADR records the design as it stood
+> and why it was retired.
+
 ## Context
 
 The API exposes the same surface over two transports: a gRPC service for

--- a/docs/adr/0002-intra-process-plaintext-grpc-dial.md
+++ b/docs/adr/0002-intra-process-plaintext-grpc-dial.md
@@ -1,5 +1,11 @@
 # ADR 0002: Intra-process plaintext gRPC dial; TLS terminates at the reverse proxy
 
+> **Status: Superseded** by ADR 0006 (single-listener net/http service with
+> a hand-owned OpenAPI 3.1 contract), PRD #112 Phase 4; landed in #135 (PR
+> #207). With the second listener gone there is no intra-process hop to
+> secure, so the plaintext-dial decision below no longer applies. TLS still
+> terminates at the reverse proxy.
+
 ## Context
 
 The binary runs two listeners (see ADR 0001): the gRPC server on one port

--- a/docs/adr/0006-single-listener-net-http-and-hand-owned-openapi.md
+++ b/docs/adr/0006-single-listener-net-http-and-hand-owned-openapi.md
@@ -1,0 +1,88 @@
+# ADR 0006: Single-listener net/http service with a hand-owned OpenAPI 3.1 contract
+
+> Supersedes ADR 0001 (split-process gRPC + HTTP gateway) and ADR 0002
+> (intra-process plaintext gRPC dial). Both described the two-listener,
+> proto-driven layout this ADR retires. The deletion landed in #135 (PR
+> #207), the final phase of PRD #112 ("Goodbye gRPC").
+
+## Context
+
+ADR 0001 split the API into a gRPC server and an HTTP/JSON gateway, both
+generated from `proto/milpacs.proto`, running as two listeners in one
+process. ADR 0002 covered the in-process plaintext hop between them. The
+design bought one thing: a single source of truth for the gRPC service,
+the REST routes, and the OpenAPI document, all falling out of code
+generation.
+
+The cost showed up over time. Two known consumers (`7cav-cavbot2` and the
+ADR tool) used the HTTP gateway. The gRPC port had no confirmed external
+consumer, and the heads-up conversation before cutover (#117) confirmed
+nobody generated client code from the served spec either; the spec was
+not accurate enough to drive a generated client. So the gRPC surface and
+the generated Swagger 2.0 document were carrying weight nothing leaned on.
+The proto/buf toolchain, the generated `*.pb.go` and `*.pb.gw.go` files,
+and the second listener were maintenance and review surface with no
+matching demand.
+
+Meanwhile the read-path latency work in earlier PRD #112 phases removed
+the response cache (ADR 0003) and proved the service could be reasoned
+about directly. The remaining question was whether we could rewrite onto
+plain `net/http` without quietly changing the wire form clients already
+depended on.
+
+## Decision
+
+Retire the split-process design. The API is one `net/http` JSON service
+with hand-written handlers, behind the same TLS-terminating reverse proxy
+as before. There is one public listener; the gRPC listener, the gateway
+translation layer, the proto files, and the buf/protoc toolchain are gone.
+
+The contract is no longer a generated artifact. It is a trio that is
+checked into the repo and enforced in CI:
+
+- the **types package** (`types/`): the hand-written wire types that
+  replaced the generated proto messages;
+- the **hand-owned OpenAPI 3.1 spec** (`openapi/openapi.yaml`): the
+  reference document served at the docs URL, replacing the generated
+  Swagger 2.0 file;
+- the **golden corpus** (`contract/goldens/`): one recorded
+  request/response per public route, captured from the old stack before
+  it was deleted.
+
+The golden corpus is what made the rewrite safe. The goldens were recorded
+against the running proto-driven stack, then replayed against the new
+`net/http` stack; a response that does not reproduce its golden fails a
+test (`contract/spec_test.go`, `contract/golden_test.go`). The same
+replay validates the OpenAPI spec in both directions: every operation must
+have a witnessing golden, and every golden route must resolve to an
+operation. Drift names the operation and the field, so the contract is
+machine-checked rather than tribal.
+
+The Swagger 2.0 document is fully retired, not frozen behind an alias.
+#117 confirmed no consumer codegens from it and that it was never accurate
+enough to use, so there was nothing to keep compatible. The OpenAPI 3.1
+document replaces it at the same docs URL; the route paths and response
+shapes clients actually call are unchanged.
+
+## Consequences
+
+- Adding an endpoint is no longer a single proto edit. It is a sequence of
+  hand-written steps (wire types, handler, route registration, spec
+  operation, goldens), written down as the add-an-endpoint checklist in
+  `CONTEXT.md`. The spec and golden steps are CI-enforced, so the sequence
+  is guarded rather than remembered.
+- There is no `make generate` / `make install` / codegen step. `make lint`
+  is `go vet`; the build is plain `go build ./...`.
+- The wire form is now owned by hand. The conventions the generated stack
+  produced (lowerCamelCase JSON, emit-everything, 64-bit ints as strings /
+  32-bit as numbers, enum name strings with an `_UNSPECIFIED` zero value)
+  are adopted as house style and enforced: by the tag lint in
+  `types/wireconventions_test.go` at declaration time, and by the golden
+  corpus and spec replay on every covered route.
+- No second listener means no intra-process plaintext dial, so the concern
+  ADR 0002 documented no longer exists. TLS still terminates at the
+  reverse proxy.
+- The contract trio is the safety net the generated stack used to provide
+  for free. A future rewrite of the same surface replays the same goldens
+  and validates the same spec; the corpus is the authoritative wire
+  reference, independent of the code that serves it.


### PR DESCRIPTION
Closes #136. The Phase 4 documentation close-out for the "Goodbye gRPC" program (PRD #112), now that the code deletion (#135 / PR #207) has landed.

## What changed
- **New ADR** `docs/adr/0006-single-listener-net-http-and-hand-owned-openapi.md`: records why the split-process design was retired (no confirmed external gRPC consumers, no spec-codegen consumers per #117, the single-listener net/http rewrite, the golden-enforced contract). Supersedes ADR 0001 and 0002.
- **ADR 0001 and 0002** each carry a superseded status header pointing at 0006 and #135 / #207.
- **CONTEXT.md**: the contract framing now points at the trio (the `types` package, the hand-owned OpenAPI 3.1 spec, the golden corpus, CI-cross-validated). New "wire conventions (house style)" section (lowerCamelCase, emit-everything, 64-bit ints as strings / 32-bit as numbers, enum name strings with the `_UNSPECIFIED` zero value). New add-an-endpoint checklist (types, handler, route registration, spec operation, goldens) with a note that the spec and golden steps are CI-enforced. The Keycloak note is now past tense.
- **README.md**: dropped the gRPC quickstart, the `proto.NewMilpacServiceClient` example, `make install` / `make generate` / `make certs`, and the "nginx is for the gRPC server" line. The architecture section now names the contract trio and points at ADR 0006. HTTP/JSON examples and the docs URL are unchanged.
- Swagger 2.0 retirement decision (full retirement, per #117) recorded in ADR 0006. The physical retirement already happened in #207.

## Verification
Docs-only (no `.go` touched). `go build ./...` and `go test ./...` green. A review pass verified every load-bearing claim against the actual code: the contract trio matches what `contract/` validates, the wire conventions match the `types/` marshalers, the README build flow works with no codegen, and ADR 0006 is correctly numbered with working supersede pointers.

> *This was generated by AI*
