### PR TITLE
docs: forum-group directory decision (ADR 0007 + glossary) (#203)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,22 @@ A `Rank` is a pay-grade entry from the upstream rank catalog. A
 `PositionExpanded` are the variants that include relational fields the
 plain message omits.
 
+## Forum group
+
+A "forum group" is an entry in the XenForo permission-group directory
+(`xf_user_group`): a named membership group such as a rank, a staff
+position, or a member-status flag. These are the IDs the forum's
+`UserGroupsScope` add-on hands a client from the forum's own `/api/me`.
+
+A forum group is not a `PositionGroup`. A `PositionGroup` is a roster
+construct from the NF Rosters add-on used to browse the org chart. A
+forum group is the forum's own membership unit, a wider set that also
+covers ranks and non-roster groups.
+
+The group directory resolves a forum-group ID to its display name. The
+ID is the stable key; the name is display data that can change at any
+time, so consumers key their logic on IDs and treat names as labels.
+
 ## Record and Award
 
 A `Record` is an entry on a member's service history (joins, promotions,

--- a/docs/adr/0007-forum-group-directory.md
+++ b/docs/adr/0007-forum-group-directory.md
@@ -1,0 +1,59 @@
+# ADR 0007: The forum-group directory is served whole, unfiltered, under the `read` scope
+
+## Context
+
+The [UserGroupsScope][ugs] add-on lets a forum OAuth client read the
+authenticated user's own group IDs from the forum's `/api/me`. That
+response is numeric IDs only, and the forum API has no ID-to-name
+lookup, so a consumer that wants to show a readable group name has to
+hardcode the mapping itself. #203 asks this API to provide the lookup,
+since it is already a read layer over the same forum DB.
+
+The IDs come from `xf_user_group`, the forum's permission-group
+directory. In the production forum that table holds about 300 groups.
+Most are rank and staff-position groups whose names are already
+derivable from the milpac surface this API serves under `read`. A tail
+of them are internal or utility groups (Discord sync groups, bot
+accounts, admin overrides) whose names are not otherwise exposed.
+
+Three things had to be decided: how much of the directory to expose,
+which scope gates it, and the response shape.
+
+## Decision
+
+`GET /api/v1/forum/groups` returns the whole directory: every row of
+`xf_user_group` as a `{groupId, groupName}` pair, ordered by `groupId`
+ascending, with no filtering. It is gated by the existing `read` scope.
+IDs are the stable key; names are display data.
+
+We expose the full directory rather than a filtered set or a per-request
+subset because the consumer's IDs come from the same `xf_user_group`
+space. Any group a member belongs to can appear in the forum's
+`/api/me`, so hiding a group would leave the consumer holding an ID it
+cannot resolve, which is the exact gap the endpoint exists to close. A
+subset endpoint (resolve only the IDs I pass) was a fair alternative,
+but it adds query-binding surface for a small, highly cacheable payload,
+and the full directory subsumes it.
+
+We reuse `read` rather than add a `read:groups` scope. The scope catalog
+is owned upstream in the `Cav7/ApiKeyManager` ACP (ADR 0004), so a new
+scope would have to be created there and granted to existing keys before
+the endpoint was usable. The directory's sensitivity matches what `read`
+already exposes, so that coordination cost buys little.
+
+## Consequences
+
+- Every `read` key can enumerate all forum group names, including the
+  internal and utility groups that are not otherwise on the served
+  surface. This is names only; the endpoint never exposes group
+  membership.
+- Narrowing the set later (filtering some groups out) is a breaking
+  change for any consumer that has come to rely on resolving an
+  arbitrary ID, so the full-directory contract is hard to walk back.
+- If a future consumer should see group names but not the milpac
+  surface, that is the point to revisit and introduce `read:groups`.
+  Until then, no upstream scope work is required.
+- The directory is small and slow-changing, so it is served with the
+  same `Cache-Control` max-age as the rest of the `read` family.
+
+[ugs]: https://github.com/7Cav/UserGroupsScope


### PR DESCRIPTION
## What

Records the design for the forum-group directory endpoint that was settled while triaging #203, ahead of implementation.

- **ADR 0007:** `GET /api/v1/forum/groups` serves the full `xf_user_group` directory as `{groupId, groupName}` pairs, ordered by id, gated by the existing `read` scope. The ADR records why the directory is served whole (the consumer's IDs come from the same space, so filtering would leave unresolvable IDs) and why it reuses `read` rather than adding a `read:groups` scope (the catalog is owned upstream per ADR 0004, and the sensitivity matches the existing read surface).
- **CONTEXT.md:** a glossary entry for "Forum group" that distinguishes it from the NF Rosters `PositionGroup`.

## Why now

The decision came out of a design session. Landing the ADR and glossary first gives whoever implements the endpoint a documented contract to build against.

## Scope

Docs only. The endpoint itself is tracked in #203 (ready-for-agent).

> *This was generated by AI*
