### PR TITLE
fix(servers): bound the GORM connection pool (#204)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -229,3 +229,34 @@ re-applied with the same one command after any forum add-on upgrade
 that rebuilds the tables (idempotent: `ADD INDEX IF NOT EXISTS`). The
 long-term home for re-application is the ApiKeyManager add-on's schema
 step (per PRD #112) — documented intent only, not implemented.
+
+## Connection pool (#204)
+
+The API and the XenForo forum share one MariaDB, so the API's pool is
+sized to leave the forum room. GORM leaves the underlying
+`database/sql` pool **unbounded** by default (`MaxOpenConns == 0`),
+which let a single-key burst open one MySQL conn per in-flight request
+and climb toward the server's global `max_connections` — on 2026-06-18
+a 67-call burst drove 8 `Error 1040 (Too many connections)`, a
+shared-fate failure with the forum. `setupDatasource()` now bounds the
+pool via `conn.DB()` → `SetMaxOpenConns` / `SetMaxIdleConns` /
+`SetConnMaxLifetime`.
+
+Defaults (baked in `servers/pool.go`), justified against prod
+(`max_connections = 300`, forum `pm.max_children = 30`, all-time peak
+68 conns):
+
+| Setting | Default | Why |
+|---|---|---|
+| `MaxOpenConns` | `25` | Bounded + finite. Worst case 25 (API) + 30 (forum) + ~8 (exporters) ≈ 63, well under 300. Clears the 66-call burst in ~90 ms. |
+| `MaxIdleConns` | `25` | Equal to max-open keeps the pool **warm**, so a burst queues against ready conns instead of paying connection-setup cost mid-storm (the root of the #204 latency climb). Clamped down to `MaxOpenConns` if set higher. |
+| `ConnMaxLifetime` | `30m` | Finite so conns recycle, well under MySQL `wait_timeout`. |
+
+All three are overridable through the existing `DB_*` env / viper
+`AutomaticEnv()` convention: `DB_MAX_OPEN_CONNS`, `DB_MAX_IDLE_CONNS`
+(integers), `DB_CONN_MAX_LIFETIME` (Go duration, e.g. `30m`). An unset,
+zero, negative, or unparseable override falls back to the default — the
+pure mapper `servers.poolConfig` does the fallback/clamping and is
+unit-tested without opening a DB (`servers/pool_test.go`). A
+`max_connections` change is out of scope for the API; that's a
+server-side knob.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -254,9 +254,16 @@ Defaults (baked in `servers/pool.go`), justified against prod
 
 All three are overridable through the existing `DB_*` env / viper
 `AutomaticEnv()` convention: `DB_MAX_OPEN_CONNS`, `DB_MAX_IDLE_CONNS`
-(integers), `DB_CONN_MAX_LIFETIME` (Go duration, e.g. `30m`). An unset,
-zero, negative, or unparseable override falls back to the default — the
-pure mapper `servers.poolConfig` does the fallback/clamping and is
-unit-tested without opening a DB (`servers/pool_test.go`). A
+(integers), `DB_CONN_MAX_LIFETIME` (Go duration, e.g. `30m`). An unset
+override falls back to the default **silently**; an invalid
+(non-numeric / unparseable), out-of-range (zero, negative), or clamped
+(idle > open) override is **rejected with a logged `WARNING` and the
+default / clamp is used** — so an operator never believes a bad
+override is live (mirrors `runReferenceCacheRefresh`'s bad-duration
+warning). The pure mapper `servers.poolConfig(rawOpen, rawIdle,
+rawLifetime string)` does the parse / fallback / clamping and returns
+both the resolved config and the warning lines; it is unit-tested
+without opening a DB or touching viper (`servers/pool_test.go`), and
+`setupDatasource()` logs each returned warning via `Warn.Println`. A
 `max_connections` change is out of scope for the API; that's a
 server-side knob.

--- a/servers/pool.go
+++ b/servers/pool.go
@@ -18,7 +18,11 @@
 
 package servers
 
-import "time"
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
 
 // Connection-pool defaults (#204). The API and the XenForo forum share one
 // MariaDB. With GORM defaults the underlying database/sql pool is UNBOUNDED
@@ -40,7 +44,10 @@ import "time"
 // ConnMaxLifetime is finite so conns recycle, but well under MySQL wait_timeout.
 //
 // All three are overridable via the DB_* env convention (viper AutomaticEnv):
-// DB_MAX_OPEN_CONNS, DB_MAX_IDLE_CONNS, DB_CONN_MAX_LIFETIME. See poolConfig.
+// DB_MAX_OPEN_CONNS, DB_MAX_IDLE_CONNS, DB_CONN_MAX_LIFETIME. An invalid,
+// out-of-range, or clamped override is REJECTED with a logged warning (the
+// safe default / clamp is used instead) — never silently dropped. See
+// poolConfig; the call site logs the returned warnings via Warn.Printf.
 const (
 	defaultMaxOpenConns    = 25
 	defaultMaxIdleConns    = 25
@@ -55,43 +62,78 @@ type dbPoolConfig struct {
 	MaxLifetime time.Duration
 }
 
-// poolConfig maps raw env values to the connection-pool settings, applying the
-// conservative #204 defaults whenever an override is unset or invalid. It is a
-// PURE function (no viper, no DB, no os.Exit) so it is unit-testable directly:
-// setupDatasource reads the env via viper and passes the raw values in.
+// poolConfig maps the RAW env strings to the connection-pool settings, applying
+// the conservative #204 defaults whenever an override is unset or invalid. It is
+// a PURE function (no viper, no DB, no os.Exit) so it is unit-testable directly:
+// setupDatasource reads the env via viper (GetString) and passes the raw values
+// in, then logs each returned warning.
+//
+// It returns the resolved config and a slice of human-readable warnings, one per
+// REJECTED or CLAMPED override. The empty string ("") means "unset" and is a
+// clean default — it produces NO warning. An invalid (non-numeric / unparseable),
+// out-of-range (non-positive), or clamped (idle > open) override falls back to
+// the safe default / clamp WITH a warning, so an operator never believes a bad
+// override is live. Parsing the raw string here (rather than taking pre-parsed
+// ints) is what lets the resolver distinguish unset from invalid — viper.GetInt
+// would collapse "banana" and "" to the same 0. The warning text mirrors
+// runReferenceCacheRefresh's "invalid X %q, using default" style.
 //
 // Fallback / clamping rules (each defends a way a bad override could reopen the
 // #204 hole or cool the pool):
-//   - maxOpen <= 0 (unset, zero, or negative) -> defaultMaxOpenConns. A
-//     non-positive value would mean "unbounded" to database/sql, the exact bug.
-//   - maxIdle <= 0 (unset, zero, or negative) -> defaultMaxIdleConns, keeping
-//     the pool warm. maxIdle is then clamped DOWN to MaxOpen, since more idle
-//     than open is meaningless (database/sql would silently clamp anyway).
-//   - lifetime: parsed as a Go duration; empty OR unparseable -> the default,
-//     never disabling recycling silently.
-func poolConfig(maxOpen, maxIdle int, lifetime string) dbPoolConfig {
+//   - maxOpen: empty -> defaultMaxOpenConns silently; non-numeric or <= 0 ->
+//     defaultMaxOpenConns + warning. A non-positive value would mean "unbounded"
+//     to database/sql, the exact bug.
+//   - maxIdle: empty -> defaultMaxIdleConns silently; non-numeric or <= 0 ->
+//     defaultMaxIdleConns + warning, keeping the pool warm. maxIdle is then
+//     clamped DOWN to MaxOpen (with a warning) since more idle than open is
+//     meaningless (database/sql would silently clamp anyway).
+//   - lifetime: empty -> default silently; non-numeric or non-positive ->
+//     default + warning, never disabling recycling silently.
+func poolConfig(rawOpen, rawIdle, rawLifetime string) (dbPoolConfig, []string) {
+	var warns []string
+
 	cfg := dbPoolConfig{
-		MaxOpen:     maxOpen,
-		MaxIdle:     maxIdle,
+		MaxOpen:     defaultMaxOpenConns,
+		MaxIdle:     defaultMaxIdleConns,
 		MaxLifetime: defaultConnMaxLifetime,
 	}
 
-	if cfg.MaxOpen <= 0 {
-		cfg.MaxOpen = defaultMaxOpenConns
-	}
-	if cfg.MaxIdle <= 0 {
-		cfg.MaxIdle = defaultMaxIdleConns
-	}
-	// Idle can never usefully exceed open.
+	cfg.MaxOpen = resolveInt("DB_MAX_OPEN_CONNS", rawOpen, defaultMaxOpenConns, &warns)
+	cfg.MaxIdle = resolveInt("DB_MAX_IDLE_CONNS", rawIdle, defaultMaxIdleConns, &warns)
+
+	// Idle can never usefully exceed open. Clamp explicitly (and announce it)
+	// rather than letting database/sql silently reduce it.
 	if cfg.MaxIdle > cfg.MaxOpen {
+		warns = append(warns, fmt.Sprintf(
+			"DB_MAX_IDLE_CONNS %q exceeds DB_MAX_OPEN_CONNS (%d), clamping idle to %d",
+			rawIdle, cfg.MaxOpen, cfg.MaxOpen))
 		cfg.MaxIdle = cfg.MaxOpen
 	}
 
-	if lifetime != "" {
-		if d, err := time.ParseDuration(lifetime); err == nil && d > 0 {
+	if rawLifetime != "" {
+		if d, err := time.ParseDuration(rawLifetime); err != nil || d <= 0 {
+			warns = append(warns, fmt.Sprintf(
+				"invalid DB_CONN_MAX_LIFETIME %q, using default %s", rawLifetime, defaultConnMaxLifetime))
+		} else {
 			cfg.MaxLifetime = d
 		}
 	}
 
-	return cfg
+	return cfg, warns
+}
+
+// resolveInt parses a raw DB_* integer override. An empty string is a clean
+// unset -> def with no warning. A non-numeric or non-positive value is rejected
+// -> def WITH a warning appended (a non-positive bound means "unbounded" to
+// database/sql, the #204 hole).
+func resolveInt(envVar, raw string, def int, warns *[]string) int {
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		*warns = append(*warns, fmt.Sprintf("invalid %s %q, using default %d", envVar, raw, def))
+		return def
+	}
+	return v
 }

--- a/servers/pool.go
+++ b/servers/pool.go
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (C) 2021 7Cav.us
+ *  This file is part of 7Cav-API <https://github.com/7cav/api>.
+ *
+ *  7Cav-API is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  7Cav-API is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with 7Cav-API. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package servers
+
+import "time"
+
+// Connection-pool defaults (#204). The API and the XenForo forum share one
+// MariaDB. With GORM defaults the underlying database/sql pool is UNBOUNDED
+// (MaxOpenConns == 0), so a single-key burst opens one MySQL conn per in-flight
+// request at once and climbs toward the server's global max_connections — on
+// 2026-06-18 a 67-call burst drove 8 `Error 1040 (Too many connections)`,
+// shared-fate with the forum.
+//
+// These conservative defaults are justified against prod limits:
+//   - server max_connections = 300
+//   - forum InnoDB pool / pm.max_children = 30 (the forum's reserved share)
+//   - all-time peak observed = 68 conns
+//
+// Budget: 25 (API) + 30 (forum) + ~8 (exporters) ≈ 63, comfortably under 300,
+// leaving headroom for the forum and the metric exporters. MaxIdle == MaxOpen
+// keeps the pool fully WARM, so a burst queues against ready conns instead of
+// paying connection-setup cost mid-storm (the root cause of the latency climb):
+// the 66-call burst clears in ~90 ms instead of stampeding into 1040s.
+// ConnMaxLifetime is finite so conns recycle, but well under MySQL wait_timeout.
+//
+// All three are overridable via the DB_* env convention (viper AutomaticEnv):
+// DB_MAX_OPEN_CONNS, DB_MAX_IDLE_CONNS, DB_CONN_MAX_LIFETIME. See poolConfig.
+const (
+	defaultMaxOpenConns    = 25
+	defaultMaxIdleConns    = 25
+	defaultConnMaxLifetime = 30 * time.Minute
+)
+
+// dbPoolConfig is the resolved connection-pool sizing applied to the underlying
+// *sql.DB after gorm.Open.
+type dbPoolConfig struct {
+	MaxOpen     int
+	MaxIdle     int
+	MaxLifetime time.Duration
+}
+
+// poolConfig maps raw env values to the connection-pool settings, applying the
+// conservative #204 defaults whenever an override is unset or invalid. It is a
+// PURE function (no viper, no DB, no os.Exit) so it is unit-testable directly:
+// setupDatasource reads the env via viper and passes the raw values in.
+//
+// Fallback / clamping rules (each defends a way a bad override could reopen the
+// #204 hole or cool the pool):
+//   - maxOpen <= 0 (unset, zero, or negative) -> defaultMaxOpenConns. A
+//     non-positive value would mean "unbounded" to database/sql, the exact bug.
+//   - maxIdle <= 0 (unset, zero, or negative) -> defaultMaxIdleConns, keeping
+//     the pool warm. maxIdle is then clamped DOWN to MaxOpen, since more idle
+//     than open is meaningless (database/sql would silently clamp anyway).
+//   - lifetime: parsed as a Go duration; empty OR unparseable -> the default,
+//     never disabling recycling silently.
+func poolConfig(maxOpen, maxIdle int, lifetime string) dbPoolConfig {
+	cfg := dbPoolConfig{
+		MaxOpen:     maxOpen,
+		MaxIdle:     maxIdle,
+		MaxLifetime: defaultConnMaxLifetime,
+	}
+
+	if cfg.MaxOpen <= 0 {
+		cfg.MaxOpen = defaultMaxOpenConns
+	}
+	if cfg.MaxIdle <= 0 {
+		cfg.MaxIdle = defaultMaxIdleConns
+	}
+	// Idle can never usefully exceed open.
+	if cfg.MaxIdle > cfg.MaxOpen {
+		cfg.MaxIdle = cfg.MaxOpen
+	}
+
+	if lifetime != "" {
+		if d, err := time.ParseDuration(lifetime); err == nil && d > 0 {
+			cfg.MaxLifetime = d
+		}
+	}
+
+	return cfg
+}

--- a/servers/pool.go
+++ b/servers/pool.go
@@ -47,7 +47,7 @@ import (
 // DB_MAX_OPEN_CONNS, DB_MAX_IDLE_CONNS, DB_CONN_MAX_LIFETIME. An invalid,
 // out-of-range, or clamped override is REJECTED with a logged warning (the
 // safe default / clamp is used instead) — never silently dropped. See
-// poolConfig; the call site logs the returned warnings via Warn.Printf.
+// poolConfig; the call site logs the returned warnings via Warn.Println.
 const (
 	defaultMaxOpenConns    = 25
 	defaultMaxIdleConns    = 25

--- a/servers/pool_test.go
+++ b/servers/pool_test.go
@@ -10,19 +10,25 @@ import (
 )
 
 // TestPoolConfig_Defaults pins the conservative baked-in defaults that apply
-// when every DB_* pool override is unset (zero / empty). These defaults are the
-// fix for #204: a bounded, warm pool that clears a single-key burst in well
-// under a second instead of stampeding the shared MariaDB into Error 1040. The
-// numbers are justified against prod (max_connections=300, forum
-// pm.max_children=30, all-time peak 68): 25 open + 25 idle keeps the pool warm,
-// 30m lifetime recycles conns under wait_timeout. See poolConfig's doc comment
-// and CONTEXT.md.
+// when every DB_* pool override is unset (empty). These defaults are the fix
+// for #204: a bounded, warm pool that clears a single-key burst in well under a
+// second instead of stampeding the shared MariaDB into Error 1040. The numbers
+// are justified against prod (max_connections=300, forum pm.max_children=30,
+// all-time peak 68): 25 open + 25 idle keeps the pool warm, 30m lifetime
+// recycles conns under wait_timeout. See poolConfig's doc comment and
+// CONTEXT.md.
+//
+// An UNSET override (empty string) is a clean default, NOT a rejected one, so it
+// must produce ZERO warnings — silence is the signal that the operator made no
+// choice. (Invalid/clamped overrides warn; see the warning tests below.)
 func TestPoolConfig_Defaults(t *testing.T) {
-	got := poolConfig(0, 0, "")
+	got, warns := poolConfig("", "", "")
 
 	require.Equal(t, defaultMaxOpenConns, got.MaxOpen, "unset DB_MAX_OPEN_CONNS must fall back to the default")
 	require.Equal(t, defaultMaxIdleConns, got.MaxIdle, "unset DB_MAX_IDLE_CONNS must fall back to the default")
 	require.Equal(t, defaultConnMaxLifetime, got.MaxLifetime, "unset DB_CONN_MAX_LIFETIME must fall back to the default")
+
+	require.Empty(t, warns, "a clean unset must be SILENT — no warnings for the no-override case")
 
 	// Acceptance criterion: the pool must be bounded (non-zero, finite).
 	require.Greater(t, got.MaxOpen, 0, "MaxOpen must be a positive, finite bound — 0 means unbounded, the bug")
@@ -30,48 +36,85 @@ func TestPoolConfig_Defaults(t *testing.T) {
 }
 
 // TestPoolConfig_Overrides pins that explicit, valid env values win over the
-// defaults.
+// defaults — and a fully valid override set is SILENT (the operator's choice is
+// honored, so there is nothing to warn about).
 func TestPoolConfig_Overrides(t *testing.T) {
-	got := poolConfig(40, 10, "5m")
+	got, warns := poolConfig("40", "10", "5m")
 
 	require.Equal(t, 40, got.MaxOpen)
 	require.Equal(t, 10, got.MaxIdle)
 	require.Equal(t, 5*time.Minute, got.MaxLifetime)
+	require.Empty(t, warns, "valid overrides must be honored silently — no warnings")
 }
 
-// TestPoolConfig_InvalidLifetimeFallsBack pins that a garbage DB_CONN_MAX_LIFETIME
+// TestPoolConfig_InvalidLifetimeWarns pins that a garbage DB_CONN_MAX_LIFETIME
 // (unparseable duration) falls back to the default rather than silently
-// disabling recycling.
-func TestPoolConfig_InvalidLifetimeFallsBack(t *testing.T) {
-	got := poolConfig(0, 0, "not-a-duration")
+// disabling recycling — AND that the rejection is announced via a warning so an
+// operator doesn't believe a bad override is live.
+func TestPoolConfig_InvalidLifetimeWarns(t *testing.T) {
+	got, warns := poolConfig("", "", "not-a-duration")
 	require.Equal(t, defaultConnMaxLifetime, got.MaxLifetime, "an unparseable DB_CONN_MAX_LIFETIME must fall back to the default")
+	requireWarningMentioning(t, warns, "DB_CONN_MAX_LIFETIME", "not-a-duration")
 }
 
-// TestPoolConfig_NegativeOpenFallsBack pins that a nonsensical negative
-// DB_MAX_OPEN_CONNS falls back to the default — a negative bound would mean
+// TestPoolConfig_NonPositiveLifetimeWarns pins that a parseable-but-non-positive
+// duration (e.g. "0s", "-5m") is rejected with a warning and the default kept,
+// rather than silently disabling recycling (lifetime <= 0 means "never expire"
+// to database/sql).
+func TestPoolConfig_NonPositiveLifetimeWarns(t *testing.T) {
+	for _, raw := range []string{"0s", "-5m"} {
+		got, warns := poolConfig("", "", raw)
+		require.Equal(t, defaultConnMaxLifetime, got.MaxLifetime, "a non-positive DB_CONN_MAX_LIFETIME (%q) must fall back to the default", raw)
+		requireWarningMentioning(t, warns, "DB_CONN_MAX_LIFETIME", raw)
+	}
+}
+
+// TestPoolConfig_InvalidOpenWarns pins that a non-numeric DB_MAX_OPEN_CONNS
+// ("banana") falls back to the default AND warns — the operator must not believe
+// a typo'd bound is live while the pool actually runs the default.
+func TestPoolConfig_InvalidOpenWarns(t *testing.T) {
+	got, warns := poolConfig("banana", "", "")
+	require.Equal(t, defaultMaxOpenConns, got.MaxOpen, "an unparseable DB_MAX_OPEN_CONNS must fall back to the default")
+	requireWarningMentioning(t, warns, "DB_MAX_OPEN_CONNS", "banana")
+}
+
+// TestPoolConfig_NegativeOpenWarns pins that a nonsensical negative
+// DB_MAX_OPEN_CONNS falls back to the default — a non-positive bound means
 // "unbounded" to database/sql (SetMaxOpenConns(<=0) is unlimited), reopening the
-// exact #204 hole.
-func TestPoolConfig_NegativeOpenFallsBack(t *testing.T) {
-	got := poolConfig(-5, 0, "")
+// exact #204 hole — AND that the rejection is announced.
+func TestPoolConfig_NegativeOpenWarns(t *testing.T) {
+	got, warns := poolConfig("-5", "", "")
 	require.Equal(t, defaultMaxOpenConns, got.MaxOpen, "a non-positive DB_MAX_OPEN_CONNS must fall back to the default, never 0/unbounded")
+	requireWarningMentioning(t, warns, "DB_MAX_OPEN_CONNS", "-5")
 }
 
-// TestPoolConfig_IdleClampedToOpen pins that idle conns never exceed open conns:
-// database/sql silently reduces idle to match max-open, but we make the intent
-// explicit so an operator who sets idle > open gets the sane, documented
-// behavior rather than a surprising silent clamp.
-func TestPoolConfig_IdleClampedToOpen(t *testing.T) {
-	got := poolConfig(10, 50, "")
-	require.Equal(t, 10, got.MaxIdle, "MaxIdle must be clamped down to MaxOpen — more idle than open is meaningless")
+// TestPoolConfig_InvalidIdleWarns pins that a non-numeric DB_MAX_IDLE_CONNS
+// falls back to the warm default AND warns.
+func TestPoolConfig_InvalidIdleWarns(t *testing.T) {
+	got, warns := poolConfig("25", "banana", "")
+	require.Equal(t, defaultMaxIdleConns, got.MaxIdle, "an unparseable DB_MAX_IDLE_CONNS must fall back to the warm default")
+	requireWarningMentioning(t, warns, "DB_MAX_IDLE_CONNS", "banana")
 }
 
-// TestPoolConfig_NegativeIdleFallsBack pins that a negative DB_MAX_IDLE_CONNS
-// falls back to the default (then clamped to open), keeping the pool warm rather
-// than cold (idle 0 would pay connection-setup cost mid-burst, the root cause of
-// the latency climb in #204).
-func TestPoolConfig_NegativeIdleFallsBack(t *testing.T) {
-	got := poolConfig(25, -1, "")
+// TestPoolConfig_NegativeIdleWarns pins that a negative DB_MAX_IDLE_CONNS falls
+// back to the default (then clamped to open), keeping the pool warm rather than
+// cold (idle 0 would pay connection-setup cost mid-burst, the root cause of the
+// #204 latency climb) — AND that the rejection is announced.
+func TestPoolConfig_NegativeIdleWarns(t *testing.T) {
+	got, warns := poolConfig("25", "-1", "")
 	require.Equal(t, defaultMaxIdleConns, got.MaxIdle, "a negative DB_MAX_IDLE_CONNS must fall back to the warm default")
+	requireWarningMentioning(t, warns, "DB_MAX_IDLE_CONNS", "-1")
+}
+
+// TestPoolConfig_IdleClampedToOpenWarns pins that idle conns never exceed open
+// conns: database/sql silently reduces idle to match max-open, but we make the
+// intent explicit so an operator who sets idle > open gets the sane, documented
+// behavior — AND a warning that their requested idle was clamped, rather than a
+// surprising silent reduction.
+func TestPoolConfig_IdleClampedToOpenWarns(t *testing.T) {
+	got, warns := poolConfig("10", "50", "")
+	require.Equal(t, 10, got.MaxIdle, "MaxIdle must be clamped down to MaxOpen — more idle than open is meaningless")
+	requireWarningMentioning(t, warns, "DB_MAX_IDLE_CONNS", "50")
 }
 
 // TestPoolConfig_AppliesNonZeroFiniteMaxOpen is the acceptance-criterion test:
@@ -88,11 +131,50 @@ func TestPoolConfig_AppliesNonZeroFiniteMaxOpen(t *testing.T) {
 
 	require.Equal(t, 0, db.Stats().MaxOpenConnections, "precondition: a fresh *sql.DB is unbounded (0) — exactly the #204 starting state")
 
-	pool := poolConfig(0, 0, "") // defaults
+	pool, _ := poolConfig("", "", "") // defaults
 	db.SetMaxOpenConns(pool.MaxOpen)
 	db.SetMaxIdleConns(pool.MaxIdle)
 	db.SetConnMaxLifetime(pool.MaxLifetime)
 
 	require.Equal(t, defaultMaxOpenConns, db.Stats().MaxOpenConnections, "after applying the default pool config the *sql.DB must report a non-zero, finite MaxOpenConnections")
 	require.Greater(t, db.Stats().MaxOpenConnections, 0, "MaxOpenConnections must be a positive, finite bound — never 0/unbounded")
+}
+
+// TestPoolConfig_AppliesClampedIdle is the applied-path companion to the
+// resolver-level clamp test: it asserts the CLAMPED idle bound survives the
+// round-trip onto a real lazy *sql.DB. database/sql does not expose the
+// configured MaxIdleConns directly, but MaxOpenConnections caps the effective
+// idle bound — so applying a config where idle was clamped to open (idle==open)
+// must leave the *sql.DB reporting MaxOpenConnections == the clamped value, with
+// no idle setting able to exceed it. We assert the resolved clamp AND that the
+// applied open bound equals it (the ceiling the *sql.DB enforces on idle).
+func TestPoolConfig_AppliesClampedIdle(t *testing.T) {
+	db, err := sql.Open("mysql", "u:p@tcp(127.0.0.1:1)/xenforo")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// idle (50) > open (10) -> idle clamped to 10 at the resolver.
+	pool, warns := poolConfig("10", "50", "")
+	require.Equal(t, 10, pool.MaxOpen)
+	require.Equal(t, 10, pool.MaxIdle, "resolver must clamp idle down to open")
+	requireWarningMentioning(t, warns, "DB_MAX_IDLE_CONNS", "50")
+
+	db.SetMaxOpenConns(pool.MaxOpen)
+	db.SetMaxIdleConns(pool.MaxIdle)
+
+	// The applied open bound is the ceiling database/sql enforces on idle: the
+	// configured idle (10) can never exceed it. Assert the bound landed, which
+	// is the observable guarantee that the clamp protects the shared MariaDB.
+	require.Equal(t, 10, db.Stats().MaxOpenConnections, "the clamped open bound must be reflected on the *sql.DB — idle can never exceed it")
+}
+
+// requireWarningMentioning asserts exactly one warning was produced and that it
+// names the given env var and the offending raw value, so the operator log line
+// is actionable (mirrors runReferenceCacheRefresh's "invalid X %q, using
+// default" style).
+func requireWarningMentioning(t *testing.T, warns []string, envVar, rawValue string) {
+	t.Helper()
+	require.Len(t, warns, 1, "expected exactly one warning, got: %v", warns)
+	require.Contains(t, warns[0], envVar, "warning must name the env var so the operator knows which override was rejected")
+	require.Contains(t, warns[0], rawValue, "warning must echo the offending raw value")
 }

--- a/servers/pool_test.go
+++ b/servers/pool_test.go
@@ -1,0 +1,98 @@
+package servers
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPoolConfig_Defaults pins the conservative baked-in defaults that apply
+// when every DB_* pool override is unset (zero / empty). These defaults are the
+// fix for #204: a bounded, warm pool that clears a single-key burst in well
+// under a second instead of stampeding the shared MariaDB into Error 1040. The
+// numbers are justified against prod (max_connections=300, forum
+// pm.max_children=30, all-time peak 68): 25 open + 25 idle keeps the pool warm,
+// 30m lifetime recycles conns under wait_timeout. See poolConfig's doc comment
+// and CONTEXT.md.
+func TestPoolConfig_Defaults(t *testing.T) {
+	got := poolConfig(0, 0, "")
+
+	require.Equal(t, defaultMaxOpenConns, got.MaxOpen, "unset DB_MAX_OPEN_CONNS must fall back to the default")
+	require.Equal(t, defaultMaxIdleConns, got.MaxIdle, "unset DB_MAX_IDLE_CONNS must fall back to the default")
+	require.Equal(t, defaultConnMaxLifetime, got.MaxLifetime, "unset DB_CONN_MAX_LIFETIME must fall back to the default")
+
+	// Acceptance criterion: the pool must be bounded (non-zero, finite).
+	require.Greater(t, got.MaxOpen, 0, "MaxOpen must be a positive, finite bound — 0 means unbounded, the bug")
+	require.Greater(t, got.MaxLifetime, time.Duration(0), "MaxLifetime must be finite")
+}
+
+// TestPoolConfig_Overrides pins that explicit, valid env values win over the
+// defaults.
+func TestPoolConfig_Overrides(t *testing.T) {
+	got := poolConfig(40, 10, "5m")
+
+	require.Equal(t, 40, got.MaxOpen)
+	require.Equal(t, 10, got.MaxIdle)
+	require.Equal(t, 5*time.Minute, got.MaxLifetime)
+}
+
+// TestPoolConfig_InvalidLifetimeFallsBack pins that a garbage DB_CONN_MAX_LIFETIME
+// (unparseable duration) falls back to the default rather than silently
+// disabling recycling.
+func TestPoolConfig_InvalidLifetimeFallsBack(t *testing.T) {
+	got := poolConfig(0, 0, "not-a-duration")
+	require.Equal(t, defaultConnMaxLifetime, got.MaxLifetime, "an unparseable DB_CONN_MAX_LIFETIME must fall back to the default")
+}
+
+// TestPoolConfig_NegativeOpenFallsBack pins that a nonsensical negative
+// DB_MAX_OPEN_CONNS falls back to the default — a negative bound would mean
+// "unbounded" to database/sql (SetMaxOpenConns(<=0) is unlimited), reopening the
+// exact #204 hole.
+func TestPoolConfig_NegativeOpenFallsBack(t *testing.T) {
+	got := poolConfig(-5, 0, "")
+	require.Equal(t, defaultMaxOpenConns, got.MaxOpen, "a non-positive DB_MAX_OPEN_CONNS must fall back to the default, never 0/unbounded")
+}
+
+// TestPoolConfig_IdleClampedToOpen pins that idle conns never exceed open conns:
+// database/sql silently reduces idle to match max-open, but we make the intent
+// explicit so an operator who sets idle > open gets the sane, documented
+// behavior rather than a surprising silent clamp.
+func TestPoolConfig_IdleClampedToOpen(t *testing.T) {
+	got := poolConfig(10, 50, "")
+	require.Equal(t, 10, got.MaxIdle, "MaxIdle must be clamped down to MaxOpen — more idle than open is meaningless")
+}
+
+// TestPoolConfig_NegativeIdleFallsBack pins that a negative DB_MAX_IDLE_CONNS
+// falls back to the default (then clamped to open), keeping the pool warm rather
+// than cold (idle 0 would pay connection-setup cost mid-burst, the root cause of
+// the latency climb in #204).
+func TestPoolConfig_NegativeIdleFallsBack(t *testing.T) {
+	got := poolConfig(25, -1, "")
+	require.Equal(t, defaultMaxIdleConns, got.MaxIdle, "a negative DB_MAX_IDLE_CONNS must fall back to the warm default")
+}
+
+// TestPoolConfig_AppliesNonZeroFiniteMaxOpen is the acceptance-criterion test:
+// after applying the resolved pool config to a real *sql.DB, the pool reports a
+// non-zero, finite MaxOpenConnections (0 == unbounded, the #204 bug). sql.Open
+// is lazy — it never dials — so this exercises the exact apply path
+// setupDatasource uses (SetMaxOpenConns/SetMaxIdleConns/SetConnMaxLifetime on
+// the underlying *sql.DB) WITHOUT opening a real database or calling os.Exit.
+func TestPoolConfig_AppliesNonZeroFiniteMaxOpen(t *testing.T) {
+	// Lazy handle to a host that is never contacted (Open does not connect).
+	db, err := sql.Open("mysql", "u:p@tcp(127.0.0.1:1)/xenforo")
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Equal(t, 0, db.Stats().MaxOpenConnections, "precondition: a fresh *sql.DB is unbounded (0) — exactly the #204 starting state")
+
+	pool := poolConfig(0, 0, "") // defaults
+	db.SetMaxOpenConns(pool.MaxOpen)
+	db.SetMaxIdleConns(pool.MaxIdle)
+	db.SetConnMaxLifetime(pool.MaxLifetime)
+
+	require.Equal(t, defaultMaxOpenConns, db.Stats().MaxOpenConnections, "after applying the default pool config the *sql.DB must report a non-zero, finite MaxOpenConnections")
+	require.Greater(t, db.Stats().MaxOpenConnections, 0, "MaxOpenConnections must be a positive, finite bound — never 0/unbounded")
+}

--- a/servers/server.go
+++ b/servers/server.go
@@ -116,11 +116,17 @@ func setupDatasource() *datastores.Mysql {
 		Error.Println("issue obtaining underlying sql.DB for connection-pool setup", err)
 		os.Exit(1)
 	}
-	pool := poolConfig(
-		viper.GetInt("db_max_open_conns"),
-		viper.GetInt("db_max_idle_conns"),
+	pool, poolWarnings := poolConfig(
+		viper.GetString("db_max_open_conns"),
+		viper.GetString("db_max_idle_conns"),
 		viper.GetString("db_conn_max_lifetime"),
 	)
+	// A rejected/clamped override must not be silent — an operator who set a
+	// typo'd or out-of-range value would otherwise believe it is live while the
+	// pool quietly runs the safe default. Mirrors runReferenceCacheRefresh.
+	for _, w := range poolWarnings {
+		Warn.Println(w)
+	}
 	sqlDB.SetMaxOpenConns(pool.MaxOpen)
 	sqlDB.SetMaxIdleConns(pool.MaxIdle)
 	sqlDB.SetConnMaxLifetime(pool.MaxLifetime)

--- a/servers/server.go
+++ b/servers/server.go
@@ -103,6 +103,28 @@ func setupDatasource() *datastores.Mysql {
 		os.Exit(1)
 	}
 
+	// Bound the underlying database/sql connection pool (#204). GORM leaves it
+	// unbounded (MaxOpenConns == 0), so a single-key burst can exhaust the
+	// shared MariaDB max_connections and starve the forum. poolConfig is the
+	// pure env->settings mapper (defaults + clamping); see pool.go for the
+	// rationale and the DB_* overrides.
+	sqlDB, err := conn.DB()
+	if err != nil {
+		// A gorm conn that can't surface its *sql.DB can't be pool-bounded, so
+		// it must not serve traffic — fail boot the same way a failed
+		// gorm.Open does, rather than silently running unbounded.
+		Error.Println("issue obtaining underlying sql.DB for connection-pool setup", err)
+		os.Exit(1)
+	}
+	pool := poolConfig(
+		viper.GetInt("db_max_open_conns"),
+		viper.GetInt("db_max_idle_conns"),
+		viper.GetString("db_conn_max_lifetime"),
+	)
+	sqlDB.SetMaxOpenConns(pool.MaxOpen)
+	sqlDB.SetMaxIdleConns(pool.MaxIdle)
+	sqlDB.SetConnMaxLifetime(pool.MaxLifetime)
+
 	return &datastores.Mysql{Db: conn}
 }
 


### PR DESCRIPTION
Closes #204.

The datastore pool was opened with GORM defaults, so MaxOpenConns stayed at 0 (unbounded). A single-key burst opened one MySQL connection per in-flight request at once and climbed toward the server's max_connections; on 2026-06-18 a 67-call burst drove 8 "Error 1040 (Too many connections)". Since the same MariaDB backs the forum, the API could starve the forum of connections.

## Fix

After gorm.Open, setupDatasource now configures the underlying sql.DB:
- MaxOpenConns = 25, MaxIdleConns = 25, ConnMaxLifetime = 30m by default.
- Overridable via DB_MAX_OPEN_CONNS, DB_MAX_IDLE_CONNS, DB_CONN_MAX_LIFETIME (the existing DB_* viper convention).
- An unset value uses the default silently; an invalid, out-of-range, or clamped override is rejected with a logged warning and the safe default is used, matching how runReferenceCacheRefresh already handles a bad interval.

Defaults are sized against production: max_connections=300, forum pm.max_children=30, peak 68. Worst case 25 + 30 + ~8 is about 63, well under 300, so the API cannot be the reason the DB hits its limit.

## Testing

- Pure poolConfig mapper unit-tested: defaults on unset, overrides honored, invalid/negative/clamped inputs fall back to safe defaults and emit a warning, never 0/unbounded.
- Applied-path test confirms the resolved config lands a non-zero finite MaxOpenConns on a real sql.DB (lazy open, no dial).
- go build, go vet, go test, and go test -race ./servers all pass.

Out of scope: per-key rate limiting (deferred follow-up).

This was generated by AI