### PR TITLE
feat(forum): resolve forum group IDs to names at GET /api/v1/forum/groups (#203)

### DIFF
--- a/contract/battery.go
+++ b/contract/battery.go
@@ -4,7 +4,7 @@ package contract
 // route × happy/edge/error/auth cases, both enum path forms, repeated-filter
 // and dual-spelling query combinations on tickets.
 //
-// 16 surviving public routes (the keycloak lookup route
+// 17 public routes (the keycloak lookup route
 // /api/v1/milpac/keycloak/{keycloak_id} is deliberately NOT recorded — it
 // dies at cutover, so there is no golden to hold it to):
 //
@@ -24,6 +24,7 @@ package contract
 //  14. GET /api/v1/tickets/ref/{ticket_ref}
 //  15. GET /api/v1/tickets/{ticket_id}/messages
 //  16. GET /api/v1/tickets/categories
+//  17. GET /api/v1/forum/groups
 //
 // Path literals reference the recording seed (see fake_datastore_test.go and
 // contract/README.md): relation 1 ↔ user 3 (Jarvis.A), relation 2 ↔ user 8
@@ -101,6 +102,10 @@ func Cases() []Case {
 			Notes: "Nested groups → positions, including false booleans emitted."},
 		{Name: "milpacs/awol", Method: "GET", Path: "/api/v1/milpacs/awol", Auth: AuthRead,
 			Notes: "AWOL list; uint64 timestamp/postId/milpacId emitted as strings."},
+
+		// --- Forum group directory ---------------------------------------
+		{Name: "forum/groups", Method: "GET", Path: "/api/v1/forum/groups", Auth: AuthRead,
+			Notes: "Forum permission-group directory (xf_user_group); bare array of {groupId, groupName}, 32-bit groupId as a JSON number, ordered by groupId asc (ADR 0007)."},
 
 		// --- Roster: both enum path forms, empty, errors -------------------
 		{Name: "roster/combat_by_name", Method: "GET", Path: "/api/v1/roster/ROSTER_TYPE_COMBAT", Auth: AuthRead,

--- a/contract/corpus_test.go
+++ b/contract/corpus_test.go
@@ -108,7 +108,7 @@ func TestCorpusHasNoOrphanGoldens(t *testing.T) {
 
 // TestBatteryIsWellFormed pins structural invariants of the battery itself:
 // unique names, GET-only, the keycloak route deliberately absent, and at
-// least one case per surviving public route (all 16).
+// least one case per public route (all 17).
 func TestBatteryIsWellFormed(t *testing.T) {
 	cases := Cases()
 	seen := map[string]bool{}

--- a/contract/fake_datastore_test.go
+++ b/contract/fake_datastore_test.go
@@ -304,6 +304,20 @@ func (recordingDatastore) FindAwol() ([]*types.Awol, error) {
 	}, nil
 }
 
+// FindForumGroups is the forum-group directory seed (xf_user_group): three
+// {groupId, groupName} pairs, groupId ascending (ADR 0007). groupId is a
+// 32-bit id so it serializes as a JSON number, distinguishing it from the
+// 64-bit milpac ids the corpus records as decimal strings. The rest-package
+// fake (rest/fake_positions_test.go) mirrors this set so the new-stack replay
+// agrees with the recorded golden.
+func (recordingDatastore) FindForumGroups() ([]*types.ForumGroup, error) {
+	return []*types.ForumGroup{
+		{GroupId: 2, GroupName: "Registered"},
+		{GroupId: 3, GroupName: "Administrative"},
+		{GroupId: 10, GroupName: "Rank - Major General"},
+	}, nil
+}
+
 // --- Tickets --------------------------------------------------------------
 
 // seedTickets returns the ticket world sorted by last_modified_date DESC,

--- a/contract/goldens/forum/groups.golden.json
+++ b/contract/goldens/forum/groups.golden.json
@@ -1,0 +1,25 @@
+{
+  "auth": "read",
+  "body": [
+    {
+      "groupId": 2,
+      "groupName": "Registered"
+    },
+    {
+      "groupId": 3,
+      "groupName": "Administrative"
+    },
+    {
+      "groupId": 10,
+      "groupName": "Rank - Major General"
+    }
+  ],
+  "case": "forum/groups",
+  "header": {
+    "Content-Type": "application/json"
+  },
+  "method": "GET",
+  "notes": "Forum permission-group directory (xf_user_group); bare array of {groupId, groupName}, 32-bit groupId as a JSON number, ordered by groupId asc (ADR 0007).",
+  "path": "/api/v1/forum/groups",
+  "status": 200
+}

--- a/contract/routes_test.go
+++ b/contract/routes_test.go
@@ -2,8 +2,8 @@ package contract
 
 import "regexp"
 
-// publicRoutes is the single test-side truth for the 16 surviving public
-// routes. Each entry carries a human label (battery coverage in
+// publicRoutes is the single test-side truth for the 17 public routes. Each
+// entry carries a human label (battery coverage in
 // corpus_test.go), the OpenAPI path template (spec coverage and golden
 // replay in spec_test.go), and the regex that classifies battery case paths
 // to the route.
@@ -26,6 +26,7 @@ var publicRoutes = []struct {
 	{"roster", "/api/v1/roster/{roster}", regexp.MustCompile(`^/api/v1/roster/[^/]+$`)},
 	{"s1 uniforms", "/api/v1/s1/uniforms/{roster}", regexp.MustCompile(`^/api/v1/s1/uniforms/[^/]+$`)},
 	{"position groups", "/api/v1/milpacs/position/groups", regexp.MustCompile(`^/api/v1/milpacs/position/groups$`)},
+	{"forum groups", "/api/v1/forum/groups", regexp.MustCompile(`^/api/v1/forum/groups$`)},
 	{"position search", "/api/v1/milpacs/position/search/{positionQuery}", regexp.MustCompile(`^/api/v1/milpacs/position/search(/.*)?$`)},
 	{"ranks", "/api/v1/milpacs/ranks", regexp.MustCompile(`^/api/v1/milpacs/ranks$`)},
 	{"awol", "/api/v1/milpacs/awol", regexp.MustCompile(`^/api/v1/milpacs/awol$`)},

--- a/contract/spec_test.go
+++ b/contract/spec_test.go
@@ -1067,7 +1067,7 @@ func TestSpec_DeclaredStatusesAreCorpusWitnessed(t *testing.T) {
 			}
 		}
 	}
-	assert.Equal(t, 14, unwitnessed401Ops,
+	assert.Equal(t, 15, unwitnessed401Ops,
 		"the 401 carve-out covers exactly the operations lacking a 401 golden")
 }
 

--- a/datastores/datastore.go
+++ b/datastores/datastore.go
@@ -81,6 +81,11 @@ type Datastore interface {
 	FindAllRanks() ([]*types.RankExpanded, error)
 	FindAllPositionGroups() ([]*types.PositionGroup, error)
 	FindAwol() ([]*types.Awol, error)
+	// FindForumGroups returns the whole forum permission-group directory
+	// (xf_user_group) as {groupId, groupName} pairs ordered by groupId
+	// ascending. Unfiltered (ADR 0007). The slice is non-nil even when empty
+	// so the handler serializes [], never null.
+	FindForumGroups() ([]*types.ForumGroup, error)
 	FindProfileByGamertag(gamertag string) (*types.Profile, error)
 	ValidateApiKey(rawKey string) (*ApiKeyResult, error)
 

--- a/datastores/forum_harness_test.go
+++ b/datastores/forum_harness_test.go
@@ -1,0 +1,48 @@
+package datastores_test
+
+import (
+	"sort"
+	"testing"
+)
+
+// FindForumGroups returns every xf_user_group row as a {groupId, groupName}
+// pair, ordered by groupId ascending and unfiltered (issue #203, ADR 0007).
+// The fixture seeds five groups out of insert order (testdb/fixtures.sql), so
+// this also proves the ORDER BY rather than relying on insert order.
+func TestFindForumGroups_WholeDirectoryOrderedByGroupId(t *testing.T) {
+	ds := openHarnessDatastore(t)
+
+	groups, err := ds.FindForumGroups()
+	if err != nil {
+		t.Fatalf("FindForumGroups: %v", err)
+	}
+
+	// Every seeded row, none filtered out.
+	want := map[uint32]string{
+		1:  "Unregistered / Unconfirmed",
+		2:  "Registered",
+		3:  "Administrative",
+		4:  "Moderating",
+		10: "Rank - Major General",
+	}
+	if len(groups) != len(want) {
+		t.Fatalf("forum group directory: want %d groups, got %d", len(want), len(groups))
+	}
+
+	ids := make([]uint32, len(groups))
+	for i, g := range groups {
+		if g == nil {
+			t.Fatalf("group %d is nil", i)
+		}
+		ids[i] = g.GroupId
+		if title, ok := want[g.GroupId]; !ok {
+			t.Errorf("unexpected groupId %d in directory", g.GroupId)
+		} else if g.GroupName != title {
+			t.Errorf("groupId %d: want name %q, got %q", g.GroupId, title, g.GroupName)
+		}
+	}
+
+	if !sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }) {
+		t.Errorf("forum groups must be ordered by groupId ascending, got %v", ids)
+	}
+}

--- a/datastores/mysql.go
+++ b/datastores/mysql.go
@@ -542,6 +542,31 @@ func (ds Mysql) FindAllPositionGroups() ([]*types.PositionGroup, error) {
 	return positionGroups, nil
 }
 
+// FindForumGroups loads the whole forum permission-group directory
+// (xf_user_group) ordered by user_group_id ascending and maps it to the
+// {groupId, groupName} wire pairs. Unfiltered (ADR 0007). The returned slice
+// is always non-nil so the handler serializes [], never null, on an empty
+// directory.
+func (ds Mysql) FindForumGroups() ([]*types.ForumGroup, error) {
+	Info.Println("Searching for all forum groups")
+	var rows []xenforo.ForumGroup
+
+	result := ds.Db.Order("user_group_id").Find(&rows)
+	if result.Error != nil {
+		return nil, fmt.Errorf("error fetching forum groups: %w", result.Error)
+	}
+
+	groups := make([]*types.ForumGroup, len(rows))
+	for i, row := range rows {
+		groups[i] = &types.ForumGroup{
+			GroupId:   row.UserGroupID,
+			GroupName: row.Title,
+		}
+	}
+
+	return groups, nil
+}
+
 func getLatestServiceRecordDate(profile milpacs.Profile) string {
 	var latestTimestamp int64
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -51,6 +51,8 @@ tags:
     description: Milpac profiles, rosters, ranks, positions and AWOL tracking.
   - name: tickets
     description: Read-only forum tickets (nixfifty addon).
+  - name: forum
+    description: Forum reference data (permission-group directory).
 
 security:
   - bearer: []
@@ -447,6 +449,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AwolResponse'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/forum/groups:
+    get:
+      operationId: ForumService_GetForumGroups
+      summary: Get the forum group directory
+      description: >-
+        Get the whole forum permission-group directory (xf_user_group) as
+        {groupId, groupName} pairs, ordered by groupId ascending and
+        unfiltered. groupId is the stable key; groupName is display data that
+        can change. Distinct from the NF Rosters position groups at
+        /api/v1/milpacs/position/groups. See ADR 0007.
+      tags: [forum]
+      responses:
+        "200":
+          description: Forum group directory.
+          headers:
+            Cache-Control:
+              description: >-
+                Freshness signal: data may be up to 10 minutes stale —
+                consumers may treat a response as fresh for 10 minutes
+                between polls.
+              schema:
+                type: string
+                const: max-age=600
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ForumGroup'
         "401":
           $ref: '#/components/responses/Unauthorized'
         default:
@@ -922,6 +958,17 @@ components:
           items:
             $ref: '#/components/schemas/RankExpanded'
       required: [ranks]
+      additionalProperties: false
+
+    ForumGroup:
+      type: object
+      properties:
+        groupId:
+          type: integer
+          minimum: 0
+        groupName:
+          type: string
+      required: [groupId, groupName]
       additionalProperties: false
 
     Position:

--- a/rest/fake_positions_test.go
+++ b/rest/fake_positions_test.go
@@ -57,3 +57,17 @@ func (f *fakeDatastore) FindAwol() ([]*types.Awol, error) {
 		},
 	}, nil
 }
