### PR TITLE
fix(ci): run the Go workflow on pull_request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,17 @@
 name: Go
-on: [push]
+# `pull_request` is what lets a fork PR be merged at all: a contributor without
+# push access pushes to their own fork, so the push event fires there and the
+# Build/Lint/Test runs never attach to the PR here — leaving the required
+# contexts permanently unsatisfiable.
+#
+# `push` is narrowed to develop rather than left bare. A same-repo PR matches
+# both events, so an unscoped `push` would run the whole suite twice per PR and
+# surface each required context twice. This way it is one run per event: PRs are
+# covered by `pull_request`, develop keeps its post-merge run.
+on:
+  push:
+    branches: [develop]
+  pull_request:
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Closes #245.

`.github/workflows/go.yml` triggered on `push` only. A contributor without push access forks, pushes to their fork, and opens a PR — the push event fires in *their* repo, so the `Build`/`Lint`/`Test` runs attach to the fork and never reach the PR here. Since #243 made those contexts required with no bypass actors, such a PR would be permanently unmergeable.

No fork PR has ever been opened against this repo (last 100 are all `7Cav`-owned branches), so this has never fired. It is now a hard block rather than a soft one, which is what makes it worth closing.

## Why `push` is narrowed rather than left alone

Appending `pull_request` to the existing `on: [push]` would be the obvious change and the wrong one: a same-repo PR matches both events, so the whole suite would run twice per PR and each required context would appear twice — exactly the ambiguity that makes required status checks unreliable.

Scoping `push` to `develop` gives one run per event:

| Event | Before | After |
|---|---|---|
| Push to a feature branch | runs | no run |
| Open / update a PR | no run (checks came from the push) | runs |
| Fork PR | **no checks at all** | runs |
| Merge to `develop` | runs | runs |

Trade-off worth naming: pushing a feature branch no longer runs CI until a PR exists. The ruleset requires a PR for every change, so nothing reaches `develop` unchecked — but you will see CI slightly later in the loop than before.

The workflow references no secrets (checkout, `go mod tidy`, `go build`, `make lint`, `go test` against a MariaDB service container), so it runs correctly under the read-only token a fork PR receives. Service containers are available to fork PRs.

## Self-verifying

This PR is itself the test: if the `pull_request` trigger works, `Build`/`Lint`/`Test` appear below from a `pull_request` run rather than a push run. What it cannot prove is the fork path specifically — that needs an actual fork PR.

> *This was generated by AI*