### PR TITLE
chore(ci): add CODEOWNERS and Dependabot auto-merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Review routing only. The `default-branch` ruleset does not require code-owner
+# review: GitHub's softener is that an approval from any one code owner suffices,
+# which needs two or more owners who actually review to be anything other than a
+# merge block. Revisit if a second regular reviewer appears.
+* @SyniRon

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: [develop]
+
+# Dependabot-triggered workflows get a read-only GITHUB_TOKEN regardless of the
+# repository default, so this block is load-bearing — without it the merge step
+# fails on permissions rather than on anything to do with the update itself.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+
+      # Arming auto-merge does not bypass anything: the PR still waits on the
+      # Build/Lint/Test gate the ruleset requires. Majors are left to land by
+      # hand. `dependabot.yml` does no grouping, so a PR carries exactly one
+      # update and this gate can't be straddled by a mixed batch.
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #243 (partially — the ruleset side is applied via the API; this is the in-repo half).

Two files, landing alongside the move from classic branch protection to rulesets.

## `.github/CODEOWNERS`

Routing only, sole owner. The `default-branch` ruleset leaves `require_code_owner_review` off: GitHub's softener is that an approval from any one code owner suffices, which needs two or more owners who actually review before the rule is anything other than a merge block. Worth revisiting if a second regular reviewer appears.

## `.github/workflows/dependabot_auto_merge.yml`

Arms GitHub auto-merge on non-major Dependabot PRs. It bypasses nothing — the PR still waits on the `Build`/`Lint`/`Test` gate the ruleset requires, so this only removes the manual click once that gate is green. Majors still land by hand.

- The `permissions:` block is load-bearing, not defensive: Dependabot-triggered workflows get a read-only `GITHUB_TOKEN` regardless of the repository default, and the merge step fails on permissions without it.
- `pull_request`, not `pull_request_target`, and the PR URL is passed through `env:` rather than interpolated into `run:` — workflow injection is a live risk in Dependabot-adjacent workflows.
- `dependabot/fetch-metadata` pinned to full semver to match the convention already used by `go.yml` and `build_and_push.yml`.
- `dependabot.yml` does no grouping, so each PR carries exactly one update and the major-version gate can't be straddled by a mixed batch.

## Verification limit

This PR is authored by a human, so the `Auto-merge` job will show as skipped — that proves the actor gate holds and the workflow parses, and nothing more. The merge step and the `permissions:` block are not exercised until a real Dependabot PR runs. Next week's batch is the first true test.

This PR also doubles as the vehicle for confirming the new ruleset behaves before classic protection is deleted.

> *This was generated by AI*