+
+// FindForumGroups mirrors the recording seed (contract/fake_datastore_test.go):
+// three forum groups, groupId ascending — the new-stack golden replay against
+// the forum/groups golden depends on the two seeds agreeing.
+func (f *fakeDatastore) FindForumGroups() ([]*types.ForumGroup, error) {
+	if f.findForumGroups != nil {
+		return f.findForumGroups()
+	}
+	return []*types.ForumGroup{
+		{GroupId: 2, GroupName: "Registered"},
+		{GroupId: 3, GroupName: "Administrative"},
+		{GroupId: 10, GroupName: "Rank - Major General"},
+	}, nil
+}

--- a/rest/forum.go
+++ b/rest/forum.go
@@ -1,0 +1,24 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/7cav/api/datastores"
+	"github.com/7cav/api/types"
+)
+
+// getForumGroups serves GET /api/v1/forum/groups: the whole forum
+// permission-group directory (xf_user_group) as a bare JSON array of
+// {groupId, groupName} pairs, ordered by groupId ascending (ADR 0007). Gated
+// by the read scope. The response is a List so an empty directory serializes
+// as [], never null — even if the datastore hands back a nil slice.
+func getForumGroups(ds datastores.Datastore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		groups, err := ds.FindForumGroups()
+		if err != nil {
+			writeError(w, r, codeInternal, "error fetching forum groups: %v", err)
+			return
+		}
+		writeJSON(w, r, types.List[*types.ForumGroup](groups))
+	})
+}

