### PR TITLE
fix(datastores): propagate secondary-lookup and post-date outages to 500 (#154, #155)

### DIFF
--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -123,6 +123,11 @@ func (ds Mysql) FindProfileByDiscordID(discordId string) (*types.Profile, error)
 }
 
 func (ds Mysql) generateProtoProfile(profile milpacs.Profile) (*types.Profile, error) {
+	secondaries, err := ds.collectSecondaryPositions(profile.SecondaryPositionIds)
+	if err != nil {
+		return nil, fmt.Errorf("collect secondary positions: %w", err)
+	}
+
 	milpac := &types.Profile{
 		User: &types.User{
 			UserId:   profile.XfUser.UserID,
@@ -141,7 +146,7 @@ func (ds Mysql) generateProtoProfile(profile milpacs.Profile) (*types.Profile, e
 			PositionTitle: profile.Primary.PositionTitle,
 			PositionId:    profile.Primary.PositionId,
 		},
-		Secondaries:     ds.collectSecondaryPositions(profile.SecondaryPositionIds),
+		Secondaries:     secondaries,
 		Records:         collectRecords(profile.Records),
 		Awards:          collectAwards(profile.AwardRecords),
 		JoinDate:        profile.UnmarshalCustomFields().JoinDate,
@@ -164,22 +169,40 @@ func extractDiscordID(profile milpacs.Profile) string {
 	return ""
 }
 
-func (ds Mysql) collectSecondaryPositions(positionIds string) []*types.Position {
+// collectSecondaryPositions resolves the comma-separated secondary-position
+// id list into full position entries. A failed lookup of ANY class (connection
+// failure, timeout, OR a missing row) is propagated rather than swallowed: the
+// route answers its outage path (the contract 500) instead of appending a
+// fabricated blank position to a degraded 200 (issue #154, reversed ruling
+// 2026-06-20 — a silent hole is worse than an honest error). A genuinely-
+// missing position row is a data fault the consumer must not mistake for real
+// data, so ErrRecordNotFound propagates alongside the connection classes.
+//
+// The error is wrapped with %v (NOT %w) deliberately: the single-profile
+// handlers (rest/milpacs.go getProfileByID and siblings) map an error that
+// errors.Is(gorm.ErrRecordNotFound) to a 404 "no profile found". A secondary-
+// position row that has vanished while the MEMBER still resolves is an outage,
+// not a missing member — masking the gorm sentinel keeps it on the contract
+// 500 outage path instead of mislabeling the member as 404. The underlying
+// message is preserved verbatim for diagnosis.
+func (ds Mysql) collectSecondaryPositions(positionIds string) ([]*types.Position, error) {
 	var positions []*types.Position
 
 	if positionIds == "" {
-		return positions
+		return positions, nil
 	}
 
 	for _, id := range strings.Split(positionIds, ",") {
 		var position milpacs.Position
-		ds.Db.First(&position, id)
+		if err := ds.Db.First(&position, id).Error; err != nil {
+			return nil, fmt.Errorf("lookup secondary position %q: %v", id, err)
+		}
 		positions = append(positions, &types.Position{
 			PositionTitle: position.PositionTitle,
 			PositionId:    position.PositionId,
 		})
 	}
-	return positions
+	return positions, nil
 }
 
 func collectRecords(recordRows []milpacs.Record) []*types.Record {
@@ -245,6 +268,11 @@ func (ds Mysql) FindLiteRosterByType(rosterType types.RosterType) (*types.LiteRo
 }
 
 func (ds Mysql) generateLiteProtoProfile(profile milpacs.Profile) (*types.LiteProfile, error) {
+	secondaries, err := ds.collectSecondaryPositions(profile.SecondaryPositionIds)
+	if err != nil {
+		return nil, fmt.Errorf("collect secondary positions: %w", err)
+	}
+
 	milpac := &types.LiteProfile{
 		User: &types.User{
 			UserId:   profile.XfUser.UserID,
@@ -263,7 +291,7 @@ func (ds Mysql) generateLiteProtoProfile(profile milpacs.Profile) (*types.LitePr
 			PositionTitle: profile.Primary.PositionTitle,
 			PositionId:    profile.Primary.PositionId,
 		},
-		Secondaries:     ds.collectSecondaryPositions(profile.SecondaryPositionIds),
+		Secondaries:     secondaries,
 		JoinDate:        profile.UnmarshalCustomFields().JoinDate,
 		PromotionDate:   profile.UnmarshalCustomFields().PromoDate,
 		Mos:             profile.UnmarshalCustomFields().Mos,
@@ -334,6 +362,11 @@ func (ds Mysql) FindS1UniformsRosterByType(rosterType types.RosterType) (*types.
 }
 
 func (ds Mysql) generateS1UniformsProtoProfile(profile milpacs.Profile) (*types.S1UniformsProfile, error) {
+	secondaries, err := ds.collectS1UniformsSecondaryPositions(profile.SecondaryPositionIds)
+	if err != nil {
+		return nil, fmt.Errorf("collect secondary positions: %w", err)
+	}
+
 	milpac := &types.S1UniformsProfile{
 		User: &types.User{
 			UserId:   profile.XfUser.UserID,
@@ -350,7 +383,7 @@ func (ds Mysql) generateS1UniformsProtoProfile(profile milpacs.Profile) (*types.
 		UniformUpdateTriggerDate: getUniformUpdateTriggerDate(profile),
 		Roster:                   types.RosterType(profile.RosterId),
 		PrimaryPositionTitle:     profile.Primary.PositionTitle,
-		Secondaries:              ds.collectS1UniformsSecondaryPositions(profile.SecondaryPositionIds),
+		Secondaries:              secondaries,
 		JoinDate:                 profile.UnmarshalCustomFields().JoinDate,
 		PromotionDate:            profile.UnmarshalCustomFields().PromoDate,
 		AreaOfResponsibility:     getPositionGroup(profile),
@@ -359,21 +392,30 @@ func (ds Mysql) generateS1UniformsProtoProfile(profile milpacs.Profile) (*types.
 	return milpac, nil
 }
 
-func (ds Mysql) collectS1UniformsSecondaryPositions(positionIds string) []*types.S1UniformsPosition {
+// collectS1UniformsSecondaryPositions resolves the secondary-position id list
+// into the S1 uniforms shape. Like collectSecondaryPositions, a failed lookup
+// of any class (connection failure, timeout, OR a missing row) is propagated
+// so the route answers its outage path rather than emitting a fabricated blank
+// position on a degraded 200 (issue #154, reversed ruling 2026-06-20). The
+// error is wrapped with %v (not %w) for the same reason as the sibling: the
+// gorm not-found sentinel must not leak into the single-profile 404 mapping.
+func (ds Mysql) collectS1UniformsSecondaryPositions(positionIds string) ([]*types.S1UniformsPosition, error) {
 	var positions []*types.S1UniformsPosition
 
 	if positionIds == "" {
-		return positions
+		return positions, nil
 	}
 
 	for _, id := range strings.Split(positionIds, ",") {
 		var position milpacs.Position
-		ds.Db.First(&position, id)
+		if err := ds.Db.First(&position, id).Error; err != nil {
+			return nil, fmt.Errorf("lookup secondary position %q: %v", id, err)
+		}
 		positions = append(positions, &types.S1UniformsPosition{
 			PositionTitle: position.PositionTitle,
 		})
 	}
-	return positions
+	return positions, nil
 }
 
 func getUniformDate(profile milpacs.Profile) string {
@@ -549,7 +591,14 @@ const (
 )
 
 // bear witness to my despair, as i try to optimize queries to a table with a gazillion rows
-func (ds Mysql) getLatestForumPostDates(profiles []milpacs.Profile) map[uint64]string {
+//
+// A failed aggregation is propagated rather than degraded to an empty map
+// (issue #155, reversed ruling 2026-06-20). The old swallow blanked every
+// lastForumPostDate on a 200 during a partial outage, indistinguishable from
+// a member who genuinely never posted; the route now answers its outage path
+// (the contract 500). The error is still logged for observability before it
+// propagates.
+func (ds Mysql) getLatestForumPostDates(profiles []milpacs.Profile) (map[uint64]string, error) {
 	dates := make(map[uint64]string)
 
 	var results []struct {
@@ -564,7 +613,7 @@ func (ds Mysql) getLatestForumPostDates(profiles []milpacs.Profile) map[uint64]s
 
 	if err := query.Find(&results).Error; err != nil {
 		Error.Printf("Error fetching forum post dates: %v", err)
-		return dates
+		return nil, fmt.Errorf("fetch forum post dates: %w", err)
 	}
 
 	for _, result := range results {
@@ -575,7 +624,7 @@ func (ds Mysql) getLatestForumPostDates(profiles []milpacs.Profile) map[uint64]s
 		}
 	}
 
-	return dates
+	return dates, nil
 }
 
 func getUserIDs(profiles []milpacs.Profile) []uint64 {
@@ -588,7 +637,10 @@ func getUserIDs(profiles []milpacs.Profile) []uint64 {
 
 // ohgodwhy
 func (ds Mysql) processLiteProfiles(profiles []milpacs.Profile) (map[uint64]*types.LiteProfile, error) {
-	forumPostDates := ds.getLatestForumPostDates(profiles)
+	forumPostDates, err := ds.getLatestForumPostDates(profiles)
+	if err != nil {
+		return nil, err
+	}
 
 	var profileMap = make(map[uint64]*types.LiteProfile, len(profiles))
 	for _, profile := range profiles {
@@ -605,7 +657,10 @@ func (ds Mysql) processLiteProfiles(profiles []milpacs.Profile) (map[uint64]*typ
 }
 
 func (ds Mysql) processProfiles(profiles []milpacs.Profile) (map[uint64]*types.Profile, error) {
-	forumPostDates := ds.getLatestForumPostDates(profiles)
+	forumPostDates, err := ds.getLatestForumPostDates(profiles)
+	if err != nil {
+		return nil, err
+	}
 
 	var profileMap = make(map[uint64]*types.Profile, len(profiles))
 	for _, profile := range profiles {

--- a/datastores/outages_harness_test.go
+++ b/datastores/outages_harness_test.go
@@ -90,6 +90,38 @@ func TestFindS1UniformsRosterByType_SecondaryPositionLookupFailurePropagates(t *
 	}
 }
 
+// #154 — first-error-aborts / no-partial-200. A member with MULTIPLE secondary
+// ids where one RESOLVES and a later one ERRORS must fail the WHOLE call, not
+// return a partial 1-element success. collectSecondaryPositions returns on the
+// first failing id with a nil slice; a future "skip the bad one, keep the good
+// ones" change would silently reintroduce the degraded-200 (the exact bug class
+// #154 fixes), and this test would flip from the asserted nil-result error to a
+// partial profile.
+//
+// Relation 1 normally carries a single secondary (id 20). Within this test's
+// own disposable database (each openHarnessDatastore call gets a fresh seed),
+// rewrite it to "20,99999": id 20 resolves first, id 99999 has no row and
+// fails second. The fixtures are untouched outside this transaction, so the
+// existing single-secondary assertions on relation 1 still hold elsewhere.
+func TestFindProfilesById_SecondaryLookupFirstErrorAbortsNoPartial(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	// 20 resolves (Military Police); 99999 is absent — the second id fails.
+	if err := ds.Db.Exec(
+		`UPDATE xf_nf_rosters_user SET secondary_position_ids = '20,99999' WHERE relation_id = 1`,
+	).Error; err != nil {
+		t.Fatalf("rewriting relation 1's secondary ids to a resolves-then-fails pair: %v", err)
+	}
+
+	profiles, err := ds.FindProfilesById(1)
+	if err == nil {
+		t.Fatal("a multi-secondary member whose SECOND id fails must error the whole call, not return a partial profile (no degraded 200)")
+	}
+	if profiles != nil {
+		t.Fatalf("the failing call must return a nil result, not a partial slice; got %d profile(s)", len(profiles))
+	}
+}
+
 // #155 — the FULL roster route propagates a failed forum-post-date
 // aggregation (getLatestForumPostDates via processProfiles).
 func TestFindRosterByType_ForumPostDateFailurePropagates(t *testing.T) {

--- a/datastores/outages_harness_test.go
+++ b/datastores/outages_harness_test.go
@@ -1,0 +1,123 @@
+package datastores_test
+
+import (
+	"testing"
+
+	"github.com/7cav/api/types"
+)
+
+// Secondary-lookup and forum-post-date outages propagate to the route's
+// outage path (the contract 500) instead of degrading to a 200 with a
+// fabricated blank position or a blanked lastForumPostDate.
+//
+// Reversed ruling (issues #154/#155, 2026-06-20): a silent hole is worse
+// than an honest error — a consumer cannot tell a degraded outage response
+// from real data and may act on a fabricated member or a stale-looking
+// blank. The 2026-06-06 parity ruling (keep prod's blank-on-200 degrade) is
+// superseded. The golden corpus only witnesses happy paths, so these outage
+// paths were never contract-pinned; pinning them here is new-stack-only.
+//
+// FAULT ISOLATION technique (mirrors the column-drop in auth_harness_test.go):
+//
+//   - #154: DELETE only the secondary position row a member references
+//     (relation 1's secondary id 20, "Military Police"), leaving its PRIMARY
+//     position row (id 11, "Squad Leader") and xf_nf_rosters_user intact. The
+//     roster query and the Primary preload still resolve; only the per-member
+//     collectSecondaryPositions First(&position, 20) fails (ErrRecordNotFound).
+//     Per the reversed ruling we propagate ALL error classes including
+//     not-found — a fabricated blank member is worse than an honest 500.
+//   - #155: DROP xf_post so the getLatestForumPostDates aggregation errors
+//     while xf_nf_rosters_user still resolves — the primary roster query
+//     succeeds, then the post-date join fails and must propagate.
+
+// #154 — the FULL roster route propagates a failed secondary-position lookup.
+func TestFindRosterByType_SecondaryPositionLookupFailurePropagates(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	// Drop ONLY relation 1's secondary position row; its primary (id 11) stays.
+	if err := ds.Db.Exec(`DELETE FROM xf_nf_rosters_position WHERE position_id = 20`).Error; err != nil {
+		t.Fatalf("deleting the secondary position row to fault only the secondary lookup: %v", err)
+	}
+
+	_, err := ds.FindRosterByType(types.RosterTypeCombat)
+	if err == nil {
+		t.Fatal("a failed secondary-position lookup must propagate (contract 500), not append a blank position on a 200")
+	}
+}
+
+// #154 — the by-id FULL profile route propagates the same failure.
+func TestFindProfilesById_SecondaryPositionLookupFailurePropagates(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	if err := ds.Db.Exec(`DELETE FROM xf_nf_rosters_position WHERE position_id = 20`).Error; err != nil {
+		t.Fatalf("deleting the secondary position row: %v", err)
+	}
+
+	// Relation 1 (Trooper.A) is the member with a secondary position.
+	_, err := ds.FindProfilesById(1)
+	if err == nil {
+		t.Fatal("by-id profile with a broken secondary lookup must propagate, not fabricate a blank position")
+	}
+}
+
+// #154 — the LITE roster route (collectSecondaryPositions via
+// generateLiteProtoProfile) propagates too.
+func TestFindLiteRosterByType_SecondaryPositionLookupFailurePropagates(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	if err := ds.Db.Exec(`DELETE FROM xf_nf_rosters_position WHERE position_id = 20`).Error; err != nil {
+		t.Fatalf("deleting the secondary position row: %v", err)
+	}
+
+	_, err := ds.FindLiteRosterByType(types.RosterTypeCombat)
+	if err == nil {
+		t.Fatal("lite roster with a broken secondary lookup must propagate, not fabricate a blank position")
+	}
+}
+
+// #154 — the S1 uniforms route (collectS1UniformsSecondaryPositions)
+// propagates its own secondary lookup failure.
+func TestFindS1UniformsRosterByType_SecondaryPositionLookupFailurePropagates(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	if err := ds.Db.Exec(`DELETE FROM xf_nf_rosters_position WHERE position_id = 20`).Error; err != nil {
+		t.Fatalf("deleting the secondary position row: %v", err)
+	}
+
+	_, err := ds.FindS1UniformsRosterByType(types.RosterTypeCombat)
+	if err == nil {
+		t.Fatal("S1 uniforms roster with a broken secondary lookup must propagate, not fabricate a blank position")
+	}
+}
+
+// #155 — the FULL roster route propagates a failed forum-post-date
+// aggregation (getLatestForumPostDates via processProfiles).
+func TestFindRosterByType_ForumPostDateFailurePropagates(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	// Drop the post table so the aggregation errors; the roster query itself
+	// (xf_nf_rosters_user + preloads) still resolves.
+	if err := ds.Db.Exec(`DROP TABLE xf_post`).Error; err != nil {
+		t.Fatalf("dropping xf_post to fault only the post-date aggregation: %v", err)
+	}
+
+	_, err := ds.FindRosterByType(types.RosterTypeCombat)
+	if err == nil {
+		t.Fatal("a failed forum post-date aggregation must propagate (contract 500), not blank every lastForumPostDate on a 200")
+	}
+}
+
+// #155 — the LITE roster route propagates the same aggregation failure
+// (getLatestForumPostDates via processLiteProfiles).
+func TestFindLiteRosterByType_ForumPostDateFailurePropagates(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	if err := ds.Db.Exec(`DROP TABLE xf_post`).Error; err != nil {
+		t.Fatalf("dropping xf_post: %v", err)
+	}
+
+	_, err := ds.FindLiteRosterByType(types.RosterTypeCombat)
+	if err == nil {
+		t.Fatal("lite roster with a failed post-date aggregation must propagate, not blank every lastForumPostDate on a 200")
+	}
+}

--- a/rest/secondary_outage_test.go
+++ b/rest/secondary_outage_test.go
@@ -1,0 +1,144 @@
+package rest_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/7cav/api/rest"
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// Outage-classification pins for issues #154/#155 (reversed ruling 2026-06-20):
+// a secondary-position lookup OR forum-post-date aggregation that fails mid
+// request now propagates so the route answers the contract 500 outage path,
+// not a degraded 200 with a fabricated blank position / blanked
+// lastForumPostDate. The corpus only witnesses happy paths, so these pin the
+// outage path new-stack-only. The datastore-side propagation itself is pinned
+// at the harness level (datastores/outages_harness_test.go); these pin the
+// HTTP classification the propagated error must receive.
+
+// secondaryOutageGet drives one authenticated GET against the mounted stack.
+func secondaryOutageGet(t *testing.T, h http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer cav7_readkey")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+// #154 — a secondary-position lookup failure on the by-id FULL-profile route
+// must surface as the contract 500, NOT a 404. The datastore wraps the
+// secondary First() error with %v (see collectSecondaryPositions): masking the
+// gorm not-found sentinel keeps a vanished secondary row — while the MEMBER
+// still resolves — on the outage path, instead of the single-profile handler's
+// errors.Is(gorm.ErrRecordNotFound)→404 "no profile found" branch mislabeling
+// the present member as missing. This is the precise trap the %v (not %w)
+// choice avoids; the fake reproduces the post-wrap error shape the datastore
+// now returns.
+func TestNewStack_SecondaryPositionLookupFailureIsInternalNot404(t *testing.T) {
+	// The shape datastores.collectSecondaryPositions returns: the gorm
+	// sentinel's MESSAGE preserved but its IDENTITY masked (%v, not %w), so
+	// errors.Is(err, gorm.ErrRecordNotFound) is false.
+	wrapped := fmt.Errorf("collect secondary positions: lookup secondary position %q: %v", "20", gorm.ErrRecordNotFound)
+	require.False(t, errors.Is(wrapped, gorm.ErrRecordNotFound),
+		"the propagated secondary-lookup error must NOT alias gorm.ErrRecordNotFound, or the by-id route 404s a present member")
+
+	h := rest.New(&fakeDatastore{
+		findProfilesById: func(...uint64) ([]*types.Profile, error) { return nil, wrapped },
+	}, &stubReferenceCache{})
+
+	rr := secondaryOutageGet(t, h, "/api/v1/milpacs/profile/id/1")
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code,
+		"a secondary-lookup outage on a resolving member is the contract 500, never a 404")
+	assert.JSONEq(t,
+		`{"code":13,"message":"fetch profile by user id: collect secondary positions: lookup secondary position \"20\": record not found","details":[]}`,
+		rr.Body.String())
+}
+
+// Regression guard for the masking decision: a genuine WHOLE-METHOD
+// gorm.ErrRecordNotFound (the member itself does not exist) must STILL map to
+// 404. The #154 fix masks only the secondary-lookup sentinel; it must not
+// disturb the real not-found path.
+func TestNewStack_GenuineProfileNotFoundStill404(t *testing.T) {
+	h := rest.New(&fakeDatastore{
+		findProfilesById: func(...uint64) ([]*types.Profile, error) { return nil, gorm.ErrRecordNotFound },
+	}, &stubReferenceCache{})
+
+	rr := secondaryOutageGet(t, h, "/api/v1/milpacs/profile/id/1")
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.JSONEq(t, `{"code":5,"message":"no profile found for user ID: 1","details":[]}`, rr.Body.String())
+}
+
+// #155 — a forum-post-date aggregation failure on the by-id FULL-profile route
+// must surface as the contract 500. getLatestForumPostDates wraps the query
+// error with %w; a LEFT JOIN aggregation never yields gorm.ErrRecordNotFound,
+// so this stays off the 404 branch and on the outage path. The fake reproduces
+// the post-wrap error shape (processProfiles propagates it verbatim).
+func TestNewStack_ForumPostDateFailureIsInternal(t *testing.T) {
+	wrapped := fmt.Errorf("fetch forum post dates: %w", errOutage)
+	require.False(t, errors.Is(wrapped, gorm.ErrRecordNotFound))
+
+	h := rest.New(&fakeDatastore{
+		findProfilesById: func(...uint64) ([]*types.Profile, error) { return nil, wrapped },
+	}, &stubReferenceCache{})
+
+	rr := secondaryOutageGet(t, h, "/api/v1/milpacs/profile/id/1")
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.JSONEq(t,
+		`{"code":13,"message":"fetch profile by user id: fetch forum post dates: simulated datastore outage","details":[]}`,
+		rr.Body.String())
+}
+
+// #154/#155 — the roster routes (which map ANY datastore error to the contract
+// 500 unconditionally) answer the outage path for both propagated classes, on
+// all three roster shapes. This complements the by-id classification pins
+// above: rosters have no 404 branch to mislabel, so the only correct answer is
+// the 500.
+func TestNewStack_RosterSecondaryAndPostDateOutagesAreInternal(t *testing.T) {
+	secondary := fmt.Errorf("error generating profiles: collect secondary positions: lookup secondary position %q: %v", "20", gorm.ErrRecordNotFound)
+	postDate := fmt.Errorf("fetch forum post dates: %w", errOutage)
+
+	cases := []struct {
+		name string
+		path string
+		fake *fakeDatastore
+		want string
+	}{
+		{
+			name: "full/secondary",
+			path: "/api/v1/roster/ROSTER_TYPE_COMBAT",
+			fake: &fakeDatastore{findRosterByType: func(types.RosterType) (*types.Roster, error) { return nil, secondary }},
+			want: `fetch roster ROSTER_TYPE_COMBAT: error generating profiles: collect secondary positions: lookup secondary position \"20\": record not found`,
+		},
+		{
+			name: "lite/postdate",
+			path: "/api/v1/roster/ROSTER_TYPE_COMBAT/lite",
+			fake: &fakeDatastore{findLiteRosterByType: func(types.RosterType) (*types.LiteRoster, error) { return nil, postDate }},
+			want: "fetch lite roster ROSTER_TYPE_COMBAT: fetch forum post dates: simulated datastore outage",
+		},
+		{
+			name: "s1/secondary",
+			path: "/api/v1/s1/uniforms/ROSTER_TYPE_COMBAT",
+			fake: &fakeDatastore{findS1UniformsRosterByType: func(types.RosterType) (*types.S1UniformsRoster, error) { return nil, secondary }},
+			want: `fetch s1 uniforms roster ROSTER_TYPE_COMBAT: error generating profiles: collect secondary positions: lookup secondary position \"20\": record not found`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := rest.New(tc.fake, &stubReferenceCache{})
+			rr := secondaryOutageGet(t, h, tc.path)
+			require.Equal(t, http.StatusInternalServerError, rr.Code)
+			assert.JSONEq(t, `{"code":13,"message":"`+tc.want+`","details":[]}`, rr.Body.String())
+		})
+	}
+}

--- a/rest/secondary_outage_test.go
+++ b/rest/secondary_outage_test.go
@@ -33,34 +33,78 @@ func secondaryOutageGet(t *testing.T, h http.Handler, path string) *httptest.Res
 	return rr
 }
 
-// #154 — a secondary-position lookup failure on the by-id FULL-profile route
-// must surface as the contract 500, NOT a 404. The datastore wraps the
-// secondary First() error with %v (see collectSecondaryPositions): masking the
-// gorm not-found sentinel keeps a vanished secondary row — while the MEMBER
-// still resolves — on the outage path, instead of the single-profile handler's
-// errors.Is(gorm.ErrRecordNotFound)→404 "no profile found" branch mislabeling
-// the present member as missing. This is the precise trap the %v (not %w)
-// choice avoids; the fake reproduces the post-wrap error shape the datastore
-// now returns.
+// #154 — a secondary-position lookup failure on ANY of the four single-profile
+// routes must surface as the contract 500, NOT a 404. All four handlers share
+// the identical errors.Is(gorm.ErrRecordNotFound)→404 else→500 branch and all
+// reach collectSecondaryPositions via generateProtoProfile, so the guard must
+// hold on every one — not just by-id.
+//
+// The datastore wraps the secondary First() error with %v (see
+// collectSecondaryPositions): masking the gorm not-found sentinel keeps a
+// vanished secondary row — while the MEMBER still resolves — on the outage
+// path, instead of the single-profile handler's 404 "no profile found" branch
+// mislabeling the present member as missing. This is the precise trap the %v
+// (not %w) choice avoids. Each fake reproduces the post-wrap error shape the
+// datastore now returns; each route's own internal-error prefix is asserted in
+// full, so a %w regression (which would flip every row to 404) flips these to
+// red. The wrapped-error guard below proves the shape is the actual %v one.
 func TestNewStack_SecondaryPositionLookupFailureIsInternalNot404(t *testing.T) {
 	// The shape datastores.collectSecondaryPositions returns: the gorm
 	// sentinel's MESSAGE preserved but its IDENTITY masked (%v, not %w), so
-	// errors.Is(err, gorm.ErrRecordNotFound) is false.
+	// errors.Is(err, gorm.ErrRecordNotFound) is false. If the datastore
+	// regressed to %w, this guard's premise breaks and the route 404s a present
+	// member — exactly what the per-route 500 assertions below would catch.
 	wrapped := fmt.Errorf("collect secondary positions: lookup secondary position %q: %v", "20", gorm.ErrRecordNotFound)
 	require.False(t, errors.Is(wrapped, gorm.ErrRecordNotFound),
-		"the propagated secondary-lookup error must NOT alias gorm.ErrRecordNotFound, or the by-id route 404s a present member")
+		"the propagated secondary-lookup error must NOT alias gorm.ErrRecordNotFound, or the single-profile routes 404 a present member")
 
-	h := rest.New(&fakeDatastore{
-		findProfilesById: func(...uint64) ([]*types.Profile, error) { return nil, wrapped },
-	}, &stubReferenceCache{})
+	// One fake serving every single-profile method the wrapped secondary error;
+	// each route is driven independently so a missing per-route 500 guard fails
+	// its own row.
+	fake := &fakeDatastore{
+		findProfilesById:       func(...uint64) ([]*types.Profile, error) { return nil, wrapped },
+		findProfilesByUsername: func(string) ([]*types.Profile, error) { return nil, wrapped },
+		findProfileByDiscordID: func(string) (*types.Profile, error) { return nil, wrapped },
+		findProfileByGamertag:  func(string) (*types.Profile, error) { return nil, wrapped },
+	}
+	h := rest.New(fake, &stubReferenceCache{})
 
-	rr := secondaryOutageGet(t, h, "/api/v1/milpacs/profile/id/1")
-
-	require.Equal(t, http.StatusInternalServerError, rr.Code,
-		"a secondary-lookup outage on a resolving member is the contract 500, never a 404")
-	assert.JSONEq(t,
-		`{"code":13,"message":"fetch profile by user id: collect secondary positions: lookup secondary position \"20\": record not found","details":[]}`,
-		rr.Body.String())
+	cases := []struct {
+		name string
+		path string
+		// want is each handler's own internal-error wrap of the propagated
+		// secondary failure (prefixes frozen from rest/milpacs.go).
+		want string
+	}{
+		{
+			name: "by_id",
+			path: "/api/v1/milpacs/profile/id/1",
+			want: `fetch profile by user id: collect secondary positions: lookup secondary position \"20\": record not found`,
+		},
+		{
+			name: "by_username",
+			path: "/api/v1/milpacs/profile/username/Jarvis.A",
+			want: `fetch profile by username: collect secondary positions: lookup secondary position \"20\": record not found`,
+		},
+		{
+			name: "by_discord",
+			path: "/api/v1/milpac/discord/112233445566778899",
+			want: `fetch profile by discord id: collect secondary positions: lookup secondary position \"20\": record not found`,
+		},
+		{
+			name: "by_gamertag",
+			path: "/api/v1/milpac/gamertag/CavGamer77",
+			want: `fetch profile by gamertag: collect secondary positions: lookup secondary position \"20\": record not found`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := secondaryOutageGet(t, h, tc.path)
+			require.Equal(t, http.StatusInternalServerError, rr.Code,
+				"a secondary-lookup outage on a resolving member is the contract 500, never a 404")
+			assert.JSONEq(t, `{"code":13,"message":"`+tc.want+`","details":[]}`, rr.Body.String())
+		})
+	}
 }
 
 // Regression guard for the masking decision: a genuine WHOLE-METHOD
@@ -141,4 +185,27 @@ func TestNewStack_RosterSecondaryAndPostDateOutagesAreInternal(t *testing.T) {
 			assert.JSONEq(t, `{"code":13,"message":"`+tc.want+`","details":[]}`, rr.Body.String())
 		})
 	}
+}
+
+// #154 — the position-search LITE route (FindProfilesByPosition →
+// processLiteProfiles → generateLiteProtoProfile → collectSecondaryPositions)
+// is the one lite consumer of the changed helper with no HTTP outage test. Its
+// handler (searchByPosition, rest/positions.go) maps ANY datastore error to the
+// contract 500 unconditionally — no 404 branch — so a propagated secondary
+// failure must surface as the 500 with the frozen "error searching profiles by
+// position" wrap, never a fabricated empty {"profiles":{}} 200.
+func TestNewStack_PositionSearchSecondaryOutageIsInternal(t *testing.T) {
+	secondary := fmt.Errorf("error generating profiles: collect secondary positions: lookup secondary position %q: %v", "20", gorm.ErrRecordNotFound)
+
+	h := rest.New(&fakeDatastore{
+		findProfilesByPosition: func(string) (*types.LiteRoster, error) { return nil, secondary },
+	}, &stubReferenceCache{})
+
+	rr := secondaryOutageGet(t, h, "/api/v1/milpacs/position/search/Military%20Police")
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code,
+		"a propagated secondary-lookup outage on the position-search route is the contract 500, never a degraded empty 200")
+	assert.JSONEq(t,
+		`{"code":13,"message":"error searching profiles by position: error generating profiles: collect secondary positions: lookup secondary position \"20\": record not found","details":[]}`,
+		rr.Body.String())
 }


### PR DESCRIPTION
Closes #154 and #155.

## Problem
Two secondary lookups discarded their errors and served a degraded 200 with fabricated or blank data during a partial outage. `collectSecondaryPositions` / `collectS1UniformsSecondaryPositions` appended a blank position (`positionTitle:""`, `positionId:0`); `getLatestForumPostDates` returned an empty map, blanking every `lastForumPostDate`. A consumer couldn't tell degraded data from real data.

## Ruling
The 2026-06-06 parity ruling on these issues (keep the degrade shape, observability only) was reversed by the 2026-06-20 maintainer decision: propagate the error so the route answers the contract 500. This is a deliberate break in the PRD #112 sense. It does not touch the golden corpus, which only witnesses happy-path responses, so the golden suite stays green and the new behavior is pinned new-stack-only.

## Change
`collectSecondaryPositions`, `collectS1UniformsSecondaryPositions`, and `getLatestForumPostDates` now return their errors, threaded through `generate*ProtoProfile` and `processProfiles` / `processLiteProfiles` up to the `Find*` methods, which the `rest/` handlers already map to the contract 500. One subtle call: the secondary-position error is wrapped with `%v`, not `%w`, so a secondary `gorm.ErrRecordNotFound` cannot satisfy the handlers' `errors.Is` check and wrongly answer 404 for a member that actually resolved. `getLatestForumPostDates` keeps `%w` (a Find aggregation never yields the not-found sentinel).

## Tests (new-stack-only pins)
- Harness-level outage injection (drop a secondary row / drop `xf_post`) asserting each datastore method returns the error, across full, lite, and S1 shapes.
- HTTP 500-vs-404 table over all four single-profile routes (by-id, by-username, by-discord, by-gamertag), each asserting a secondary failure answers 500, not 404; plus a counter-test that a genuine whole-profile not-found still answers 404. A switch back to `%w` turns these red.
- First-error-aborts pin: a member with two secondary positions where the second is absent fails the whole request rather than returning a partial 200.
- Position-search route answers 500 on a propagated secondary error.

## Verification
`go build ./...`, `go vet ./...`, `gofmt` clean; `make test-integration` green against a disposable MariaDB; golden suite green; `go test -race ./datastores/... ./rest/...` clean. RED confirmed by reverting the propagation and the `%v` masking.

> *This was generated by AI*