--- a/rest/forum_test.go
+++ b/rest/forum_test.go
@@ -1,0 +1,100 @@
+package rest_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/7cav/api/rest"
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The forum-group directory happy path: a valid read key gets a bare JSON
+// array of {groupId, groupName} pairs, groupId a JSON number (32-bit), in the
+// order the datastore returns them (groupId ascending, ADR 0007).
+func TestNewStack_ForumGroupsHappy(t *testing.T) {
+	h := rest.New(&fakeDatastore{findForumGroups: func() ([]*types.ForumGroup, error) {
+		return []*types.ForumGroup{
+			{GroupId: 2, GroupName: "Registered"},
+			{GroupId: 3, GroupName: "Administrative"},
+		}, nil
+	}}, &stubReferenceCache{})
+
+	rr := forumGet(t, h, "/api/v1/forum/groups", "cav7_readkey")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `[{"groupId":2,"groupName":"Registered"},{"groupId":3,"groupName":"Administrative"}]`, rr.Body.String())
+}
+
+// An empty directory must serialize as [], never null — the allocation
+// discipline the goldens can only witness on a populated route. Both a nil and
+// an empty slice from the datastore must produce the same [].
+func TestNewStack_ForumGroupsEmptyIsEmptyArray(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ret  []*types.ForumGroup
+	}{
+		{"nil slice", nil},
+		{"empty slice", []*types.ForumGroup{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := rest.New(&fakeDatastore{findForumGroups: func() ([]*types.ForumGroup, error) {
+				return tc.ret, nil
+			}}, &stubReferenceCache{})
+
+			rr := forumGet(t, h, "/api/v1/forum/groups", "cav7_readkey")
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, `[]`, strings.TrimSpace(rr.Body.String()))
+		})
+	}
+}
+
+// A datastore failure surfaces as the frozen Internal error shape with the
+// handler-specific wrapped message.
+func TestNewStack_ForumGroupsOutageIsInternalJSON(t *testing.T) {
+	h := rest.New(&fakeDatastore{findForumGroups: func() ([]*types.ForumGroup, error) {
+		return nil, errOutage
+	}}, &stubReferenceCache{})
+
+	rr := forumGet(t, h, "/api/v1/forum/groups", "cav7_readkey")
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.JSONEq(t, `{"code":13,"message":"error fetching forum groups: simulated datastore outage","details":[]}`, rr.Body.String())
+}
+
+// The route is gated by the read scope exactly like the milpac surface: a
+// read:tickets key must 403 with the frozen scope-required body, not serve the
+// directory.
+func TestNewStack_ForumGroups403UnderTicketScopedKey(t *testing.T) {
+	h := newStack(t)
+
+	rr := forumGet(t, h, "/api/v1/forum/groups", "cav7_ticketskey")
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	assert.JSONEq(t, `{"code":7,"message":"scope required: read","details":[]}`, rr.Body.String())
+}
+
+// A 200 forum-groups response carries the read-family freshness signal.
+func TestNewStack_ForumGroupsCarriesCacheControl(t *testing.T) {
+	h := newStack(t)
+
+	rr := forumGet(t, h, "/api/v1/forum/groups", "cav7_readkey")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "max-age=600", rr.Header().Get("Cache-Control"))
+}
+
+func forumGet(t *testing.T, h http.Handler, path, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -164,6 +164,12 @@ func routes(ds datastores.Datastore, rc datastores.TicketReferenceCache) *http.S
 	handle(mux, "GET /api/v1/roster/{roster}/lite", "read", maxAgeRosterFamily, getLiteRoster(ds))
 	handle(mux, "GET /api/v1/s1/uniforms/{roster}", "read", maxAgeRosterFamily, getS1UniformsRoster(ds))
 
+	// --- forum (scope: read, max-age 600) ----------------------------------
+	// The forum permission-group directory (xf_user_group), distinct from the
+	// NF Rosters position groups at /api/v1/milpacs/position/groups (ADR 0007).
+	// Same read scope and read-family freshness bound as the milpac surface.
+	handle(mux, "GET /api/v1/forum/groups", "read", maxAgeRosterFamily, getForumGroups(ds))
+
 	// --- tickets (scope: read:tickets, max-age 0 — never cached, live) -----
 	// The literal /categories segment wins over {ticket_id} (mux precedence,
 	// golden-pinned by tickets/categories).

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -49,6 +49,7 @@ type fakeDatastore struct {
 	findAllPositionGroups  func() ([]*types.PositionGroup, error)
 	findProfilesByPosition func(positionQuery string) (*types.LiteRoster, error)
 	findAwol               func() ([]*types.Awol, error)
+	findForumGroups        func() ([]*types.ForumGroup, error)
 
 	// Tickets overrides (seeded defaults live in fake_tickets_test.go); a
 	// test sets one to inject an outage or observe the bound filter.
@@ -261,6 +262,7 @@ var implementedCases = []string{
 	"milpacs/ranks",
 	"milpacs/position_groups",
 	"milpacs/awol",
+	"forum/groups",
 	"position/search_happy",
 	"position/search_empty_result",
 	"position/search_multi_segment",

--- a/rest/spec_test.go
+++ b/rest/spec_test.go
@@ -53,6 +53,8 @@ var specRoutes = map[string]string{
 	// Reference lists (#128): position groups and the AWOL list.
 	"/api/v1/milpacs/position/groups": "/api/v1/milpacs/position/groups",
 	"/api/v1/milpacs/awol":            "/api/v1/milpacs/awol",
+	// Forum group directory (#203): xf_user_group, bare array.
+	"/api/v1/forum/groups": "/api/v1/forum/groups",
 	// Position search (#128): happy (%20-encoded title), empty result
 	// (frozen #137 behavior), multi-segment (the ** glob form an OpenAPI
 	// template cannot express — classified to the canonical template so the

--- a/testdb/fixtures.sql
+++ b/testdb/fixtures.sql
@@ -27,6 +27,18 @@ VALUES
   (400, 'TicketGuy.G', 'g@example.test', 1, 0, 'UTC', 2, '', 1, 'k400'),
   (401, 'Helpdesk.H',  'h@example.test', 1, 0, 'UTC', 2, '', 1, 'k401');
 
+-- Forum permission-group directory (issue #203). Rows are intentionally
+-- inserted out of user_group_id order so the harness test proves
+-- FindForumGroups sorts by groupId ascending rather than relying on insert
+-- order. The four built-in groups plus one rank-shaped group mirror the
+-- production shape (rank/staff groups dominate the real ~300-row table).
+INSERT INTO xf_user_group (user_group_id, title) VALUES
+  (10, 'Rank - Major General'),
+  (1,  'Unregistered / Unconfirmed'),
+  (3,  'Administrative'),
+  (2,  'Registered'),
+  (4,  'Moderating');
+
 -- ---------------------------------------------------------------------
 -- Milpacs (NF Rosters)
 -- ---------------------------------------------------------------------

--- a/testdb/schema.sql
+++ b/testdb/schema.sql
@@ -3,7 +3,8 @@
 -- Tables are cribbed from the production XenForo database (MariaDB 11.5)
 -- and cover exactly what the API reads: the NF Rosters add-on tables, the
 -- NF Tickets add-on tables, the Cav7 ApiKeyManager tables, and the core
--- xf_user / xf_user_connected_account / xf_post / xf_phrase tables.
+-- xf_user / xf_user_group / xf_user_connected_account / xf_post / xf_phrase
+-- tables.
 --
 -- Index fidelity matters here: the harness carries production's stock
 -- indexes and must NOT carry the four indexes proposed by PRD #112
@@ -93,6 +94,17 @@ CREATE TABLE `xf_user` (
   KEY `siropu_donation_count` (`siropu_donation_count`),
   KEY `siropu_donation_amount` (`siropu_donation_amount`),
   KEY `siropu_donation_date` (`siropu_donation_date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- The forum permission-group directory the forum-group endpoint reads
+-- (issue #203). Trimmed to the two columns the API maps (user_group_id,
+-- title); production carries display_style_priority, banner/CSS and the
+-- NF-server group ids besides, none of which this surface exposes (ADR 0007).
+CREATE TABLE `xf_user_group` (
+  `user_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(50) NOT NULL,
+  PRIMARY KEY (`user_group_id`),
+  KEY `title` (`title`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- NOTE: stock XenForo indexes only. Production carries no

--- a/types/forum.go
+++ b/types/forum.go
@@ -1,0 +1,16 @@
+package types
+
+// ForumGroup is one entry of the forum permission-group directory
+// (xf_user_group), served by GET /api/v1/forum/groups: a forum-group id paired
+// with its display name. The id is the stable key consumers index on (it
+// matches the numeric ids the forum's UserGroupsScope add-on hands a client);
+// the name is display data that can change at any time. See CONTEXT.md
+// ("Forum group") and ADR 0007.
+//
+// GroupId is a 32-bit id, so it serializes as a JSON number — unlike the
+// 64-bit milpac ids (rankId, positionId, …) which serialize as decimal
+// strings.
+type ForumGroup struct {
+	GroupId   uint32 `json:"groupId"`
+	GroupName string `json:"groupName"`
+}

--- a/types/forum_test.go
+++ b/types/forum_test.go
@@ -1,0 +1,30 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/7cav/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// ForumGroup is one entry of the forum permission-group directory
+// (GET /api/v1/forum/groups). groupId is a 32-bit id → JSON number (not a
+// decimal string like the 64-bit milpac ids), groupName a plain string. The
+// zero value still emits every field (no omitempty).
+func TestForumGroup_ZeroValueEmitsEveryField(t *testing.T) {
+	m := marshalToMap(t, types.ForumGroup{})
+
+	assert.Equal(t, map[string]any{
+		"groupId":   float64(0), // 32-bit id: JSON number, never a string
+		"groupName": "",
+	}, m)
+}
+
+func TestForumGroup_WireForm(t *testing.T) {
+	m := marshalToMap(t, types.ForumGroup{GroupId: 7, GroupName: "Administrator"})
+
+	assert.Equal(t, map[string]any{
+		"groupId":   float64(7),
+		"groupName": "Administrator",
+	}, m)
+}

--- a/xenforo/userGroup.go
+++ b/xenforo/userGroup.go
@@ -1,0 +1,14 @@
+package xenforo
+
+// ForumGroup models the XenForo permission-group directory table
+// (xf_user_group). Only the id and its display title are needed for the
+// forum-group directory (GET /api/v1/forum/groups); the rest of the table
+// (user_title, banner/CSS, NF-server group ids, …) is out of scope (ADR 0007).
+type ForumGroup struct {
+	UserGroupID uint32 `gorm:"column:user_group_id;primaryKey"`
+	Title       string `gorm:"column:title"`
+}
+
+func (ForumGroup) TableName() string {
+	return "xf_user_group"
+}


### PR DESCRIPTION
Closes #203.

Adds a read endpoint that turns the numeric forum group IDs from the forum's /api/me into readable names, so consumers stop hardcoding the ID-to-name mapping.

## What

GET /api/v1/forum/groups returns the full forum-group directory: every row of xf_user_group as a {groupId, groupName} pair, ordered by groupId ascending. Gated by the existing read scope, with the read family's Cache-Control max-age. The decision to serve the whole directory and reuse the read scope is recorded in ADR 0007 (landed in #212).

## Contract artifacts

- Wire type types.ForumGroup (groupId is 32-bit so it stays a JSON number; groupName is a string).
- GORM model xenforo.ForumGroup over xf_user_group (id and title only).
- Datastore method FindForumGroups.
- OpenAPI operation plus golden case forum/groups, so the contract suite's two-way check passes.

## Testing

- rest unit tests: happy path, empty table serializes as [] for both nil and empty slice, missing-scope 403, datastore outage 500.
- datastores harness test against the MariaDB seam, with out-of-order fixtures proving the ORDER BY.
- go build, go vet, go test all pass; integration tests pass against the dockerized MariaDB.

This was generated by AI